### PR TITLE
Add track submodule branches parameter

### DIFF
--- a/source_control/git.py
+++ b/source_control/git.py
@@ -129,13 +129,13 @@ options:
             - if C(no), repository will be cloned without the --recursive
               option, skipping sub-modules.
 
-    track_branches:
+    track_submodule_branches:
         required: false
         default: "yes"
         choices: ["yes", "no"]
         version_added: "1.7"
         description:
-            - if C(no), repository will be cloned without the --recursive
+            - if C(no), submodules will be updated without the --remote
               option, allowing submodules to be tracked by commit hash
               instead of branch name.
 notes:
@@ -409,7 +409,7 @@ def get_head_branch(git_path, module, dest, remote, bare=False):
     f.close()
     return branch
 
-def fetch(git_path, module, repo, dest, version, remote, bare, track_branches):
+def fetch(git_path, module, repo, dest, version, remote, bare, track_submodule_branches):
     ''' updates repo from remote sources '''
     (rc, out0, err0) = module.run_command([git_path, 'remote', 'set-url', remote, repo], cwd=dest)
     if rc != 0:
@@ -427,10 +427,10 @@ def fetch(git_path, module, repo, dest, version, remote, bare, track_branches):
         (rc, out2, err2) = module.run_command("%s fetch --tags %s" % (git_path, remote), cwd=dest)
     if rc != 0:
         module.fail_json(msg="Failed to download remote objects and refs")
-    (rc, out3, err3) = submodule_update(git_path, module, dest, track_branches )
+    (rc, out3, err3) = submodule_update(git_path, module, dest, track_submodule_branches )
     return (rc, out1 + out2 + out3, err1 + err2 + err3)
 
-def submodule_update(git_path, module, dest, track_branches):
+def submodule_update(git_path, module, dest, track_submodule_branches):
     ''' init and update any submodules '''
 
     # get the valid submodule params
@@ -441,7 +441,7 @@ def submodule_update(git_path, module, dest, track_branches):
         return (0, '', '')
     cmd = [ git_path, 'submodule', 'sync' ]
     (rc, out, err) = module.run_command(cmd, check_rc=True, cwd=dest)
-    if 'remote' in params and track_branches:
+    if 'remote' in params and track_submodule_branches:
         cmd = [ git_path, 'submodule', 'update', '--init', '--recursive' ,'--remote' ]
     else:
         cmd = [ git_path, 'submodule', 'update', '--init', '--recursive' ]
@@ -451,7 +451,7 @@ def submodule_update(git_path, module, dest, track_branches):
     return (rc, out, err)
 
 
-def switch_version(git_path, module, dest, remote, version, recursive, track_branches):
+def switch_version(git_path, module, dest, remote, version, recursive, track_submodule_branches):
     cmd = ''
     if version != 'HEAD':
         if is_remote_branch(git_path, module, dest, remote, version):
@@ -477,7 +477,7 @@ def switch_version(git_path, module, dest, remote, version, recursive, track_bra
         else:
             module.fail_json(msg="Failed to checkout branch %s" % (branch))
     if recursive:
-        (rc, out2, err2) = submodule_update(git_path, module, dest, track_branches)
+        (rc, out2, err2) = submodule_update(git_path, module, dest, track_submodule_branches)
         out1 += out2
         err1 += err1
     return (rc, out1, err1)
@@ -501,7 +501,7 @@ def main():
             executable=dict(default=None),
             bare=dict(default='no', type='bool'),
             recursive=dict(default='yes', type='bool'),
-            track_branches=dict(default='yes', type='bool'),
+            track_submodule_branches=dict(default='yes', type='bool'),
         ),
         supports_check_mode=True
     )
@@ -546,7 +546,7 @@ def main():
         add_git_host_key(module, repo, accept_hostkey=module.params['accept_hostkey'])
 
     recursive = module.params['recursive']
-    track_branches = module.params['track_branches']
+    track_submodule_branches = module.params['track_submodule_branches']
 
     rc, out, err, status = (0, None, None, None)
 
@@ -592,12 +592,12 @@ def main():
                 module.exit_json(changed=False, before=before, after=remote_head)
         if module.check_mode:
             module.exit_json(changed=True, before=before, after=remote_head)
-        fetch(git_path, module, repo, dest, version, remote, bare, track_branches)
+        fetch(git_path, module, repo, dest, version, remote, bare, track_submodule_branches)
 
     # switch to version specified regardless of whether
     # we cloned or pulled
     if not bare:
-        switch_version(git_path, module, dest, remote, version, recursive, track_branches)
+        switch_version(git_path, module, dest, remote, version, recursive, track_submodule_branches)
 
     # determine if we changed anything
     after = get_version(module, git_path, dest)


### PR DESCRIPTION
Was https://github.com/ansible/ansible/pull/7877
Allows user to decide if git submodule should track branches/tags or track commit hashes defined in the superproject.

Add track_branches parameter to the git module.

Defaults to track branches behavior.

Original Issue was https://github.com/ansible/ansible/issues/7030
##### Issue Type:

“Bug Report” /  “Feature Idea”
##### Ansible Version:

ansible 1.6 (devel a5e7492c4f) last updated 2014/04/15 21:12:13 (GMT -400)
##### Environment:

Ubuntu 12.04
##### Summary:

Git submodule update is hard coded to track branches (always adds the `--remote` flag, assuming the git version is late enough to support tracking branches.

https://github.com/ansible/ansible/blob/1c9950678a8a226020c6a1a32d6a60f942495072/library/source_control/git#L423-424

I have a use case where we definitely want to track the sha1 recorded in the superproject, not a branch or tag of the submodule. I'm willing to put in a PR on this, but wonder about the best way to add in a choice on this. A submodule_remote parameter? Something else?
##### Steps To Reproduce:

In a git repo with submodules that are tracked by commit hash stored in the superproject rather than branch or tag, run 

`git: repo=reponame dest=place/to/put/it`
##### Expected Results:

I'd expect all of my submodule repos to be checkout out on the commit stored in the the superproject.
##### Actual Results:

All of my submodule repos are be checkout out to the commit at the tip of the master branch.

If the submodules also do not use the label "master" for the master branch, it throws an error

`fatal: Needed a single revision`

`Unable to find current origin/master revision in submodule path` 
