### PR TITLE
Add hostname to generated user SSH key comment

### DIFF
--- a/system/user.py
+++ b/system/user.py
@@ -159,7 +159,7 @@ options:
             - Optionally specify the SSH key filename.
     ssh_key_comment:
         required: false
-        default: ansible-generated
+        default: ansible-generated on $HOSTNAME
         version_added: "0.9"
         description:
             - Optionally define the comment for the SSH key.
@@ -198,6 +198,7 @@ import pwd
 import grp
 import syslog
 import platform
+import socket
 
 try:
     import spwd
@@ -1453,7 +1454,7 @@ def main():
             'bits': '2048',
             'type': 'rsa',
             'passphrase': None,
-            'comment': 'ansible-generated'
+            'comment': 'ansible-generated on %s' % socket.gethostname()
     }
     module = AnsibleModule(
         argument_spec = dict(


### PR DESCRIPTION
The default is not very useful to sort between different
keys and user. Adding the hostname in the comment permit to later
sort them if you start to reuse the key and set them in different
servers. See https://github.com/ansible/ansible/pull/7420
for the rational.
