### PR TITLE
template, copy: archive, (m/a)time support added, file: (m/a)time support added

### DIFF
--- a/files/copy.py
+++ b/files/copy.py
@@ -148,7 +148,10 @@ def main():
             backup            = dict(default=False, type='bool'),
             force             = dict(default=True, aliases=['thirsty'], type='bool'),
             validate          = dict(required=False, type='str'),
-            directory_mode    = dict(required=False)
+            directory_mode    = dict(required=False),
+            atime             = dict(required=False),
+            mtime             = dict(required=False),
+            archive           = dict(type='bool',required=False), # Dissolved into other parameters before delegation to remote host
         ),
         add_file_common_args=True,
         supports_check_mode=True,

--- a/files/file.py
+++ b/files/file.py
@@ -110,6 +110,9 @@ def main():
             state = dict(choices=['file','directory','link','hard','touch','absent'], default=None),
             path  = dict(aliases=['dest', 'name'], required=True),
             original_basename = dict(required=False), # Internal use only, for recursive ops
+            archive = dict(type='bool',required=False), # Internal use only, delegated here (see template)
+            atime = dict(required=False),
+            mtime = dict(required=False),
             recurse  = dict(default='no', type='bool'),
             force = dict(required=False,default=False,type='bool'),
             diff_peek = dict(default=None),

--- a/files/template.py
+++ b/files/template.py
@@ -47,6 +47,12 @@ options:
     required: false
     default: ""
     version_added: "1.2"
+  archive:
+    description:
+      - When set to true, the created file retains permissions and ownership of the source template file.
+    required: false
+    default: ""
+    version_added: "1.8"
 notes:
   - "Since Ansible version 0.9, templates are loaded with C(trim_blocks=True)."
 requirements: []


### PR DESCRIPTION
template, copy: added support for archive parameter to retain permissions, ownership and timestamps of the source(s) on the destination(s).

template, copy, file: added support for mtime, atime - setting access/mod datetime of the destination(s) in unix touch format HHMMDDhhmi[.ss].

Please note: mtime, atime suport addition is a side-effect of archive and cannot be split in separate pull request.
