### PR TITLE
Add working status detection for pf on FreeBSD

### DIFF
--- a/system/service.py
+++ b/system/service.py
@@ -913,10 +913,13 @@ class FreeBsdService(Service):
 
     def get_service_status(self):
         rc, stdout, stderr = self.execute_command("%s %s %s %s" % (self.svc_cmd, self.name, 'onestatus', self.arguments))
-        if rc == 1:
-            self.running = False
-        elif rc == 0:
-            self.running = True
+        if self.name == "pf":
+            self.running = "Enabled" in stdout
+        else:
+            if rc == 1:
+                self.running = False
+            elif rc == 0:
+                self.running = True
 
     def service_enable(self):
         if self.enable:


### PR DESCRIPTION
The return code of "service pf onestatus" is usually zero on FreeBSD (tested with FreeBSD 10.0), even if pf is not running. So the service module always thinks that pf is running, even when it needs to be started.
