### PR TITLE
synchronize: use a single -F instead of -FF

### DIFF
--- a/files/synchronize.py
+++ b/files/synchronize.py
@@ -252,7 +252,7 @@ def main():
     group = module.params['group']
     rsync_opts = module.params['rsync_opts']
 
-    cmd = '%s --delay-updates -FF' % rsync
+    cmd = '%s --delay-updates -F' % rsync
     if compress:
         cmd = cmd + ' --compress'
     if rsync_timeout:


### PR DESCRIPTION
This small change corrects behavior when one uses an .rsync-filter file to exclude some paths from both being transferred and being deleted, so that these excluded paths can be handled separately with different tasks (e.g. in order to deploy the excluded paths independently from the rest paths and notify handlers appropriately). The problem with the double -FF option is that it excludes the .rsync-filter file from being transferred to the receiver. However, deletions are done on the side of the receiver, so it is absolutely necessary the .rsync-filter file to be transferred to the receiver, so that the receiver knows what files to delete and what not to delete.
