### PR TITLE
Add documentation that add_host is a host list bypass plugin

### DIFF
--- a/inventory/add_host.py
+++ b/inventory/add_host.py
@@ -19,6 +19,15 @@ options:
     description:
     - The groups to add the hostname to, comma separated.
     required: false
+notes:
+  - This module is most commonly used in conjunction with a C(with_) style loop
+  - This module is commonly referred to as a host list bypass plugin. This
+    means that add_host will not execute for every host targeted by a playbook.
+    Instead add_host will only execute on the first host in the hosts
+    list as defined by inventory.
+  - For instances where you need to dynamically add all hosts targeted by a
+    playbook to a group for later use, the C(group_by) module is
+    potentially the better choice.
 author: Seth Vidal
 '''
 


### PR DESCRIPTION
Ref: https://github.com/ansible/ansible/pull/7499

Over the past few weeks there has been an increase in the number of people being confused and submitting issues to the fact that add_host only runs on the first host in a playbook.

This pull requests adds a few notes items to the add_host module docs to hopefully clarify this some place in the docs.
