### PR TITLE
Openbsd rcctl

### DIFF
--- a/system/service.py
+++ b/system/service.py
@@ -979,6 +979,9 @@ class OpenBsdService(Service):
 
         rc, stdout, stderr = self.execute_command("%s %s %s" % (self.enable_cmd, 'status', self.name))
 
+        if stderr:
+            self.module.fail_json(msg=stderr)
+
         if self.enable:
             action = "enable %s flags %s" % (self.name, self.arguments)
             args = self.arguments
@@ -987,8 +990,6 @@ class OpenBsdService(Service):
         else:
             action = "disable %s" % self.name
             if rc == 1:
-                if stderr:
-                    self.module.fail_json(msg=stderr)
                 return
 
         if self.module.check_mode:
@@ -999,8 +1000,6 @@ class OpenBsdService(Service):
         if rc != 0:
             if stderr:
                 self.module.fail_json(msg=stderr)
-            elif stdout:
-                self.module.fail_json(msg=stdout)
             else:
                 self.module.fail_json(msg="rcctl failed to modify service enablement")
 

--- a/system/service.py
+++ b/system/service.py
@@ -996,7 +996,14 @@ class OpenBsdService(Service):
         if stderr:
             self.module.fail_json(msg=stderr)
 
-        default_flags = stdout.rstrip()
+        default_string = stdout.rstrip()
+
+        # Depending on the service the string returned from 'default' may be
+        # either a set of flags or the boolean YES/NO
+        if default_string == "YES" or default_string == "NO":
+            default_flags = ''
+        else:
+            default_flags = default_string
 
         rc, stdout, stderr = self.execute_command("%s %s %s" % (self.enable_cmd, 'status', self.name))
 

--- a/system/service.py
+++ b/system/service.py
@@ -989,6 +989,9 @@ class OpenBsdService(Service):
             if rc == 1:
                 return
 
+        if self.module.check_mode:
+            self.module.exit_json(changed=True, msg="changing service enablement")
+
         # XXX check rc ?
         rc, stdout, stderr = self.execute_command("%s %s" % (self.enable_cmd, action))
         self.changed = True

--- a/system/service.py
+++ b/system/service.py
@@ -1007,7 +1007,7 @@ class OpenBsdService(Service):
 
         # Depending on the service the string returned from 'status' may be
         # either a set of flags or the boolean YES/NO
-        if status_string == "YES" or status_string == "N0":
+        if status_string == "YES" or status_string == "NO":
             current_flags = ''
         else:
             current_flags = status_string

--- a/system/service.py
+++ b/system/service.py
@@ -944,34 +944,48 @@ class FreeBsdService(Service):
 
 class OpenBsdService(Service):
     """
-    This is the OpenBSD Service manipulation class - it uses /etc/rc.d for
-    service control. Enabling a service is currently supported if rcctl is present
+    This is the OpenBSD Service manipulation class - it uses rcctl(8) or
+    /etc/rc.d scripts for service control. Enabling a service is
+    only supported if rcctl is present.
     """
 
     platform = 'OpenBSD'
     distribution = None
 
     def get_service_tools(self):
-        rcdir = '/etc/rc.d'
-
-        rc_script = "%s/%s" % (rcdir, self.name)
-        if os.path.isfile(rc_script):
-            self.svc_cmd = rc_script
-
-        if not self.svc_cmd:
-            self.module.fail_json(msg='unable to find rc.d script')
-
         self.enable_cmd = self.module.get_bin_path('rcctl')
 
+        if self.enable_cmd:
+            self.svc_cmd = self.enable_cmd
+        else:
+            rcdir = '/etc/rc.d'
+
+            rc_script = "%s/%s" % (rcdir, self.name)
+            if os.path.isfile(rc_script):
+                self.svc_cmd = rc_script
+
+        if not self.svc_cmd:
+            self.module.fail_json(msg='unable to find svc_cmd')
+
     def get_service_status(self):
-        rc, stdout, stderr = self.execute_command("%s %s" % (self.svc_cmd, 'check'))
+        if self.enable_cmd:
+            rc, stdout, stderr = self.execute_command("%s %s %s" % (self.svc_cmd, 'check', self.name))
+        else:
+            rc, stdout, stderr = self.execute_command("%s %s" % (self.svc_cmd, 'check'))
+
+        if stderr:
+            self.module.fail_json(msg=stderr)
+
         if rc == 1:
             self.running = False
         elif rc == 0:
             self.running = True
 
     def service_control(self):
-        return self.execute_command("%s -f %s" % (self.svc_cmd, self.action))
+        if self.enable_cmd:
+            return self.execute_command("%s -f %s %s" % (self.svc_cmd, self.action, self.name))
+        else:
+            return self.execute_command("%s -f %s" % (self.svc_cmd, self.action))
 
     def service_enable(self):
         if not self.enable_cmd:
@@ -982,10 +996,13 @@ class OpenBsdService(Service):
         if stderr:
             self.module.fail_json(msg=stderr)
 
+        current_flags = stdout.rstrip()
+
         if self.enable:
-            action = "enable %s flags %s" % (self.name, self.arguments)
-            args = self.arguments
-            if rc == 0:
+            action = "enable %s" % (self.name)
+            if self.arguments or self.arguments != current_flags:
+                action = action + " flags %s" % (self.arguments)
+            if rc == 0 and self.arguments == current_flags:
                 return
         else:
             action = "disable %s" % self.name

