### PR TITLE
fields in /proc/net/tcp* are not always delimited by single space

### DIFF
--- a/utilities/wait_for.py
+++ b/utilities/wait_for.py
@@ -228,7 +228,7 @@ class LinuxTCPConnectionInfo(TCPConnectionInfo):
         active_connections = 0
         f = open(self.source_file[self.family])
         for tcp_connection in f.readlines():
-            tcp_connection = tcp_connection.strip().split(' ')
+            tcp_connection = tcp_connection.strip().split()
             if tcp_connection[self.local_address_field] == 'local_address':
                 continue
             if tcp_connection[self.connection_state_field] not in self.connection_states:


### PR DESCRIPTION
Using split(' '):

```
>>> f = open('/proc/net/tcp')
>>> f.readline().strip().split(' ')
['sl', '', 'local_address', 'rem_address', '', '', 'st', 'tx_queue', 'rx_queue', 'tr', 'tm->when', 'retrnsmt', '', '', 'uid', '', 'timeout', 'inode']
```

Index of 'local_address' in the outputted list = 2

Using split():

```
>>> f = open('/proc/net/tcp')
>>> f.readline().strip().split()
['sl', 'local_address', 'rem_address', 'st', 'tx_queue', 'rx_queue', 'tr', 'tm->when', 'retrnsmt', 'uid', 'timeout', 'inode']
```

Index of 'local_address' in the outputted list = 1 (which is what the code expects: `local_address_field = 1`)
