### PR TITLE
Osx support for users/groups

### DIFF
--- a/system/group.py
+++ b/system/group.py
@@ -251,6 +251,49 @@ class FreeBsdGroup(Group):
 
 # ===========================================
 
+
+
+class DarwinGroup(Group):
+    """
+    This is a Mac OS X Darwin Group manipulation class.
+
+    This overrides the following methods from the generic class:-
+      - group_del()
+      - group_add()
+      - group_mod()
+
+    group manupulation are done using dseditgroup(1).
+    """
+
+    platform = 'Darwin'
+    distribution = None
+
+    def group_add(self, **kwargs):
+        cmd = [self.module.get_bin_path('dseditgroup', True)]
+        cmd += [ '-o', 'create' ]
+        cmd += [ '-i', self.gid ]
+        cmd += [ '-L', self.name ]
+        (rc, out, err) = self.execute_command(cmd)
+        return (rc, out, err)
+
+    def group_del(self):
+        cmd = [self.module.get_bin_path('dseditgroup', True)]
+        cmd += [ '-o', 'delete' ]
+        cmd += [ '-L', self.name ]
+        (rc, out, err) = self.execute_command(cmd)
+        return (rc, out, err)
+
+    def group_mod(self):
+        info = self.group_info()
+        if self.gid is not None and int(self.gid) != info[2]:
+            cmd = [self.module.get_bin_path('dseditgroup', True)]
+            cmd += [ '-o', 'edit' ]
+            cmd += [ '-i', self.gid ]
+            cmd += [ '-L', self.name ]
+            (rc, out, err) = self.execute_command(cmd)
+            return (rc, out, err)
+        return (None, '', '')
+
 class OpenBsdGroup(Group):
     """
     This is a OpenBSD Group manipulation class.


### PR DESCRIPTION
##### Issue Type:

Feature Pull Request
##### Ansible Version:

```
ansible 1.8 (devel b7082677de) last updated 2014/08/29 00:02:43 (GMT +200)
```
##### Environment:

All, target Darwin Mac OS X
##### Summary:

Add basic users and groups management for Darwin Mac OS X hosts.
##### How to use:

Same as for other hosts.

Please note that this version does not yet support encrypted user
passwords. Be aware of security concerns.
