### PR TITLE
add retry with exponential backoff when we receive throttling error code...

### DIFF
--- a/cloud/cloudformation.py
+++ b/cloud/cloudformation.py
@@ -159,7 +159,7 @@ def stack_operation(cfn, stack_name, operation):
     operation_complete = False
     while operation_complete == False:
         try:
-            stack = cfn.describe_stacks(stack_name)[0]
+            stack = invoke_with_throttling_retries(cfn.describe_stacks, stack_name)[0]
             existed.append('yes')
         except:
             if 'yes' in existed:
@@ -188,6 +188,19 @@ def stack_operation(cfn, stack_name, operation):
             time.sleep(5)
     return result
 
+IGNORE_CODE = 'Throttling'
+MAX_RETRIES=3
+def invoke_with_throttling_retries(function_ref, *argv):
+    retries=0
+    while True:
+        try:
+            retval=function_ref(*argv)
+            return retval
+        except boto.exception.BotoServerError, e:
+            if e.code != IGNORE_CODE or retries==MAX_RETRIES:
+                raise e
+        time.sleep(5 * (2**retries))
+        retries += 1
 
 def main():
     argument_spec = ec2_argument_spec()
@@ -281,7 +294,7 @@ def main():
     # and get the outputs of the stack
 
     if state == 'present' or update:
-        stack = cfn.describe_stacks(stack_name)[0]
+        stack = invoke_with_throttling_retries(cfn.describe_stacks,stack_name)[0]
         for output in stack.outputs:
             stack_outputs[output.key] = output.value
         result['stack_outputs'] = stack_outputs
@@ -292,7 +305,7 @@ def main():
 
     if state == 'absent':
         try:
-            cfn.describe_stacks(stack_name)
+            invoke_with_throttling_retries(cfn.describe_stacks,stack_name)
             operation = 'DELETE'
         except Exception, err:
             error_msg = boto_exception(err)


### PR DESCRIPTION
... from cloudformation

Occasionally when polling for completion of the creation or deletion of a CloudFormation stack, AWS will return an exception indicating that a rate limit has been exceeded and throttling is occurring.  It looks like this:

```
boto.exception.BotoServerError: BotoServerError: 400 Bad Request
<ErrorResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
  <Error>
    <Type>Sender</Type>
    <Code>Throttling</Code>
    <Message>Rate exceeded</Message>
  </Error>
  <RequestId>2ab5db0d-5bca-11e4-9592-272cff50ba2d</RequestId>
</ErrorResponse>
```

This can be avoided by retrying the operation repeatedly with an exponential backoff up to a max number of retries.

This PR implements such a retry for all describe_stacks operations within the cloudformation module.

retry is only invoked when the error code received indicates throttling is occurring, otherwise the exception is re-raised to maintain prior functionality.