--- a/system/service.py
+++ b/system/service.py
@@ -945,9 +945,7 @@ class FreeBsdService(Service):
 class OpenBsdService(Service):
     """
     This is the OpenBSD Service manipulation class - it uses /etc/rc.d for
-    service control. Enabling a service is currently not supported because the
-    <service>_flags variable is not boolean, you should supply a rc.conf.local
-    file in some other way.
+    service control. Enabling a service is currently supported if rcctl is present
     """
 
     platform = 'OpenBSD'
@@ -963,6 +961,8 @@ class OpenBsdService(Service):
         if not self.svc_cmd:
             self.module.fail_json(msg='unable to find rc.d script')
 
+        self.enable_cmd = self.module.get_bin_path('rcctl')
+
     def get_service_status(self):
         rc, stdout, stderr = self.execute_command("%s %s" % (self.svc_cmd, 'check'))
         if rc == 1:
@@ -971,7 +971,27 @@ class OpenBsdService(Service):
             self.running = True
 
     def service_control(self):
-        return self.execute_command("%s %s" % (self.svc_cmd, self.action))
+        return self.execute_command("%s -f %s" % (self.svc_cmd, self.action))
+
+    def service_enable(self):
+        if not self.enable_cmd:
+            return super(OpenBsdService, self).service_enable()
+
+        rc, stdout, stderr = self.execute_command("%s %s %s" % (self.enable_cmd, 'status', self.name))
+
+        if self.enable:
+            action = "enable %s flags %s" % (self.name, self.arguments)
+            args = self.arguments
+            if rc == 0:
+                return
+        else:
+            action = "disable %s" % self.name
+            if rc == 1:
+                return
+
+        # XXX check rc ?
+        rc, stdout, stderr = self.execute_command("%s %s" % (self.enable_cmd, action))
+        self.changed = True
 
 # ===========================================
 # Subclass: NetBSD

--- a/system/service.py
+++ b/system/service.py
@@ -1000,7 +1000,7 @@ class OpenBsdService(Service):
 
         if self.enable:
             action = "enable %s" % (self.name)
-            if self.arguments or self.arguments != current_flags:
+            if self.arguments or current_flags:
                 action = action + " flags %s" % (self.arguments)
             if rc == 0 and self.arguments == current_flags:
                 return

--- a/system/service.py
+++ b/system/service.py
@@ -992,8 +992,16 @@ class OpenBsdService(Service):
         if self.module.check_mode:
             self.module.exit_json(changed=True, msg="changing service enablement")
 
-        # XXX check rc ?
         rc, stdout, stderr = self.execute_command("%s %s" % (self.enable_cmd, action))
+
+        if rc != 0:
+            if stderr:
+                self.module.fail_json(msg=stderr)
+            elif stdout:
+                self.module.fail_json(msg=stdout)
+            else:
+                self.module.fail_json(msg="rcctl failed to modify service enablement")
+
         self.changed = True
 
 # ===========================================

--- a/system/service.py
+++ b/system/service.py
@@ -991,23 +991,51 @@ class OpenBsdService(Service):
         if not self.enable_cmd:
             return super(OpenBsdService, self).service_enable()
 
+        rc, stdout, stderr = self.execute_command("%s %s %s" % (self.enable_cmd, 'default', self.name))
+
+        if stderr:
+            self.module.fail_json(msg=stderr)
+
+        default_flags = stdout.rstrip()
+
         rc, stdout, stderr = self.execute_command("%s %s %s" % (self.enable_cmd, 'status', self.name))
 
         if stderr:
             self.module.fail_json(msg=stderr)
 
-        current_flags = stdout.rstrip()
+        status_string = stdout.rstrip()
+
+        # Depending on the service the string returned from 'status' may be
+        # either a set of flags or the boolean YES/NO
+        if status_string == "YES" or status_string == "N0":
+            current_flags = ''
+        else:
+            current_flags = status_string
+
+        # If there are arguments from the user we use these as flags unless
+        # they are already set.
+        if self.arguments and self.arguments != current_flags:
+            changed_flags = self.arguments
+        # If the user has not supplied any arguments and the current flags
+        # differ from the default we reset them.
+        elif not self.arguments and current_flags != default_flags:
+            changed_flags = ' '
+        # Otherwise there is no need to modify flags.
+        else:
+            changed_flags = ''
 
         if self.enable:
-            action = "enable %s" % (self.name)
-            if self.arguments or current_flags:
-                action = action + " flags %s" % (self.arguments)
-            if rc == 0 and self.arguments == current_flags:
+            if rc == 0 and not changed_flags:
                 return
+
+            action = "enable %s" % (self.name)
+            if changed_flags:
+                action = action + " flags %s" % (changed_flags)
         else:
-            action = "disable %s" % self.name
             if rc == 1:
                 return
+
+            action = "disable %s" % self.name
 
         if self.module.check_mode:
             self.module.exit_json(changed=True, msg="changing service enablement")

--- a/system/service.py
+++ b/system/service.py
@@ -987,6 +987,8 @@ class OpenBsdService(Service):
         else:
             action = "disable %s" % self.name
             if rc == 1:
+                if stderr:
+                    self.module.fail_json(msg=stderr)
                 return
 
         if self.module.check_mode:


### PR DESCRIPTION
Work to improve the OpenBsdService service backend.

It uses rcctl on recent OpenBSD to enable / disable services. 
The behavior is not changed on older OpenBSD version.

Thanks to @eest who did a lot of the work and ajacoutot@openbsd.org who helped and improved  rcctl to fit your needs.
