### PR TITLE
Add mention of fetch module to the copy module docs.

### DIFF
--- a/files/copy.py
+++ b/files/copy.py
@@ -27,7 +27,7 @@ module: copy
 version_added: "historical"
 short_description: Copies files to remote locations.
 description:
-     - The M(copy) module copies a file on the local box to remote locations.
+     - The M(copy) module copies a file on the local box to remote locations. Use the M(fetch) module to copy files from remote locations to the local box.
 options:
   src:
     description:


### PR DESCRIPTION
I've run into this twice, and someone today on IRC also mentioned it; the `copy` module makes no mention of the `fetch` module (which is basically `copy` in reverse).

The `fetch` docs _do_ mention `copy`. So to help people who are searching for things like "ansible copy files to host" or something like that, it would be good if the copy docs mentioned `fetch` as well.
