### PR TITLE
django_manage migrate using with `--database` variable

### DIFF
--- a/web_infrastructure/django_manage.py
+++ b/web_infrastructure/django_manage.py
@@ -170,7 +170,7 @@ def main():
         syncdb=('database', ),
         test=('failfast', 'testrunner', 'liveserver', 'apps', ),
         validate=(),
-        migrate=('apps', 'skip', 'merge'),
+        migrate=('apps', 'skip', 'merge', 'database'),
         collectstatic=('link', ),
         )
 


### PR DESCRIPTION
Now ansible cant run django_manage `migrate` command with `database` variable, but in django==1.7 unsing django-migrations with not required valirable `database`
