### PR TITLE
Added support for specifying a folder on vm creation

### DIFF
--- a/cloud/vsphere_guest.py
+++ b/cloud/vsphere_guest.py
@@ -67,7 +67,7 @@ options:
     description:
      - Indicate desired state of the vm.
     default: present
-    choices: ['present', 'powered_on', 'absent', 'powered_off', 'restarted', 'reconfigured']
+    choices: ['present', 'powered_on', 'absent', 'powered_on', 'restarted', 'reconfigured']
   vm_disk:
     description:
       - A key, value list of disks and their sizes and which datastore to keep it in.
@@ -130,6 +130,7 @@ EXAMPLES = '''
       vcpu.hotadd: yes
       mem.hotadd:  yes
       notes: This is a test VM
+      folder: AutoDeploys
     vm_disk:
       disk1:
         size_gb: 10
@@ -618,7 +619,16 @@ def create_vm(vsphere_client, module, esxi, resource_pool, cluster_name, guest, 
     hfmor = dcprops.hostFolder._obj
 
     # virtualmachineFolder managed object reference
-    vmfmor = dcprops.vmFolder._obj
+    if vm_extra_config.get('folder'):
+        if vm_extra_config['folder'] not in vsphere_client._get_managed_objects(MORTypes.Folder).values():
+            vsphere_client.disconnect()
+            module.fail_json(msg="Could not find folder named: %s" % vm_extra_config['folder'])
+
+        for mor, name in vsphere_client._get_managed_objects(MORTypes.Folder).iteritems():
+            if name == vm_extra_config['folder']:
+                vmfmor = mor
+    else:
+        vmfmor = dcprops.vmFolder._obj
 
     # networkFolder managed object reference
     nfmor = dcprops.networkFolder._obj


### PR DESCRIPTION
This change allows for folder to be given as a vm_extra_config parameter, defaulting to the Virtual Machines (or whatever the default folder is set to) if none is given.
