### PR TITLE
Support libcloud > 0.15 'metadata' argument format on cloud/gce module

### DIFF
--- a/cloud/google/gce.py
+++ b/cloud/google/gce.py
@@ -188,6 +188,7 @@ EXAMPLES = '''
 import sys
 
 try:
+    import libcloud
     from libcloud.compute.types import Provider
     from libcloud.compute.providers import get_driver
     from libcloud.common.google import GoogleBaseError, QuotaExceededError, \
@@ -301,10 +302,13 @@ def create_instances(module, gce, instance_names):
             print("failed=True msg='bad metadata syntax'")
             sys.exit(1)
 
+    if hasattr(libcloud, '__version__') and libcloud.__version__ < '0.15':
         items = []
         for k, v in md.items():
             items.append({"key": k, "value": v})
         metadata = {'items': items}
+    else:
+        metadata = md
 
     # These variables all have default values but check just in case
     if not lc_image or not lc_network or not lc_machine_type or not lc_zone:

--- a/cloud/google/gce.py
+++ b/cloud/google/gce.py
@@ -224,7 +224,7 @@ def get_instance_info(inst):
     else:
         disk_names = []
     return({
-        'image': not inst.image is None and inst.image.split('/')[-1] or None,
+        'image': inst.image is not None and inst.image.split('/')[-1] or None,
         'disks': disk_names,
         'machine_type': inst.size,
         'metadata': metadata,

--- a/cloud/google/gce.py
+++ b/cloud/google/gce.py
@@ -91,7 +91,10 @@ options:
     aliases: []
   disks:
     description:
-      - a list of persistent disks to attach to the instance; a string value gives the name of the disk; alternatively, a dictionary value can define 'name' and 'mode' ('READ_ONLY' or 'READ_WRITE'). The first entry will be the boot disk (which must be READ_WRITE).
+      - a list of persistent disks to attach to the instance; a string value
+        gives the name of the disk; alternatively, a dictionary value can
+        define 'name' and 'mode' ('READ_ONLY' or 'READ_WRITE'). The first entry
+        will be the boot disk (which must be READ_WRITE).
     required: false
     default: null
     aliases: []
@@ -154,7 +157,8 @@ EXAMPLES = '''
   tasks:
     - name: Launch instances
       local_action: gce instance_names={{names}} machine_type={{machine_type}}
-                    image={{image}} zone={{zone}} service_account_email={{ service_account_email }}
+                    image={{image}} zone={{zone}}
+                    service_account_email={{ service_account_email }}
                     pem_file={{ pem_file }} project_id={{ project_id }}
       register: gce
     - name: Wait for SSH to come up

--- a/cloud/google/gce.py
+++ b/cloud/google/gce.py
@@ -190,14 +190,14 @@ try:
         ResourceExistsError, ResourceInUseError, ResourceNotFoundError
     _ = Provider.GCE
 except ImportError:
