### PR TITLE
fixes #240, #274, #108

### DIFF
--- a/cloud/amazon/ec2_asg.py
+++ b/cloud/amazon/ec2_asg.py
@@ -199,7 +199,7 @@ except ImportError:
 ASG_ATTRIBUTES = ('availability_zones', 'default_cooldown', 'desired_capacity',
     'health_check_period', 'health_check_type', 'launch_config_name',
     'load_balancers', 'max_size', 'min_size', 'name', 'placement_group',
-    'tags', 'termination_policies', 'vpc_zone_identifier')
+    'termination_policies', 'vpc_zone_identifier')
 
 INSTANCE_ATTRIBUTES = ('instance_id', 'health_status', 'lifecycle_state', 'launch_config_name')
 


### PR DESCRIPTION
https://github.com/ansible/ansible/commit/09979ac20d6381e4a8da04b7cb59e8ee4951cbb1 caused a number of problems relating to tags.  This patch removes the tag attribute from the returned results.  Special handling will need to be had if we want to return tags as part of the result as it is not a JSON serializable object.

The commit listed also causing issues when do tag comparisons, and creating/updating tags.
