### PR TITLE
Added better region handling and enabled eu-central-1

### DIFF
--- a/cloud/amazon/ec2_ami_search.py
+++ b/cloud/amazon/ec2_ami_search.py
@@ -56,7 +56,8 @@ options:
     required: false
     default: us-east-1
     choices: ["ap-northeast-1", "ap-southeast-1", "ap-southeast-2",
-              "eu-west-1", "sa-east-1", "us-east-1", "us-west-1", "us-west-2", "us-gov-west-1"]
+              "eu-central-1", "eu-west-1", "sa-east-1", "us-east-1",
+              "us-west-1", "us-west-2", "us-gov-west-1"]
   virt:
     description: virutalization type
     required: false
@@ -88,11 +89,13 @@ SUPPORTED_DISTROS = ['ubuntu']
 AWS_REGIONS = ['ap-northeast-1',
                'ap-southeast-1',
                'ap-southeast-2',
+               'eu-central-1',
                'eu-west-1',
                'sa-east-1',
                'us-east-1',
                'us-west-1',
-               'us-west-2']
+               'us-west-2',
+               "us-gov-west-1"]
 
 
 def get_url(module, url):

--- a/cloud/amazon/ec2_asg.py
+++ b/cloud/amazon/ec2_asg.py
@@ -272,7 +272,7 @@ def create_autoscaling_group(connection, module):
         region, ec2_url, aws_connect_params = get_aws_connection_info(module)
         try:
             ec2_connection = connect_to_aws(boto.ec2, region, **aws_connect_params)
-        except boto.exception.NoAuthHandlerFound, e:
+        except (boto.exception.NoAuthHandlerFound, StandardError), e:
             module.fail_json(msg=str(e))
 
     asg_tags = []

--- a/cloud/amazon/ec2_elb.py
+++ b/cloud/amazon/ec2_elb.py
@@ -258,7 +258,7 @@ class ElbManager:
         try:
             elb = connect_to_aws(boto.ec2.elb, self.region, 
                                  **self.aws_connect_params)
-        except boto.exception.NoAuthHandlerFound, e:
+        except (boto.exception.NoAuthHandlerFound, StandardError), e:
             self.module.fail_json(msg=str(e))
 
         elbs = elb.get_all_load_balancers()
@@ -278,7 +278,7 @@ class ElbManager:
         try:
             ec2 = connect_to_aws(boto.ec2, self.region, 
                                  **self.aws_connect_params)
-        except boto.exception.NoAuthHandlerFound, e:
+        except (boto.exception.NoAuthHandlerFound, StandardError), e:
             self.module.fail_json(msg=str(e))
         return ec2.get_only_instances(instance_ids=[self.instance_id])[0]
 

--- a/cloud/amazon/ec2_elb_lb.py
+++ b/cloud/amazon/ec2_elb_lb.py
@@ -374,7 +374,7 @@ class ElbManager(object):
         try:
             return connect_to_aws(boto.ec2.elb, self.region,
                                   **self.aws_connect_params)
-        except boto.exception.NoAuthHandlerFound, e:
+        except (boto.exception.NoAuthHandlerFound, StandardError), e:
             self.module.fail_json(msg=str(e))
 
     def _delete_elb(self):

--- a/cloud/amazon/ec2_facts.py
+++ b/cloud/amazon/ec2_facts.py
@@ -65,6 +65,7 @@ class Ec2Metadata(object):
     AWS_REGIONS = ('ap-northeast-1',
                    'ap-southeast-1',
                    'ap-southeast-2',
+                   'eu-central-1',
                    'eu-west-1',
                    'sa-east-1',
                    'us-east-1',

--- a/cloud/amazon/ec2_lc.py
+++ b/cloud/amazon/ec2_lc.py
@@ -265,7 +265,7 @@ def main():
 
     try:
         connection = connect_to_aws(boto.ec2.autoscale, region, **aws_connect_params)
-    except boto.exception.NoAuthHandlerFound, e:
+    except (boto.exception.NoAuthHandlerFound, StandardError), e:
         module.fail_json(msg=str(e))
 
     state = module.params.get('state')

--- a/cloud/amazon/ec2_metric_alarm.py
+++ b/cloud/amazon/ec2_metric_alarm.py
@@ -271,7 +271,7 @@ def main():
     region, ec2_url, aws_connect_params = get_aws_connection_info(module)
     try:
         connection = connect_to_aws(boto.ec2.cloudwatch, region, **aws_connect_params)
-    except boto.exception.NoAuthHandlerFound, e:
+    except (boto.exception.NoAuthHandlerFound, StandardError), e:
         module.fail_json(msg=str(e))
 
     if state == 'present':

--- a/cloud/amazon/ec2_scaling_policy.py
+++ b/cloud/amazon/ec2_scaling_policy.py
@@ -163,9 +163,7 @@ def main():
 
     try:
         connection = connect_to_aws(boto.ec2.autoscale, region, **aws_connect_params)
-        if not connection:
-            module.fail_json(msg="failed to connect to AWS for the given region: %s" % str(region))
-    except boto.exception.NoAuthHandlerFound, e:
+    except (boto.exception.NoAuthHandlerFound, StandardError), e:
         module.fail_json(msg = str(e))
 
     if state == 'present':


### PR DESCRIPTION
Make use of improved connect_to_aws that throws an exception
if a region can't be connected to (e.g. eu-central-1 requires
boto 2.34 onwards)

Add eu-central-1 to the two modules that hardcode their regions

This pull request makes use of the changes in ansible/ansible#9419
