### PR TITLE
Added support of returning owner's group name in stat module

### DIFF
--- a/files/stat.py
+++ b/files/stat.py
@@ -66,6 +66,7 @@ import os
 import sys
 from stat import *
 import pwd
+import grp
 
 def main():
     module = AnsibleModule(
@@ -140,6 +141,9 @@ def main():
         pw = pwd.getpwuid(st.st_uid)
 
         d['pw_name']   = pw.pw_name
+
+        grp_info = grp.getgrgid(pw.pw_gid)
+        d['gr_name'] = grp_info.gr_name
     except:
         pass
 


### PR DESCRIPTION
##### Issue Type:

Feature Pull Request
##### Ansible Version:

1.7.1
##### Environment:

N/A
##### Summary:

Added support for returning owner's group name in stat module.

This would enable Ansible users to use stat module to get the group name of a file or a directory. (The current stat module is only able to get the gid.)
###### Usage:

```
- name: "Get a file's group name"
  stat: path="/somepath/somefile"
  register: st

- debug: var=st.stat.gr_name
```
###### Original from

https://github.com/ansible/ansible/pull/8975
