### PR TITLE
Refactor force basic auth, now all modules which use fetch_url() can use force_basic_auth

### DIFF
--- a/network/basics/get_url.py
+++ b/network/basics/get_url.py
@@ -110,6 +110,15 @@ options:
         parameter is not specified, the C(url_password) parameter will not be used.
     required: false
     version_added: '1.6'
+  force_basic_auth:
+    description:
+      - httplib2, the library used by the uri module only sends authentication information when a webservice
+        responds to an initial request with a 401 status. Since some basic auth services do not properly
+        send a 401, logins will fail. This option forces the sending of the Basic authentication header
+        upon initial request.
+    required: false
+    choices: [ "yes", "no" ]
+    default: "no"
   others:
     description:
       - all arguments accepted by the M(file) module also work here
@@ -125,6 +134,9 @@ EXAMPLES='''
 
 - name: download file with sha256 check
   get_url: url=http://example.com/path/file.conf dest=/etc/foo.conf sha256sum=b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c
+
+- name: download file and force basic auth
+  get_url: url=http://example.com/path/file.conf dest=/etc/foo.conf force_basic_auth=yes
 '''
 
 import urlparse

--- a/network/basics/uri.py
+++ b/network/basics/uri.py
@@ -23,6 +23,7 @@
 import cgi
 import shutil
 import tempfile
+import base64
 import datetime
 try:
     import json
@@ -368,6 +369,7 @@ def main():
             body_format = dict(required=False, default='raw', choices=['raw', 'json']),
             method = dict(required=False, default='GET', choices=['GET', 'POST', 'PUT', 'HEAD', 'DELETE', 'OPTIONS', 'PATCH']),
             return_content = dict(required=False, default='no', type='bool'),
+            force_basic_auth = dict(required=False, default='no', type='bool'),
             follow_redirects = dict(required=False, default='safe', choices=['all', 'safe', 'none', 'yes', 'no']),
             creates = dict(required=False, default=None),
             removes = dict(required=False, default=None),
@@ -392,6 +394,7 @@ def main():
     method = module.params['method']
     dest = module.params['dest']
     return_content = module.params['return_content']
+    force_basic_auth = module.params['force_basic_auth']
     redirects = module.params['follow_redirects']
     creates = module.params['creates']
     removes = module.params['removes']
@@ -429,6 +432,13 @@ def main():
         v = os.path.expanduser(removes)
         if not os.path.exists(removes):
             module.exit_json(stdout="skipped, since %s does not exist" % removes, changed=False, stderr=False, rc=0)
+
+
+    # httplib2 only sends authentication after the server asks for it with a 401.
+    # Some 'basic auth' servies fail to send a 401 and require the authentication
+    # up front. This creates the Basic authentication header and sends it immediately. 
+    if force_basic_auth:
+        dict_headers["Authorization"] = "Basic {0}".format(base64.b64encode("{0}:{1}".format(user, password))) 
 
 
     # Make the request

--- a/network/basics/uri.py
+++ b/network/basics/uri.py
@@ -23,7 +23,6 @@
 import cgi
 import shutil
 import tempfile
-import base64
 import datetime
 try:
     import json
@@ -369,7 +368,6 @@ def main():
             body_format = dict(required=False, default='raw', choices=['raw', 'json']),
             method = dict(required=False, default='GET', choices=['GET', 'POST', 'PUT', 'HEAD', 'DELETE', 'OPTIONS', 'PATCH']),
             return_content = dict(required=False, default='no', type='bool'),
-            force_basic_auth = dict(required=False, default='no', type='bool'),
             follow_redirects = dict(required=False, default='safe', choices=['all', 'safe', 'none', 'yes', 'no']),
             creates = dict(required=False, default=None),
             removes = dict(required=False, default=None),
@@ -394,7 +392,6 @@ def main():
     method = module.params['method']
     dest = module.params['dest']
     return_content = module.params['return_content']
-    force_basic_auth = module.params['force_basic_auth']
     redirects = module.params['follow_redirects']
     creates = module.params['creates']
     removes = module.params['removes']
@@ -432,13 +429,6 @@ def main():
         v = os.path.expanduser(removes)
         if not os.path.exists(removes):
             module.exit_json(stdout="skipped, since %s does not exist" % removes, changed=False, stderr=False, rc=0)
-
-
-    # httplib2 only sends authentication after the server asks for it with a 401.
-    # Some 'basic auth' servies fail to send a 401 and require the authentication
-    # up front. This creates the Basic authentication header and sends it immediately. 
-    if force_basic_auth:
-        dict_headers["Authorization"] = "Basic {0}".format(base64.b64encode("{0}:{1}".format(user, password))) 
 
 
     # Make the request


### PR DESCRIPTION
Check out PR: https://github.com/ansible/ansible/pull/9281 which is related to this PR.
