### PR TITLE
Added user, tenant and password to module parameters declaration

### DIFF
--- a/cloud/keystone_user.py
+++ b/cloud/keystone_user.py
@@ -291,6 +291,9 @@ def main():
     argument_spec.update(dict(
             tenant_description=dict(required=False),
             email=dict(required=False),
+            user=dict(required=False),
+            tenant=dict(required=False),
+            password=dict(required=False),
             role=dict(required=False),
             state=dict(default='present', choices=['present', 'absent']),
             endpoint=dict(required=False,


### PR DESCRIPTION
Without this change, user creation via Keystone fails with the errors "msg: unsupported parameter for module: user/tenant/password"
