### PR TITLE
Support specifying cidr_ip as a list

### DIFF
--- a/cloud/amazon/ec2_group.py
+++ b/cloud/amazon/ec2_group.py
@@ -288,19 +288,24 @@ def main():
                     rule['from_port'] = None
                     rule['to_port'] = None
 
-                # If rule already exists, don't later delete it
-                ruleId = make_rule_key('in', rule, group_id, ip)
-                if ruleId in groupRules:
-                    del groupRules[ruleId]
-                # Otherwise, add new rule
-                else:
-                    grantGroup = None
-                    if group_id:
-                        grantGroup = groups[group_id]
+                # Convert ip to list we can iterate over
+                if not isinstance(ip, list):
+                    ip = [ip]
 
-                    if not module.check_mode:
-                        group.authorize(rule['proto'], rule['from_port'], rule['to_port'], ip, grantGroup)
-                    changed = True
+                # If rule already exists, don't later delete it
+                for thisip in ip:
+                    ruleId = make_rule_key('in', rule, group_id, thisip)
+                    if ruleId in groupRules:
+                        del groupRules[ruleId]
+                    # Otherwise, add new rule
+                    else:
+                        grantGroup = None
+                        if group_id:
+                            grantGroup = groups[group_id]
+
+                        if not module.check_mode:
+                            group.authorize(rule['proto'], rule['from_port'], rule['to_port'], thisip, grantGroup)
+                        changed = True
 
         # Finally, remove anything left in the groupRules -- these will be defunct rules
         if purge_rules:
@@ -328,25 +333,30 @@ def main():
                     rule['from_port'] = None
                     rule['to_port'] = None
 
-                # If rule already exists, don't later delete it
-                ruleId = make_rule_key('out', rule, group_id, ip)
-                if ruleId in groupRules:
-                    del groupRules[ruleId]
-                # Otherwise, add new rule
-                else:
-                    grantGroup = None
-                    if group_id:
-                        grantGroup = groups[group_id].id
+                # Convert ip to list we can iterate over
+                if not isinstance(ip, list):
+                    ip = [ip]
 
-                    if not module.check_mode:
-                        ec2.authorize_security_group_egress(
-                                group_id=group.id,
-                                ip_protocol=rule['proto'],
-                                from_port=rule['from_port'],
-                                to_port=rule['to_port'],
-                                src_group_id=grantGroup,
-                                cidr_ip=ip)
-                    changed = True
+                # If rule already exists, don't later delete it
+                for thisip in ip:
+                    ruleId = make_rule_key('out', rule, group_id, thisip)
+                    if ruleId in groupRules:
+                        del groupRules[ruleId]
+                    # Otherwise, add new rule
+                    else:
+                        grantGroup = None
+                        if group_id:
+                            grantGroup = groups[group_id].id
+
+                        if not module.check_mode:
+                            ec2.authorize_security_group_egress(
+                                    group_id=group.id,
+                                    ip_protocol=rule['proto'],
+                                    from_port=rule['from_port'],
+                                    to_port=rule['to_port'],
+                                    src_group_id=grantGroup,
+                                    cidr_ip=thisip)
+                        changed = True
         elif vpc_id and not module.check_mode:
             # when using a vpc, but no egress rules are specified,
             # we add in a default allow all out rule, which was the


### PR DESCRIPTION
Support specifying ec2_group cidr_ip as a list

**Example:**

``` yaml
ec2_group:
  name: ec2_group list example
  rules:
    - proto: tcp
      from_port: 3306
      to_port: 3306
      cidr_ip: [
        192.168.0.0/24,
        172.16.0.0/16,
        10.0.0.0/8,
      ]
```
