### PR TITLE
Fix a typo in nova_compute documentation string

### DIFF
--- a/cloud/openstack/nova_compute.py
+++ b/cloud/openstack/nova_compute.py
@@ -124,7 +124,7 @@ options:
      default: 'yes'
      version_added: "1.8"
    floating_ips:
-     decription:
+     description:
         - list of valid floating IPs that pre-exist to assign to this node
      required: false
      default: None


### PR DESCRIPTION
Without this patch, ansible-doc was failing this way:

$ ansible-doc nova_compute
Traceback (most recent call last):
  File "/home/francois/WORK/dev/ansible/bin/ansible-doc", line 324, in <module>
    main()
  File "/home/francois/WORK/dev/ansible/bin/ansible-doc", line 316, in main
    text += get_man_text(doc)
  File "/home/francois/WORK/dev/ansible/bin/ansible-doc", line 112, in get_man_text
    desc = " ".join(opt['description'])
KeyError: 'description'
