### PR TITLE
digital ocean: Remove unsupported states

### DIFF
--- a/cloud/digital_ocean_domain.py
+++ b/cloud/digital_ocean_domain.py
@@ -27,7 +27,7 @@ options:
     description:
      - Indicate desired state of the target.
     default: present
-    choices: ['present', 'active', 'absent', 'deleted']
+    choices: ['present', 'absent']
   client_id:
      description:
      - DigitalOcean manager id.
@@ -217,7 +217,7 @@ def core(module):
 def main():
     module = AnsibleModule(
         argument_spec = dict(
-            state = dict(choices=['active', 'present', 'absent', 'deleted'], default='present'),
+            state = dict(choices=['present', 'absent'], default='present'),
             client_id = dict(aliases=['CLIENT_ID'], no_log=True),
             api_key = dict(aliases=['API_KEY'], no_log=True),
             name = dict(type='str'),


### PR DESCRIPTION
The code in the `core` method only supports `present` and `absent` states. If a user chooses `active` or `deleted`, no code is run in the `core` method and no error is raised, leaving the user baffled about what is going on and why nothing happens.
