### PR TITLE
Support for EC2 dedicated tenancy option

### DIFF
--- a/cloud/amazon/ec2.py
+++ b/cloud/amazon/ec2.py
@@ -67,6 +67,12 @@ options:
     required: true
     default: null
     aliases: []
+  tenancy:
+    description:
+      - An instance with a tenancy of "dedicated" runs on single-tenant hardware and can only be launched into a VPC. Valid values are:"default" or "dedicated". NOTE: To use dedicated tenancy you MUST specify a vpc_subnet_id as well. Dedicated tenancy is not available for EC2 "micro" instances. 
+    required: false
+    default: default
+    aliases: []
   spot_price:
     version_added: "1.5"
     description:
@@ -311,6 +317,18 @@ local_action:
     wait: yes
     vpc_subnet_id: subnet-29e63245
     assign_public_ip: yes
+
+# Dedicated tenancy example
+- local_action:
+    module: ec2
+    assign_public_ip: yes
+    group_id: sg-1dc53f72
+    key_name: mykey
+    image: ami-6e649707
+    instance_type: m1.small
+    tenancy: dedicated
+    vpc_subnet_id: subnet-29e63245
+    wait: yes
 
 # Spot instance example
 - local_action:
@@ -728,6 +746,7 @@ def create_instances(module, ec2, override_count=None):
     group_id = module.params.get('group_id')
     zone = module.params.get('zone')
     instance_type = module.params.get('instance_type')
+    tenancy = module.params.get('tenancy')
     spot_price = module.params.get('spot_price')
     image = module.params.get('image')
     if override_count:
@@ -811,6 +830,9 @@ def create_instances(module, ec2, override_count=None):
 
             if ebs_optimized:
               params['ebs_optimized'] = ebs_optimized
+              
+            if tenancy:
+              params['tenancy'] = tenancy
 
             if boto_supports_profile_name_arg(ec2):
                 params['instance_profile_name'] = instance_profile_name
@@ -1153,6 +1175,7 @@ def main():
             count_tag = dict(),
             volumes = dict(type='list'),
             ebs_optimized = dict(type='bool', default=False),
+            tenancy = dict(default='default'),
         )
     )
 

--- a/cloud/amazon/ec2.py
+++ b/cloud/amazon/ec2.py
@@ -68,6 +68,7 @@ options:
     default: null
     aliases: []
   tenancy:
+    version_added: "1.8"
     description:
       - An instance with a tenancy of "dedicated" runs on single-tenant hardware and can only be launched into a VPC. Valid values are:"default" or "dedicated". NOTE: To use dedicated tenancy you MUST specify a vpc_subnet_id as well. Dedicated tenancy is not available for EC2 "micro" instances. 
     required: false

--- a/cloud/amazon/ec2.py
+++ b/cloud/amazon/ec2.py
@@ -604,6 +604,11 @@ def get_instance_info(inst):
     except AttributeError:
         instance_info['ebs_optimized'] = False
 
+    try:
+        instance_info['tenancy'] = getattr(inst, 'placement_tenancy')
+    except AttributeError:
+        instance_info['tenancy'] = 'default'
+
     return instance_info
 
 def boto_supports_associate_public_ip_address(ec2):


### PR DESCRIPTION
When an AWS VPC is set to "standard" tenancy, this addition will allow you to override tenancy on a per instance level. See http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/dedicated-instance.html for details.
