### PR TITLE
Ansible is verbose when MySQLdb library import fails

### DIFF
--- a/database/mysql_db.py
+++ b/database/mysql_db.py
@@ -104,10 +104,10 @@ import os
 import pipes
 try:
     import MySQLdb
-except ImportError:
-    mysqldb_found = False
+except ImportError, e:
+    mysqldb_import_error = e
 else:
-    mysqldb_found = True
+    mysqldb_import_error = None
 
 # ===========================================
 # MySQL module specific support methods.
@@ -273,8 +273,8 @@ def main():
         )
     )
 
-    if not mysqldb_found:
-        module.fail_json(msg="the python mysqldb module is required")
+    if mysqldb_import_error is not None:
+        module.fail_json(msg="the python mysqldb module failed to import: %s" % mysqldb_import_error)
 
     db = module.params["name"]
     encoding = module.params["encoding"]

--- a/database/mysql_user.py
+++ b/database/mysql_user.py
@@ -146,10 +146,10 @@ import getpass
 import tempfile
 try:
     import MySQLdb
-except ImportError:
-    mysqldb_found = False
+except ImportError, e:
+    mysqldb_import_error = e
 else:
-    mysqldb_found = True
+    mysqldb_import_error = None
 
 # ===========================================
 # MySQL module specific support methods.
@@ -419,8 +419,8 @@ def main():
     check_implicit_admin = module.params['check_implicit_admin']
     append_privs = module.boolean(module.params["append_privs"])
 
-    if not mysqldb_found:
-        module.fail_json(msg="the python mysqldb module is required")
+    if mysqldb_import_error is not None:
+        module.fail_json(msg="the python mysqldb module failed to import: %s" % mysqldb_import_error)
 
     if priv is not None:
         try:

--- a/database/mysql_variables.py
+++ b/database/mysql_variables.py
@@ -70,10 +70,10 @@ import warnings
 
 try:
     import MySQLdb
-except ImportError:
-    mysqldb_found = False
+except ImportError, e:
+    mysqldb_import_error = e
 else:
-    mysqldb_found = True
+    mysqldb_import_error = None
 
 
 def typedvalue(value):
@@ -201,8 +201,8 @@ def main():
     host = module.params["login_host"]
     mysqlvar = module.params["variable"]
     value = module.params["value"]
-    if not mysqldb_found:
-        module.fail_json(msg="the python mysqldb module is required")
+    if mysqldb_import_error is not None:
+        module.fail_json(msg="the python mysqldb module failed to import: %s" % mysqldb_import_error)
     else:
         warnings.filterwarnings('error', category=MySQLdb.Warning)
 


### PR DESCRIPTION
Ansible displays error message from mysqldb library imports, thus correctly indicating what kind of issue mysqldb library has - i.e. missing, invalid version, link error, etc.
