### PR TITLE
yum module: add support for check_mode /w yum package groups

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,10 @@ I'd also read the community page above, but in particular, make sure you copy [t
 
 Also please make sure you are testing on the latest released version of Ansible or the development branch.
 
+If you'd like to contribute code to an existing module
+======================================================
+Each module in Core is maintained by the owner of that module; each module's owner is indicated in the documentation section of the module itself. Any pull request for a module that is given a +1 by the owner in the comments will be merged by the Ansible team.
+
 Thanks!
 
 

--- a/cloud/amazon/_ec2_ami_search.py
+++ b/cloud/amazon/_ec2_ami_search.py
@@ -65,15 +65,6 @@ options:
     required: false
     default: paravirtual
     choices: ["paravirtual", "hvm"]
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated.  This should only
-        be set to C(no) used on personally controlled sites using self-signed
-        certificates.  Prior to 1.9.3 the code defaulted to C(no).
-    required: false
-    default: 'yes'
-    choices: ['yes', 'no']
-    version_added: '1.9.3'
 
 author: Lorin Hochstein
 '''
@@ -193,7 +184,6 @@ def main():
         region=dict(required=False, default='us-east-1', choices=AWS_REGIONS),
         virt=dict(required=False, default='paravirtual',
             choices=['paravirtual', 'hvm']),
-        validate_certs = dict(required=False, default=True, type='bool'),
     )
     module = AnsibleModule(argument_spec=arg_spec)
     distro = module.params['distro']

--- a/cloud/amazon/iam_policy.py
+++ b/cloud/amazon/iam_policy.py
@@ -120,7 +120,7 @@ tasks:
   iam_policy:
     iam_type: user
     iam_name: "{{ item.user }}"
-    policy_name: "s3_limited_access_{{ item.s3_user_prefix }}"
+    policy_name: "s3_limited_access_{{ item.prefix }}"
     state: present
     policy_json: " {{ lookup( 'template', 's3_policy.json.j2') }} "
     with_items:

--- a/cloud/amazon/route53.py
+++ b/cloud/amazon/route53.py
@@ -213,7 +213,7 @@ EXAMPLES = '''
 - route53:
       command: "create"
       zone: "foo.com"
-      hostes_zone_id: "Z2AABBCCDDEEFF"
+      hosted_zone_id: "Z2AABBCCDDEEFF"
       record: "localhost.foo.com"
       type: "AAAA"
       ttl: "7200"
@@ -224,7 +224,7 @@ EXAMPLES = '''
 - route53:
       command: "create"
       zone: "foo.com"
-      hostes_zone_id: "Z2AABBCCDDEEFF"
+      hosted_zone_id: "Z2AABBCCDDEEFF"
       record: "localhost.foo.com"
       type: "AAAA"
       ttl: "7200"

--- a/database/mysql/mysql_user.py
+++ b/database/mysql/mysql_user.py
@@ -254,7 +254,7 @@ def privileges_get(cursor, user,host):
             return x
 
     for grant in grants:
-        res = re.match("GRANT (.+) ON (.+) TO '.+'@'.+'( IDENTIFIED BY PASSWORD '.+')? ?(.*)", grant[0])
+        res = re.match("GRANT (.+) ON (.+) TO '.*'@'.+'( IDENTIFIED BY PASSWORD '.+')? ?(.*)", grant[0])
         if res is None:
             raise InvalidPrivsError('unable to parse the MySQL grant string: %s' % grant[0])
         privileges = res.group(1).split(", ")

--- a/database/mysql/mysql_user.py
+++ b/database/mysql/mysql_user.py
@@ -109,7 +109,7 @@ options:
 notes:
    - Requires the MySQLdb Python package on the remote host. For Ubuntu, this
      is as easy as apt-get install python-mysqldb.
-   - Both C(login_password) and C(login_username) are required when you are
+   - Both C(login_password) and C(login_user) are required when you are
      passing credentials. If none are present, the module will attempt to read
      the credentials from C(~/.my.cnf), and finally fall back to using the MySQL
      default login of 'root' with no password.

--- a/database/postgresql/postgresql_user.py
+++ b/database/postgresql/postgresql_user.py
@@ -92,7 +92,7 @@ options:
     description:
       - "PostgreSQL role attributes string in the format: CREATEDB,CREATEROLE,SUPERUSER"
     required: false
-    default: null
+    default: ""
     choices: [ "[NO]SUPERUSER","[NO]CREATEROLE", "[NO]CREATEUSER", "[NO]CREATEDB",
                     "[NO]INHERIT", "[NO]LOGIN", "[NO]REPLICATION" ]
   state:
@@ -233,7 +233,7 @@ def user_alter(cursor, module, user, password, role_attr_flags, encrypted, expir
             return False
 
     # Handle passwords.
-    if not no_password_changes and (password is not None or role_attr_flags is not None):
+    if not no_password_changes and (password is not None or role_attr_flags != ''):
         # Select password and all flag-like columns in order to verify changes.
         query_password_data = dict(password=password, expires=expires)
         select = "SELECT * FROM pg_authid where rolname=%(user)s"

--- a/database/postgresql/postgresql_user.py
+++ b/database/postgresql/postgresql_user.py
@@ -490,10 +490,10 @@ def parse_role_attrs(role_attr_flags):
 
 def normalize_privileges(privs, type_):
     new_privs = set(privs)
-    if 'ALL' in privs:
+    if 'ALL' in new_privs:
         new_privs.update(VALID_PRIVS[type_])
         new_privs.remove('ALL')
-    if 'TEMP' in privs:
+    if 'TEMP' in new_privs:
         new_privs.add('TEMPORARY')
         new_privs.remove('TEMP')
 

--- a/windows/win_user.ps1
+++ b/windows/win_user.ps1
@@ -146,6 +146,7 @@ If ($state -eq 'present') {
             If ($password -ne $null) {
                 $user_obj.SetPassword($password)
             }
+            $user_obj.SetInfo()
             $result.changed = $true
         }
         ElseIf (($password -ne $null) -and ($update_password -eq 'always')) {


### PR DESCRIPTION
Currently, when using check_mode with a yum package group (@group), ansible will return changed=True all the time. This is inconvenient when running in check_mode to see if your hosts configs are proper. In my use case, I have a playbook that I run in check_mode every morning and an email report is sent if I have any non-compliant hosts/tasks. (changed != 0)

This pull request adds check_mode support for package groups with state=installed or state=latest

Checking for package removal is tricky and I have not found a clean way to implement this. Ideas are welcome.

There is no way to ask yum or repoquery directly if a package group has installable packages or updateable packages. The way this is implemented is by expanding the package group using 'repoquery' and by passing the list of packages to is_installed which will return wether or not it has any packages that would be installed. Since repoquery will list ALL member packages even though they are excluded in yum.conf, there is a need to use both is_installed and is_available to ensure we only check for those packages yum would normally install (taking into account the excluded ones)
