### PR TITLE
Fixed postgresql_db failing on Python 2.4 with --check

### DIFF
--- a/database/postgresql/postgresql_db.py
+++ b/database/postgresql/postgresql_db.py
@@ -281,15 +281,19 @@ def main():
             elif state == "present":
                 changed = not db_matches(cursor, db, owner, template, encoding,
                                          lc_collate, lc_ctype)
-        else:
-            if state == "absent":
-                changed = db_delete(cursor, db)
+            module.exit_json(changed=changed,db=db)
 
-            elif state == "present":
-                changed = db_create(cursor, db, owner, template, encoding,
-                                    lc_collate, lc_ctype)
+        if state == "absent":
+            changed = db_delete(cursor, db)
+
+        elif state == "present":
+            changed = db_create(cursor, db, owner, template, encoding,
+                                lc_collate, lc_ctype)
     except NotSupportedError, e:
         module.fail_json(msg=str(e))
+    except SystemExit:
+        # Avoid catching this on Python 2.4 
+        raise
     except Exception, e:
         module.fail_json(msg="Database query failed: %s" % e)
 

--- a/database/postgresql/postgresql_db.py
+++ b/database/postgresql/postgresql_db.py
@@ -281,14 +281,13 @@ def main():
             elif state == "present":
                 changed = not db_matches(cursor, db, owner, template, encoding,
                                          lc_collate, lc_ctype)
-            module.exit_json(changed=changed,db=db)
+        else:
+            if state == "absent":
+                changed = db_delete(cursor, db)
 
-        if state == "absent":
-            changed = db_delete(cursor, db)
-
-        elif state == "present":
-            changed = db_create(cursor, db, owner, template, encoding,
-                                lc_collate, lc_ctype)
+            elif state == "present":
+                changed = db_create(cursor, db, owner, template, encoding,
+                                    lc_collate, lc_ctype)
     except NotSupportedError, e:
         module.fail_json(msg=str(e))
     except Exception, e:


### PR DESCRIPTION
Fixed a minor bug where `postgresql_db` module fails with `--check`. This happens because on Python 2.4 (Centos 5) `module.exit_json` calls `sys.exit()` which throws an exception which is then caught by the try/except around it, so it reports an error.

This is just a minor change it the code, where I only put if/else instead of the exit_json() after the first if.
