### PR TITLE
docker: use env vars if present

### DIFF
--- a/cloud/docker/_docker_image.py
+++ b/cloud/docker/_docker_image.py
@@ -29,6 +29,7 @@ version_added: "1.5"
 short_description: manage docker images
 description:
      - Create, check and remove docker images
+     - If DOCKER_HOST is set, will get connection info from environment variables
 options:
   path:
     description:
@@ -108,6 +109,7 @@ try:
     import re
     import json
     import docker.client
+    import docker.utils
     from requests.exceptions import *
     from urlparse import urlparse
 except ImportError, e:
@@ -128,7 +130,12 @@ class DockerImageManager:
         self.tag = self.module.params.get('tag')
         self.nocache = self.module.params.get('nocache')
         docker_url = urlparse(module.params.get('docker_url'))
-        self.client = docker.Client(base_url=docker_url.geturl(), timeout=module.params.get('timeout'))
+        if 'DOCKER_HOST' in os.environ:
+            args = docker.utils.kwargs_from_env(assert_hostname=False)
+            args['timeout'] = module.params.get('timeout')
+            self.client = docker.Client(**args)
+        else:
+            self.client = docker.Client(base_url=docker_url.geturl(), timeout=module.params.get('timeout'))
         self.changed = False
         self.log = []
         self.error_msg = None

--- a/cloud/docker/_docker_image.py
+++ b/cloud/docker/_docker_image.py
@@ -105,6 +105,7 @@ Remove image from local docker storage:
 '''
 
 try:
+    import os
     import sys
     import re
     import json

--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -28,6 +28,7 @@ version_added: "1.4"
 short_description: manage docker containers
 description:
      - Manage the life cycle of docker containers.
+     - If DOCKER_HOST is set, will get connection info from environment variables
 options:
   count:
     description:

--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -444,7 +444,12 @@ class DockerManager:
         # connect to docker server
         docker_url = urlparse(module.params.get('docker_url'))
         docker_api_version = module.params.get('docker_api_version')
-        self.client = docker.Client(base_url=docker_url.geturl(), version=docker_api_version)
+
+        # If DOCKER_HOST is set, use environment variables to configure client
+        if 'DOCKER_HOST' in os.environ:
+            self.client = docker.Client(**docker.utils.kwargs_from_env(assert_hostname=False))
+        else:
+            self.client = docker.Client(base_url=docker_url.geturl(), version=docker_api_version)
 
 
     def get_links(self, links):


### PR DESCRIPTION
If the DOCKER_HOST environment variable is set, use environment variables
to configure the docker client.

This makes it much simpler to use this module with boot2docker on OS X. 

Fixes #176.
