### PR TITLE
Alternative fix for #28

### DIFF
--- a/packaging/apt.py
+++ b/packaging/apt.py
@@ -229,7 +229,8 @@ def expand_dpkg_options(dpkg_options_compressed):
 
 def expand_pkgspec_from_fnmatches(m, pkgspec, cache):
     new_pkgspec = []
-    for pkgname_or_fnmatch_pattern in pkgspec:
+    for name_or_fnmatch_or_version in pkgspec:
+        pkgname_or_fnmatch_pattern = name_or_fnmatch_or_version.split("=")[0]
         # note that any of these chars is not allowed in a (debian) pkgname
         if [c for c in pkgname_or_fnmatch_pattern if c in "*?[]!"]:
             if "=" in pkgname_or_fnmatch_pattern:
@@ -249,7 +250,7 @@ def expand_pkgspec_from_fnmatches(m, pkgspec, cache):
             else:
                 new_pkgspec.extend(matches)
         else:
-            new_pkgspec.append(pkgname_or_fnmatch_pattern)
+            new_pkgspec.append(name_or_fnmatch_or_version)
     return new_pkgspec
 
 def install(m, pkgspec, cache, upgrade=False, default_release=None,

--- a/packaging/apt.py
+++ b/packaging/apt.py
@@ -230,10 +230,10 @@ def expand_dpkg_options(dpkg_options_compressed):
 def expand_pkgspec_from_fnmatches(m, pkgspec, cache):
     new_pkgspec = []
     for name_or_fnmatch_or_version in pkgspec:
-        pkgname_or_fnmatch_pattern = name_or_fnmatch_or_version.split("=")[0]
+        pkgname_or_fnmatch_pattern, version = package_split(name_or_fnmatch_or_version)
         # note that any of these chars is not allowed in a (debian) pkgname
         if [c for c in pkgname_or_fnmatch_pattern if c in "*?[]!"]:
-            if "=" in pkgname_or_fnmatch_pattern:
+            if version:
                 m.fail_json(msg="pkgname wildcard and version can not be mixed")
             # handle multiarch pkgnames, the idea is that "apt*" should
             # only select native packages. But "apt*:i386" should still work
@@ -560,4 +560,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+# FIXME: if __name__ == "__main__": ?
+if "ANSIBLE_IN_HAPPY_UNITTEST_LAND" not in os.environ:
+    main()

--- a/tests/test_apt.py
+++ b/tests/test_apt.py
@@ -1,0 +1,42 @@
+import collections
+import mock
+import os
+import unittest
+
+# FIXME: this is not super elegant
+os.environ["ANSIBLE_IN_HAPPY_UNITTEST_LAND"] = "1"
+from packaging.apt import (
+    expand_pkgspec_from_fnmatches,
+)
+
+
+class AptExpandPkgspecTestCase(unittest.TestCase):
+
+    def setUp(self):
+        FakePackage = collections.namedtuple("Package", ("name",))
+        self.fake_cache = [ FakePackage("apt"),
+                            FakePackage("apt-utils"),
+        ]
+
+    def test_trivil(self):
+        foo = ["apt"]
+        self.assertEqual(
+            expand_pkgspec_from_fnmatches(None, foo, self.fake_cache), foo)
+
+    def test_bug_28(self):
+        foo = ["apt=1.0*"]
+        self.assertEqual(
+            expand_pkgspec_from_fnmatches(None, foo, self.fake_cache), foo)
+
+    def test_pkgname_wildcard_version_wildcard_fails(self):
+        foo = ["apt*=1.0*"]
+        m_mock = mock.Mock()
+        expand_pkgspec_from_fnmatches(m_mock, foo, self.fake_cache)
+        self.assertTrue(m_mock.fail_json.called)
+
+    def test_pkgname_expands(self):
+        foo = ["apt*"]
+        m_mock = mock.Mock()
+        self.assertEqual(
+            expand_pkgspec_from_fnmatches(m_mock, foo, self.fake_cache),
+            ["apt", "apt-utils"])


### PR DESCRIPTION
Based on the discussion in https://github.com/ansible/ansible-modules-core/pull/28 a alternative way of solving the issue. I personally don't mind either way but I think it would be great if you would pull in the unittest so that this kind of code is easier to change in the future.
