### PR TITLE
Now its possible to use wildcard for versions in apt

### DIFF
--- a/packaging/apt.py
+++ b/packaging/apt.py
@@ -231,7 +231,8 @@ def expand_pkgspec_from_fnmatches(m, pkgspec, cache):
     new_pkgspec = []
     for pkgname_or_fnmatch_pattern in pkgspec:
         # note that any of these chars is not allowed in a (debian) pkgname
-        if [c for c in pkgname_or_fnmatch_pattern if c in "*?[]!"]:
+        pkg_name = pkgname_or_fnmatch_pattern.split('=')[0]
+        if [c for c in pkg_name if c in "*?[]!"]:
             if "=" in pkgname_or_fnmatch_pattern:
                 m.fail_json(msg="pkgname wildcard and version can not be mixed")
             # handle multiarch pkgnames, the idea is that "apt*" should


### PR DESCRIPTION
This pull request try to solve the issue ansible/ansible#6885 letting to use apt with wildcards in the version of the package
