### PR TITLE
Expand the user home folder in the key_file argument of the git module

### DIFF
--- a/source_control/git.py
+++ b/source_control/git.py
@@ -518,6 +518,10 @@ def main():
         else:
             gitconfig = os.path.join(dest, '.git', 'config')
 
+    # make sure the key_file path is expanded for ~ and $HOME
+    if key_file is not None:
+        key_file = os.path.abspath(os.path.expanduser(key_file))
+
     # create a wrapper script and export
     # GIT_SSH=<path> as an environment variable
     # for git to use the wrapper script


### PR DESCRIPTION
This is a clone of https://github.com/ansible/ansible/pull/8351 (cloned after the repository structure change), that is based of a recent version of the `git`module.

It fixes #91 by using `expanduser` and `abspath` on the `key_file` argument.
