### PR TITLE
Ability to specify new SSD EBS option

### DIFF
--- a/cloud/amazon/ec2_vol.py
+++ b/cloud/amazon/ec2_vol.py
@@ -55,6 +55,7 @@ options:
     required: false
     default: standard
     aliases: []
+    version_added: "1.8"
   iops:
     description:
       - the provisioned IOPs you want to associate with this volume (integer).


### PR DESCRIPTION
AWS [rolled out general purpose SSD volumes](http://aws.amazon.com/blogs/aws/new-ssd-backed-elastic-block-storage/) in June 2014 as the default storage volume type for EBS. This PR keeps the previous default ("standard" magnetic drives) but it also exposes volume_type as an option, allowing the selection of the SSD (i.e. "gp2") volume type.
