### PR TITLE
Docker: Handle images with multiple tags

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -356,7 +356,6 @@ HAS_DOCKER_PY = True
 
 import sys
 from urlparse import urlparse
-from collections import defaultdict
 try:
     import docker.client
     import docker.utils
@@ -683,11 +682,9 @@ class DockerManager(object):
             name = '/' + name
         deployed = []
 
-        all_valid_tags = []
         for img in self.client.images():
             if image in img['RepoTags']:
-                for x in img['RepoTags']:
-                    all_valid_tags.append(x.split(':', 1)[1])
+                all_valid_tags = set(x.rsplit(':', 1)[1] for x in img['RepoTags'])
 
         # if we weren't given a tag with the image, we need to only compare on the image name, as that
         # docker will give us back the full image name including a tag in the container list if one exists.
@@ -703,7 +700,7 @@ class DockerManager(object):
             image_matches = (running_image == image)
 
             # images can and most probably have multiple tags associated
-            tag_matches = (not tag or running_tag == tag or running_tag in all_valid_tags)
+            tag_matches = (not tag or running_tag in all_valid_tags)
 
             # if a container has an entrypoint, `command` will actually equal
             # '{} {}'.format(entrypoint, command)

--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -681,6 +681,7 @@ class DockerManager(object):
         if name and not name.startswith('/'):
             name = '/' + name
         deployed = []
+        all_valid_tags = set()
 
         for img in self.client.images():
             if image in img['RepoTags']:

--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -488,7 +488,7 @@ class DockerManager(object):
                 if len(parts) == 2:
                     self.volumes[parts[1]] = {}
                     self.binds[parts[0]] = parts[1]
-                # with bind mode 
+                # with bind mode
                 elif len(parts) == 3:
                     if parts[2] not in ['ro', 'rw']:
                         self.module.fail_json(msg='bind mode needs to either be "ro" or "rw"')
@@ -694,7 +694,17 @@ class DockerManager(object):
             if i["Names"]:
                 name_matches = (name and name in i['Names'])
             image_matches = (running_image == image)
+
+            # images can and most likly have multiple tags associated
+            # find all tags of the given image and match agains all of them
             tag_matches = (not tag or running_tag == tag)
+            if not tag_matches:
+                for img in self.client.images(name=running_image):
+                    running_tags = (x.split(':', 1)[1] for x in img['RepoTags'])
+                    if tag in running_tags:
+                        tag_matches = True
+                        break
+
             # if a container has an entrypoint, `command` will actually equal
             # '{} {}'.format(entrypoint, command)
             command_matches = (not command or running_command.endswith(command))

--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -686,6 +686,7 @@ class DockerManager(object):
         for img in self.client.images():
             if image in img['RepoTags']:
                 all_valid_tags = set(x.rsplit(':', 1)[1] for x in img['RepoTags'])
+                break
 
         # if we weren't given a tag with the image, we need to only compare on the image name, as that
         # docker will give us back the full image name including a tag in the container list if one exists.

--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -683,16 +683,15 @@ class DockerManager(object):
             name = '/' + name
         deployed = []
 
+        all_valid_tags = []
+        for img in self.client.images():
+            if image in img['RepoTags']:
+                for x in img['RepoTags']:
+                    all_valid_tags.append(x.split(':', 1)[1])
+
         # if we weren't given a tag with the image, we need to only compare on the image name, as that
         # docker will give us back the full image name including a tag in the container list if one exists.
         image, tag = get_split_image_tag(image)
-
-        # Get list of all images and create dict image_tag_map[image] = [tag1, tag2]
-        image_tag_map = defaultdict(list)
-        for i in self.client.images():
-            for t in i['RepoTags']:
-                a, b = t.split(':', 1)
-                image_tag_map[a].append(b)
 
         for i in self.client.containers(all=True):
             running_image, running_tag = get_split_image_tag(i['Image'])
@@ -704,7 +703,7 @@ class DockerManager(object):
             image_matches = (running_image == image)
 
             # images can and most probably have multiple tags associated
-            tag_matches = (not tag or running_tag == tag or running_tag in image_tag_map[running_image])
+            tag_matches = (not tag or running_tag == tag or running_tag in all_valid_tags)
 
             # if a container has an entrypoint, `command` will actually equal
             # '{} {}'.format(entrypoint, command)


### PR DESCRIPTION
## Scenario: Tags returned from docker and ansible may not always match

Single docker image has multiple tags associated (latest, prod, 456). Playbook looks like this:

```
tasks:
    - name: stop old containers
      local_action:
        module: docker
        docker_url: tcp://{{ facter_ipaddress_eth0 }}:2375
        image: hub.example.com/base
        state: stopped
    - name: run container
      local_action:
        module: docker
        docker_url: tcp://{{ facter_ipaddress_eth0 }}:2375
        image: hub.example.com/base:prod
        command: sleep 300
        count: 3
        state: running
```

Before the patch you end up with 3 new containers and the old containers would still be running. Docker will return the tag 456 (or one of the other tags) and the match in docker.py will fail. The patch will get all tags associated with the given image and return the correct list of containers.

Cheers :beers: 
Daniel
