### PR TITLE
S3 headers

### DIFF
--- a/cloud/amazon/s3.py
+++ b/cloud/amazon/s3.py
@@ -56,6 +56,11 @@ options:
     required: false
     default: 600
     aliases: []
+  headers:
+    description:
+      - Custom headers for PUT operation, as a dictionary of 'key=value' and 'key=value,key=value'.
+    required: false
+    default: null
   marker:
     description:
       - Specifies the key to start with when using list mode. Object keys are returned in alphabetical order, starting with key after the marker in order.
@@ -128,7 +133,7 @@ options:
     version_added: "1.3"
 
 requirements: [ "boto" ]
-author: 
+author:
     - "Lester Wade (@lwade)"
     - "Ralph Tice (@ralph-tice)"
 extends_documentation_fragment: aws
@@ -147,6 +152,9 @@ EXAMPLES = '''
 # PUT/upload with metadata
 - s3: bucket=mybucket object=/my/desired/key.txt src=/usr/local/myfile.txt mode=put metadata='Content-Encoding=gzip,Cache-Control=no-cache'
 
+# PUT/upload with custom headers
+- s3: bucket=mybucket object=/my/desired/key.txt src=/usr/local/myfile.txt mode=put headers=x-amz-grant-full-control=emailAddress=owner@example.com
+
 # List keys simple
 - s3: bucket=mybucket mode=list
 
@@ -162,7 +170,7 @@ EXAMPLES = '''
 # Delete a bucket and all contents
 - s3: bucket=mybucket mode=delete
 
-# GET an object but dont download if the file checksums match 
+# GET an object but dont download if the file checksums match
 - s3: bucket=mybucket object=/my/desired/key.txt dest=/usr/local/myfile.txt mode=get overwrite=different
 
 # Delete an object from a bucket
@@ -285,7 +293,7 @@ def path_check(path):
         return False
 
 
-def upload_s3file(module, s3, bucket, obj, src, expiry, metadata, encrypt):
+def upload_s3file(module, s3, bucket, obj, src, expiry, metadata, encrypt, headers):
     try:
         bucket = s3.lookup(bucket)
         key = bucket.new_key(obj)
@@ -293,7 +301,7 @@ def upload_s3file(module, s3, bucket, obj, src, expiry, metadata, encrypt):
             for meta_key in metadata.keys():
                 key.set_metadata(meta_key, metadata[meta_key])
 
-        key.set_contents_from_filename(src, encrypt_key=encrypt)
+        key.set_contents_from_filename(src, encrypt_key=encrypt, headers=headers)
         url = key.generate_url(expiry)
         module.exit_json(msg="PUT operation complete", url=url, changed=True)
     except s3.provider.storage_copy_error, e:
@@ -367,6 +375,7 @@ def main():
             dest           = dict(default=None),
             encrypt        = dict(default=True, type='bool'),
             expiry         = dict(default=600, aliases=['expiration']),
+            headers        = dict(type='dict'),
             marker         = dict(default=None),
             max_keys       = dict(default=1000),
             metadata       = dict(type='dict'),
@@ -390,6 +399,7 @@ def main():
     expiry = int(module.params['expiry'])
     if module.params.get('dest'):
         dest = os.path.expanduser(module.params.get('dest'))
+    headers = module.params.get('headers')
     marker = module.params.get('marker')
     max_keys = module.params.get('max_keys')
     metadata = module.params.get('metadata')
@@ -402,16 +412,16 @@ def main():
     s3_url = module.params.get('s3_url')
     src = module.params.get('src')
 
-    if overwrite not in  ['always', 'never', 'different']: 
-        if module.boolean(overwrite): 
-            overwrite = 'always' 
-        else: 
+    if overwrite not in  ['always', 'never', 'different']:
+        if module.boolean(overwrite):
+            overwrite = 'always'
+        else:
             overwrite='never'
 
-    if overwrite not in  ['always', 'never', 'different']: 
-        if module.boolean(overwrite): 
-            overwrite = 'always' 
-        else: 
+    if overwrite not in  ['always', 'never', 'different']:
+        if module.boolean(overwrite):
+            overwrite = 'always'
+        else:
             overwrite='never'
 
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module)
@@ -533,24 +543,24 @@ def main():
                 if md5_local == md5_remote:
                     sum_matches = True
                     if overwrite == 'always':
-                        upload_s3file(module, s3, bucket, obj, src, expiry, metadata, encrypt)
+                        upload_s3file(module, s3, bucket, obj, src, expiry, metadata, encrypt, headers)
                     else:
                         get_download_url(module, s3, bucket, obj, expiry, changed=False)
                 else:
                     sum_matches = False
                     if overwrite in ('always', 'different'):
-                        upload_s3file(module, s3, bucket, obj, src, expiry, metadata, encrypt)
+                        upload_s3file(module, s3, bucket, obj, src, expiry, metadata, encrypt, headers)
                     else:
                         module.exit_json(msg="WARNING: Checksums do not match. Use overwrite parameter to force upload.")
 
         # If neither exist (based on bucket existence), we can create both.
         if bucketrtn is False and pathrtn is True:
             create_bucket(module, s3, bucket, location)
-            upload_s3file(module, s3, bucket, obj, src, expiry, metadata, encrypt)
+            upload_s3file(module, s3, bucket, obj, src, expiry, metadata, encrypt, headers)
 
         # If bucket exists but key doesn't, just upload.
         if bucketrtn is True and pathrtn is True and keyrtn is False:
-            upload_s3file(module, s3, bucket, obj, src, expiry, metadata, encrypt)
+            upload_s3file(module, s3, bucket, obj, src, expiry, metadata, encrypt, headers)
 
     # Delete an object from a bucket, not the entire bucket
     if mode == 'delobj':


### PR DESCRIPTION
Our use case requires that we maintain all of our buckets in our production AWS account, and allow access to our testing AWS account via Cross Account Access: http://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html

To allow the production account full access to objects uploaded by the testing account, we are setting the "x-amz-grant-full-control" header, and this pull request allows us to do so.

As we have an IAM policy to explicitly deny uploads from the testing account that don't set the "x-amz-grant-full-control header" to an expected value, I've also opted to catch the S3ResponseError.
