### PR TITLE
Remove redundant check for creates argument.

### DIFF
--- a/files/unarchive.py
+++ b/files/unarchive.py
@@ -193,7 +193,6 @@ def main():
     src    = os.path.expanduser(module.params['src'])
     dest   = os.path.expanduser(module.params['dest'])
     copy   = module.params['copy']
-    creates = module.params['creates']
 
     # did tar file arrive?
     if not os.path.exists(src):
@@ -203,20 +202,6 @@ def main():
             module.fail_json(msg="Source '%s' does not exist" % src)
     if not os.access(src, os.R_OK):
         module.fail_json(msg="Source '%s' not readable" % src)
-
-    if creates:
-        # do not run the command if the line contains creates=filename
-        # and the filename already exists.  This allows idempotence
-        # of command executions.
-        v = os.path.expanduser(creates)
-        if os.path.exists(v):
-            module.exit_json(
-                stdout="skipped, since %s exists" % v,
-                skipped=True,
-                changed=False,
-                stderr=False,
-                rc=0
-            )
 
     # is dest OK to receive tar file?
     if not os.path.isdir(dest):


### PR DESCRIPTION
It doesn't make sense to check 'creates' in the core module for unarchive as the copy will already have taken place in action_plugins. This should be combined with: https://github.com/ansible/ansible/pull/9261 which moves the check earlier to prevent any unnecessary file transfers.
