### PR TITLE
fix gce_net add firewall rule example

### DIFF
--- a/cloud/google/gce_net.py
+++ b/cloud/google/gce_net.py
@@ -35,7 +35,7 @@ options:
     description:
       - the protocol:ports to allow ('tcp:80' or 'tcp:80,443' or 'tcp:80-800')
     required: false
-    default: null 
+    default: null
     aliases: []
   ipv4_range:
     description:
@@ -101,15 +101,16 @@ author: Eric Johnson <erjohnso@google.com>
 
 EXAMPLES = '''
 # Simple example of creating a new network
-- local_action: 
+- local_action:
     module: gce_net
     name: privatenet
     ipv4_range: '10.240.16.0/24'
-   
+
 # Simple example of creating a new firewall rule
-- local_action: 
+- local_action:
     module: gce_net
     name: privatenet
+    fwname: all-web-webproxy
     allowed: tcp:80,8080
     src_tags: ["web", "proxy"]
 


### PR DESCRIPTION
This is a tiny patch, it's only documentation. At the time of this writing, the [gce_net module example](http://docs.ansible.com/gce_net_module.html) for adding a firewall rule doesn't actually add the firewall rule becuase it's misssing the fwname field to name the firewall rule.

Here's a simple task I tested with:

``` yaml
    - name: Create firewall rule
      gce_net:
        service_account_email: "{{ gce_service_account_email }}"
        pem_file: "{{ gce_pem_file }}"
        project_id: "{{ gce_project_id }}"
        name: "{{ oo_network }}"
        fwname: all-ssh
        allowed: tcp:22
        src_tags: ['ssh']
      register: gce_net

```

This is what happens if you run without a firewall rule name:

```
TASK: [Create firewall rule] ************************************************** 
ok: [localhost] => {"changed": false, "ipv4_range": "10.240.16.0/24", "name": "amtestnet", "state": "present"}
```

And with the fwname provided:

```
TASK: [Create firewall rule] ************************************************** 
changed: [localhost] => {"allowed": "tcp:22", "changed": true, "fwname": "all-ssh", "ipv4_range": "10.240.16.0/24", "name": "amtestnet", "src_range": null, "src_tags": ["ssh"], "state": "present"}
```

(Also, random note ... it looks like one of my vim plugins cleaned up some whitespace also. If that's a problem I can resubmit without those changes.)