-    print("failed=True " + \
+    print("failed=True " +
           "msg='libcloud withGCE support (0.13.3+) required for this module'")
     sys.exit(1)
 
 try:
     from ast import literal_eval
 except ImportError:
-    print("failed=True " + \
+    print("failed=True " +
           "msg='GCE module requires python's 'ast' module, python v2.6+'")
     sys.exit(1)
 
@@ -326,7 +326,7 @@ def create_instances(module, gce, instance_names):
         except ResourceExistsError:
             inst = gce.ex_get_node(name, lc_zone)
         except GoogleBaseError, e:
-            module.fail_json(msg='Unexpected error attempting to create ' + \
+            module.fail_json(msg='Unexpected error attempting to create ' +
                              'instance %s, error: %s' % (name, e.value))
 
         for i, lc_disk in enumerate(lc_disks):

--- a/cloud/google/gce.py
+++ b/cloud/google/gce.py
@@ -294,10 +294,10 @@ def create_instances(module, gce, instance_names):
             md = literal_eval(metadata)
             if not isinstance(md, dict):
                 raise ValueError('metadata must be a dict')
-        except ValueError, e:
+        except ValueError as e:
             print("failed=True msg='bad metadata: %s'" % str(e))
             sys.exit(1)
-        except SyntaxError, e:
+        except SyntaxError as e:
             print("failed=True msg='bad metadata syntax'")
             sys.exit(1)
 
@@ -329,7 +329,7 @@ def create_instances(module, gce, instance_names):
             changed = True
         except ResourceExistsError:
             inst = gce.ex_get_node(name, lc_zone)
-        except GoogleBaseError, e:
+        except GoogleBaseError as e:
             module.fail_json(msg='Unexpected error attempting to create ' +
                              'instance %s, error: %s' % (name, e.value))
 
@@ -387,7 +387,7 @@ def terminate_instances(module, gce, instance_names, zone_name):
             inst = gce.ex_get_node(name, zone_name)
         except ResourceNotFoundError:
             pass
-        except Exception, e:
+        except Exception as e:
             module.fail_json(msg=unexpected_error_msg(e), changed=False)
         if inst:
             gce.destroy_node(inst)

--- a/cloud/google/gce.py
+++ b/cloud/google/gce.py
@@ -469,7 +469,7 @@ def main():
             json_output['name'] = name
 
     json_output['changed'] = changed
-    print json.dumps(json_output)
+    print(json.dumps(json_output))
     sys.exit(0)
 
 # import module snippets

--- a/cloud/google/gce.py
+++ b/cloud/google/gce.py
@@ -187,18 +187,18 @@ try:
     from libcloud.compute.types import Provider
     from libcloud.compute.providers import get_driver
     from libcloud.common.google import GoogleBaseError, QuotaExceededError, \
-            ResourceExistsError, ResourceInUseError, ResourceNotFoundError
+        ResourceExistsError, ResourceInUseError, ResourceNotFoundError
     _ = Provider.GCE
 except ImportError:
     print("failed=True " + \
-        "msg='libcloud with GCE support (0.13.3+) required for this module'")
+          "msg='libcloud withGCE support (0.13.3+) required for this module'")
     sys.exit(1)
 
 try:
     from ast import literal_eval
 except ImportError:
     print("failed=True " + \
-        "msg='GCE module requires python's 'ast' module, python v2.6+'")
+          "msg='GCE module requires python's 'ast' module, python v2.6+'")
     sys.exit(1)
 
 
@@ -236,6 +236,7 @@ def get_instance_info(inst):
         'tags': ('tags' in inst.extra) and inst.extra['tags'] or [],
         'zone': ('zone' in inst.extra) and inst.extra['zone'].name or None,
     })
