### PR TITLE
Add word boundary in apache2_module regexp

### DIFF
--- a/web_infrastructure/apache2_module.py
+++ b/web_infrastructure/apache2_module.py
@@ -51,7 +51,7 @@ def _disable_module(module):
     a2dismod_binary = module.get_bin_path("a2dismod")
     result, stdout, stderr = module.run_command("%s %s" % (a2dismod_binary, name))
 
-    if re.match(r'.*' + name + r' already disabled.*', stdout, re.S):
+    if re.match(r'.*\b' + name + r' already disabled', stdout, re.S):
         module.exit_json(changed = False, result = "Success")
     elif result != 0:
         module.fail_json(msg="Failed to disable module %s: %s" % (name, stdout))
@@ -63,7 +63,7 @@ def _enable_module(module):
     a2enmod_binary = module.get_bin_path("a2enmod")
     result, stdout, stderr = module.run_command("%s %s" % (a2enmod_binary, name))
 
-    if re.match(r'.*' + name + r' already enabled.*', stdout, re.S):
+    if re.match(r'.*\b' + name + r' already enabled', stdout, re.S):
         module.exit_json(changed = False, result = "Success")
     elif result != 0:
         module.fail_json(msg="Failed to enable module %s: %s" % (name, stdout))


### PR DESCRIPTION
Add a word boundary \b to the regexp for checking the output of a2{en,dis}mod,
to avoid a false positive for a module that ends with the same text as the
module we're working on.

For example, the previous regexp r'.*spam already enabled' would also match
against 'eggs_spam already enabled'.

Also, get rid of the redundant '.*' from the end of the regexp.
