### PR TITLE
Fix old ticket #9092 where a playbook can enter in recursion

### DIFF
--- a/files/copy.py
+++ b/files/copy.py
@@ -176,7 +176,7 @@ def main():
     if original_basename and dest.endswith("/"):
         dest = os.path.join(dest, original_basename)
         dirname = os.path.dirname(dest)
-        if not os.path.exists(dirname):
+        if not os.path.exists(dirname) and '/' in dirname:
             (pre_existing_dir, new_directory_list) = split_pre_existing_dir(dirname)
             os.makedirs(dirname)
             directory_args = module.load_file_common_arguments(module.params)


### PR DESCRIPTION
This can be tested with this command :

```
ansible -c local -m copy -a 'src=/etc/group dest=foo/' all
```

This is a corner case of the algorithm used to find how we should
copy recursively a folder, and this commit detect it and avoid it.

Check https://github.com/ansible/ansible/issues/9092 for the story
