### PR TITLE
Using `database` variable in django_manage commands

### DIFF
--- a/web_infrastructure/django_manage.py
+++ b/web_infrastructure/django_manage.py
@@ -58,7 +58,7 @@ options:
     required: false
   database:
     description:
-      - The database to target. Used by the 'createcachetable', 'flush', 'loaddata', and 'syncdb' commands.
+      - The database to target. Used by the 'createcachetable', 'flush', 'loaddata', 'migrate' and 'syncdb' commands.
     required: false
   failfast:
     description:

--- a/web_infrastructure/django_manage.py
+++ b/web_infrastructure/django_manage.py
@@ -170,7 +170,7 @@ def main():
         syncdb=('database', ),
         test=('failfast', 'testrunner', 'liveserver', 'apps', ),
         validate=(),
-        migrate=('apps', 'skip', 'merge'),
+        migrate=('apps', 'skip', 'merge', 'database'),
         collectstatic=('link', ),
         )
 


### PR DESCRIPTION
Django==1.7 use django-migration system, which using `database` variable in `migrate` command
