### PR TITLE
apt_key: add keyserver example to docs

### DIFF
--- a/packaging/apt_key.py
+++ b/packaging/apt_key.py
@@ -81,6 +81,9 @@ options:
 '''
 
 EXAMPLES = '''
+# Add an apt key by id from a keyserver
+- apt_key: keyserver=keyserver.ubuntu.com id=36A1D7869245C8950F966E92D8576A8BA88D21E9
+
 # Add an Apt signing key, uses whichever key is at the URL
 - apt_key: url=https://ftp-master.debian.org/keys/archive-key-6.0.asc state=present
 


### PR DESCRIPTION
For the `apt_key` module, add keyserver example to docs.