+
 
 def create_instances(module, gce, instance_names):
     """Creates new instances. Attributes other than instance_names are picked
@@ -297,14 +298,14 @@ def create_instances(module, gce, instance_names):
             sys.exit(1)
 
         items = []
-        for k,v in md.items():
-            items.append({"key": k,"value": v})
+        for k, v in md.items():
+            items.append({"key": k, "value": v})
         metadata = {'items': items}
 
     # These variables all have default values but check just in case
     if not lc_image or not lc_network or not lc_machine_type or not lc_zone:
         module.fail_json(msg='Missing required create instance variable',
-                changed=False)
+                         changed=False)
 
     for name in instance_names:
         pd = None
@@ -317,15 +318,16 @@ def create_instances(module, gce, instance_names):
                 pd = gce.ex_get_volume("%s" % name, lc_zone)
         inst = None
         try:
-            inst = gce.create_node(name, lc_machine_type, lc_image,
-                    location=lc_zone, ex_network=network, ex_tags=tags,
-                    ex_metadata=metadata, ex_boot_disk=pd)
+            inst = gce.create_node(
+                name, lc_machine_type, lc_image, location=lc_zone,
+                ex_network=network, ex_tags=tags, ex_metadata=metadata,
+                ex_boot_disk=pd)
             changed = True
         except ResourceExistsError:
             inst = gce.ex_get_node(name, lc_zone)
         except GoogleBaseError, e:
             module.fail_json(msg='Unexpected error attempting to create ' + \
-                    'instance %s, error: %s' % (name, e.value))
+                             'instance %s, error: %s' % (name, e.value))
 
         for i, lc_disk in enumerate(lc_disks):
             # Check whether the disk is already attached
@@ -393,22 +395,22 @@ def terminate_instances(module, gce, instance_names, zone_name):
 
 def main():
     module = AnsibleModule(
-        argument_spec = dict(
-            image = dict(default='debian-7'),
-            instance_names = dict(),
-            machine_type = dict(default='n1-standard-1'),
-            metadata = dict(),
-            name = dict(),
-            network = dict(default='default'),
-            persistent_boot_disk = dict(type='bool', default=False),
-            disks = dict(type='list'),
-            state = dict(choices=['active', 'present', 'absent', 'deleted'],
-                    default='present'),
-            tags = dict(type='list'),
-            zone = dict(default='us-central1-a'),
-            service_account_email = dict(),
-            pem_file = dict(),
-            project_id = dict(),
+        argument_spec=dict(
+            image=dict(default='debian-7'),
+            instance_names=dict(),
+            machine_type=dict(default='n1-standard-1'),
+            metadata=dict(),
+            name=dict(),
+            network=dict(default='default'),
+            persistent_boot_disk=dict(type='bool', default=False),
+            disks=dict(type='list'),
+            state=dict(choices=['active', 'present', 'absent', 'deleted'],
+                       default='present'),
+            tags=dict(type='list'),
+            zone=dict(default='us-central1-a'),
+            service_account_email=dict(),
+            pem_file=dict(),
+            project_id=dict(),
         )
     )
 
@@ -435,15 +437,15 @@ def main():
         inames.append(name)
     if not inames:
         module.fail_json(msg='Must specify a "name" or "instance_names"',
-                changed=False)
+                         changed=False)
     if not zone:
         module.fail_json(msg='Must specify a "zone"', changed=False)
 
     json_output = {'zone': zone}
     if state in ['absent', 'deleted']:
         json_output['state'] = 'absent'
-        (changed, terminated_instance_names) = terminate_instances(module,
-                gce, inames, zone)
+        (changed, terminated_instance_names) = terminate_instances(
+            module, gce, inames, zone)
 
         # based on what user specified, return the same variable, although
         # value could be different if an instance could not be destroyed
@@ -454,14 +456,13 @@ def main():
 
     elif state in ['active', 'present']:
         json_output['state'] = 'present'
-        (changed, instance_data,instance_name_list) = create_instances(
-                module, gce, inames)
+        (changed, instance_data, instance_name_list) = create_instances(
+            module, gce, inames)
         json_output['instance_data'] = instance_data
         if instance_names:
             json_output['instance_names'] = instance_name_list
         elif name:
             json_output['name'] = name
-
 
     json_output['changed'] = changed
     print json.dumps(json_output)

--- a/cloud/google/gce.py
+++ b/cloud/google/gce.py
@@ -291,16 +291,19 @@ def create_instances(module, gce, instance_names):
     # with:
     # [ {'key': key1, 'value': value1}, {'key': key2, 'value': value2}, ...]
     if metadata:
-        try:
-            md = literal_eval(metadata)
-            if not isinstance(md, dict):
-                raise ValueError('metadata must be a dict')
-        except ValueError as e:
-            print("failed=True msg='bad metadata: %s'" % str(e))
-            sys.exit(1)
-        except SyntaxError as e:
-            print("failed=True msg='bad metadata syntax'")
-            sys.exit(1)
+        if isinstance(metadata, dict):
+            md = metadata
+        else:
+            try:
+                md = literal_eval(metadata)
+                if not isinstance(md, dict):
+                    raise ValueError('metadata must be a dict')
+            except ValueError as e:
+                print("failed=True msg='bad metadata: %s'" % str(e))
+                sys.exit(1)
+            except SyntaxError as e:
+                print("failed=True msg='bad metadata syntax'")
+                sys.exit(1)
 
     if hasattr(libcloud, '__version__') and libcloud.__version__ < '0.15':
         items = []


### PR DESCRIPTION
In apache-libcloud > 0.15, for at least the 'create_node' method, the format in which the 'metadata' argument is expect has changed. This PR adds support for the new format while keeping support for the old format by detecting the 'apache-libcloud' version at runtime.

Actual changes are on the last commit. The other commits are just general code cleanups.
