### PR TITLE
Fix get_flavor_id() when flavor_ram is specified

### DIFF
--- a/cloud/openstack/nova_compute.py
+++ b/cloud/openstack/nova_compute.py
@@ -405,7 +405,7 @@ def _get_flavor_id(module, nova):
             if (flavor.ram >= module.params['flavor_ram'] and
                     (not module.params['flavor_include'] or module.params['flavor_include'] in flavor.name)):
                 return flavor.id
-            module.fail_json(msg = "Error finding flavor with %sMB of RAM" % module.params['flavor_ram'])
+        module.fail_json(msg = "Error finding flavor with %sMB of RAM" % module.params['flavor_ram'])
     return module.params['flavor_id']
 
 


### PR DESCRIPTION
Without this fix, _get_flavor_id() fails to find a matching flavor if
both:
- the flavor_ram parameter is specified
- the first flavor in the list does not match.

The bug is simply that the module.fail_json() call lies within the loop
iterating through the flavors.  This call should only be made if the
loop completes and no matching flavors have been found.
