### PR TITLE
dpkg does not take a --force-yes option

### DIFF
--- a/packaging/os/apt.py
+++ b/packaging/os/apt.py
@@ -358,7 +358,7 @@ def install_deb(m, debs, cache, force, install_recommends, dpkg_options):
         if m.check_mode:
             options += " --simulate"
         if force:
-            options += " --force-yes"
+            options += " --force-all"
 
         cmd = "dpkg %s -i %s" % (options, " ".join(pkgs_to_install))
         rc, out, err = m.run_command(cmd)


### PR DESCRIPTION
If you try to install a .deb (uploaded or downloaded outside of the usual `apt` channels), and you set `force=yes`, you'll get an error because `dkpg` (unlike `apt-get` or `aptitude`) will not take `--force-yes`.

Substituting a mostly similar command, which will make sure you will install the package even if it's probably a bad idea.
