### PR TITLE
Ability to tag route tables

### DIFF
--- a/cloud/amazon/ec2_vpc.py
+++ b/cloud/amazon/ec2_vpc.py
@@ -72,7 +72,7 @@ options:
     aliases: []
   route_tables:
     description:
-      - 'A dictionary array of route tables to add of the form: { subnets: [172.22.2.0/24, 172.22.3.0/24,], routes: [{ dest: 0.0.0.0/0, gw: igw},] }. Where the subnets list is those subnets the route table should be associated with, and the routes list is a list of routes to be in the table.  The special keyword for the gw of igw specifies that you should the route should go through the internet gateway attached to the VPC. gw also accepts instance-ids in addition igw. This module is currently unable to affect the "main" route table due to some limitations in boto, so you must explicitly define the associated subnets or they will be attached to the main table implicitly. As of 1.8, if the route_tables parameter is not specified, no existing routes will be modified.'
+      - 'A dictionary array of route tables to add of the form: { subnets: [172.22.2.0/24, 172.22.3.0/24,], routes: [{ dest: 0.0.0.0/0, gw: igw },], resource_tags: [{ tag1: value1, tag2: value2, }] }. Where the subnets list is those subnets the route table should be associated with, and the routes list is a list of routes to be in the table.  The special keyword for the gw of igw specifies that you should the route should go through the internet gateway attached to the VPC. gw also accepts instance-ids in addition igw. This module is currently unable to affect the "main" route table due to some limitations in boto, so you must explicitly define the associated subnets or they will be attached to the main table implicitly. Tags (i.e.: resource_tags) is optional and uses the dictionary form: { "Environment":"Dev", "Tier":"Web", ...}. As of 1.8, if the route_tables parameter is not specified, no existing routes will be modified.'
     required: false
     default: null
     aliases: []
@@ -161,11 +161,13 @@ EXAMPLES = '''
             routes:
               - dest: 0.0.0.0/0
                 gw: igw
+            resource_tags: { "Environment":"Dev" }
           - subnets:
               - 172.22.1.0/24
             routes:
               - dest: 0.0.0.0/0
                 gw: igw
+            resource_tags: { "Environment":"Dev" }
         region: us-west-2
       register: vpc
 
@@ -461,6 +463,10 @@ def create_vpc(module, vpc_conn):
                         vpc_conn.disassociate_route_table(association_id)
 
                     vpc_conn.associate_route_table(new_rt.id, rsn.id)
+                    
+                rt_tags = rt.get('resource_tags', None)
+                if rt_tags:
+                    vpc_conn.create_tags(new_rt.id, rt_tags)
 
                 all_route_tables.append(new_rt)
                 changed = True


### PR DESCRIPTION
I've tested this functionality in a local integration test, in which I checked no tagging vs. these two different formats:

```
# format 1
resource_tags:
  Environment: Dev

# format 2
resource_tags: { "Environment":"Dev" }
```

One thing that isn't addressed is removing tags, but the other resources (e.g. subnets) don't expose that functionality yet either. Will tackle that in a separate, future PR.
