### PR TITLE
acl: Fix X support in ACL permissions

### DIFF
--- a/files/acl.py
+++ b/files/acl.py
@@ -111,6 +111,9 @@ def normalize_permissions(p):
             perms[1] = 'w'
         if char == 'x':
             perms[2] = 'x'
+        if char == 'X':
+            if perms[2] != 'x':  # 'x' is more permissive
+              perms[2] = 'X'
     return ''.join(perms)
 
 def split_entry(entry):


### PR DESCRIPTION
If you try to set rwX permissions, ACL fails to set x at all.

Expected:

```
$ sudo setfacl -m 'group::rwX' www
...
drwxrwxr-x  2 root root  4096 Nov 10 17:09 www
```

With Ansible:

```
acl: name=/var/www permissions=rwX etype=group state=present
...
drwxrw-r-x  2 root root  4096 Nov 10 17:30 www
```

x for group is erased. =/
