### PR TITLE
[git] Find the actual commit annotated tags refer to instead of the tag object.

### DIFF
--- a/source_control/git.py
+++ b/source_control/git.py
@@ -287,6 +287,7 @@ def reset(git_path, module, dest):
 def get_remote_head(git_path, module, dest, version, remote, bare):
     cloning = False
     cwd = None
+    tag = False
     if remote == module.params['repo']:
         cloning = True
     else:
@@ -301,7 +302,8 @@ def get_remote_head(git_path, module, dest, version, remote, bare):
     elif is_remote_branch(git_path, module, dest, remote, version):
         cmd = '%s ls-remote %s -h refs/heads/%s' % (git_path, remote, version)
     elif is_remote_tag(git_path, module, dest, remote, version):
-        cmd = '%s ls-remote %s -t refs/tags/%s' % (git_path, remote, version)
+        tag = True
+        cmd = '%s ls-remote %s -t refs/tags/%s*' % (git_path, remote, version)
     else:
         # appears to be a sha1.  return as-is since it appears
         # cannot check for a specific sha1 on remote
@@ -309,6 +311,16 @@ def get_remote_head(git_path, module, dest, version, remote, bare):
     (rc, out, err) = module.run_command(cmd, check_rc=True, cwd=cwd)
     if len(out) < 1:
         module.fail_json(msg="Could not determine remote revision for %s" % version)
+
+    if tag:
+    # Find the dereferenced tag if this is an annotated tag.
+        for tag in out.split('\n'):
+            if tag.endswith(version + '^{}'):
+                out = tag
+                break
+            elif tag.endswith(version):
+                out = tag
+
     rev = out.split()[0]
     return rev
 


### PR DESCRIPTION
There is a bug in the git module handling of git tags. When the git module version parameter is an annotated tag (all github tags are annotated), the git module incorrectly gets the tag object id instead of the commit it points to in get_remote_head(). This bug results in check mode always reporting a task as changed and unnecessary work in real runs.

The proposed change fixes the bug by always finding the dereferenced tag from ls-remote for annotated tags.
