### PR TITLE
Update syntax for cloudformation example

### DIFF
--- a/cloud/cloudformation.py
+++ b/cloud/cloudformation.py
@@ -97,7 +97,7 @@ EXAMPLES = '''
 # Basic task example
 tasks:
 - name: launch ansible cloudformation example
-  action: cloudformation >
+  cloudformation:
     stack_name="ansible-cloudformation" state=present
     region=us-east-1 disable_rollback=true
     template=files/cloudformation-example.json


### PR DESCRIPTION
The spare `>` freaked me out when I saw it (not a yaml line continuation since it was after a word), and the `action:` syntax is deprecated.
