### PR TITLE
The nova_compute module create a list of un-use floating ip by value of fixed_ip

### DIFF
--- a/cloud/openstack/_nova_compute.py
+++ b/cloud/openstack/_nova_compute.py
@@ -324,7 +324,7 @@ def _add_floating_ip_from_pool(module, nova, server):
         # loop through all floating IPs
         for f_ip in all_floating_ips:
             # if not reserved and the correct pool, add
-            if f_ip.instance_id is None and (f_ip.pool == pool):
+            if f_ip.fixed_ip is None and (f_ip.pool == pool):
                 pool_ips.append(f_ip.ip)
                 # only need one
                 break


### PR DESCRIPTION
The nova_compute module create a list of un-use floating ip by value of fixed_ip.

Fixes #249
