### PR TITLE
Added 'clear_keys' parameter to the authorized_key module

### DIFF
--- a/system/authorized_key.py
+++ b/system/authorized_key.py
@@ -70,6 +70,13 @@ options:
     required: false
     default: null
     version_added: "1.4"
+  clear_keys:
+    description:
+      - Whether this module should clear all keys in the authorized_keys file before adding a new one.
+    required: false
+    choices: [ "yes", "no" ]
+    default: "no"
+    version_added: "1.8"
 description:
     - "Adds or removes authorized keys for particular user accounts"
 author: Brad Olson
@@ -108,6 +115,7 @@ EXAMPLES = '''
 #    path = path to the user's authorized_keys file (default: ~/.ssh/authorized_keys)
 #    manage_dir = whether to create, and control ownership of the directory (default: true)
 #    state = absent|present (default: present)
+#    clear_keys = whether to clear all keys before adding a new one (default: false)
 #
 # see example in examples/playbooks
 
@@ -332,9 +340,14 @@ def enforce_state(module, params):
     manage_dir  = params.get("manage_dir", True)
     state       = params.get("state", "present")
     key_options = params.get("key_options", None)
+    clear_keys  = params.get("clear_keys")
 
-    # extract indivial keys into an array, skipping blank lines and comments
-    key = [s for s in key.splitlines() if s and not s.startswith('#')]
+    # an array of passed SSH keys
+    keys = []
+    # 'key' is a string of all keys separated by a comma
+    for split_key in key.split(','):
+        # extract individual keys into an array, skipping blank lines and comments
+        keys += [s for s in split_key.splitlines() if s and not s.startswith('#')]
 
 
     # check current state -- just get the filename, don't create file
@@ -342,8 +355,12 @@ def enforce_state(module, params):
     params["keyfile"] = keyfile(module, user, do_write, path, manage_dir)
     existing_keys = readkeys(module, params["keyfile"])
 
+    # All parsed new keys will be saved here.
+    # We will need this later if clear_keys is True
+    parsed_new_keys = {}
+
     # Check our new keys, if any of them exist we'll continue.
-    for new_key in key:
+    for new_key in keys:
         parsed_new_key = parsekey(module, new_key)
         if key_options is not None:
             parsed_options = parseoptions(module, key_options)
@@ -371,6 +388,8 @@ def enforce_state(module, params):
 
         # handle idempotent state=present
         if state=="present":
+            parsed_new_keys[parsed_new_key[0]] = parsed_new_key
+            
             if len(non_matching_keys) > 0:
                 for non_matching_key in non_matching_keys:
                     if non_matching_key[0] in existing_keys:
@@ -387,6 +406,13 @@ def enforce_state(module, params):
             del existing_keys[parsed_new_key[0]]
             do_write = True
 
+    # If clear_keys is True and the lengths of parsed_new_keys and existing_keys are different,
+    # that means there are keys in the authorized_keys file which need to be delete, so we only
+    # need to write parsed_new_keys
+    if clear_keys and len(parsed_new_keys) != len(existing_keys):
+        existing_keys = parsed_new_keys
+        do_write = True
+	
     if do_write:
         if module.check_mode:
             module.exit_json(changed=True)
@@ -409,6 +435,7 @@ def main():
            state       = dict(default='present', choices=['absent','present']),
            key_options = dict(required=False, type='str'),
            unique      = dict(default=False, type='bool'),
+           clear_keys  = dict(default=False, type='bool'),
         ),
         supports_check_mode=True
     )


### PR DESCRIPTION
Added a new `clear_keys` parameter to the `authorized_keys` module which if it is set to yes (default: no), clears all keys from the authorized_keys file before adding a new key.

This parameter could be useful if you would like to be sure that the user's authorized_keys file only has the key(s) you would like it to have and no other. Because the `authorized_keys` module appends new keys and only deletes those whose state is put as `absent`, so it was very hard to delete other keys which were not set by Ansible. `clear_keys=yes` could be an easy and fast solution for clearing all unneeded keys.

This pull request is dependent on the following pull request in core https://github.com/ansible/ansible/pull/9206
