### PR TITLE
ec2_asg: Initialize create_changed and replace_changed

### DIFF
--- a/cloud/ec2_asg.py
+++ b/cloud/ec2_asg.py
@@ -591,7 +591,7 @@ def main():
             module.fail_json(msg="failed to connect to AWS for the given region: %s" % str(region))
     except boto.exception.NoAuthHandlerFound, e:
         module.fail_json(msg=str(e))
-    changed = False
+    changed = create_changed = replace_changed = False
     if replace_all_instances and replace_instances:
         module.fail_json(msg="You can't use replace_instances and replace_all_instances in the same task.")
     if state == 'present':


### PR DESCRIPTION
Running `ec2_asg` with an already existing `asg` makes ansible crash if there is no value for `replace_all_instances` or `replace_instances`. (i.e wating for `viable_instances > X`)

```
- name: Wait for viable_instances
  local_action:
        module: ec2_asg
        name: asg-name
        region: eu-west-1
  register: asg
  until: asg.viable_instances|int >= 2
  delay: 10
  retries: 120
```

**Expected behavior:** Do not crash and return the status of the `asg`.

**Current behavior:** Crash with the following error `UnboundLocalError: local variable 'replace_changed' referenced before assignment`.

**Fix behavior:** Expected behavior.
