### PR TITLE
Allow empty EC2 Security Group rules.

### DIFF
--- a/cloud/amazon/ec2_group.py
+++ b/cloud/amazon/ec2_group.py
@@ -24,11 +24,15 @@ options:
     required: false
   rules:
     description:
-      - List of firewall inbound rules to enforce in this group (see example).
+      - List of firewall inbound rules to enforce in this group (see'''
+''' example). If none are supplied, a default all-out rule is assumed.'''
+''' If an empty list is supplied, no inbound rules will be enabled.
     required: false
   rules_egress:
     description:
-      - List of firewall outbound rules to enforce in this group (see example).
+      - List of firewall outbound rules to enforce in this group (see'''
+''' example). If none are supplied, a default all-out rule is assumed.'''
+''' If an empty list is supplied, no outbound rules will be enabled.
     required: false
     version_added: "1.6"
   region:
@@ -268,7 +272,7 @@ def main():
         addRulesToLookup(group.rules, 'in', groupRules)
 
         # Now, go through all provided rules and ensure they are there.
-        if rules:
+        if rules is not None:
             for rule in rules:
                 group_id, ip, target_group_created = get_target_from_rule(module, ec2, rule, name, group, groups, vpc_id)
                 if target_group_created:
@@ -309,7 +313,7 @@ def main():
         addRulesToLookup(group.rules_egress, 'out', groupRules)
 
         # Now, go through all provided rules and ensure they are there.
-        if rules_egress:
+        if rules_egress is not None:
             for rule in rules_egress:
                 group_id, ip, target_group_created = get_target_from_rule(module, ec2, rule, name, group, groups, vpc_id)
                 if target_group_created:


### PR DESCRIPTION
Previously, there was no way to specify "no rules" on a security group short of specifying a phony rule. (e.g. you would need to add something like "only allow access to localhost").

This was because the module would check whether any rules were defined, and if not, add an "anything goes" default rule. This was counter to intuition about what `purge_rules` etc. did and causes unintentionally permissive security groups.

This PR allows you to continue using that default behavior, if desired, by omitting either `rules` or `rules_egress`; however you may now specify that there are no rules at all by supplying an empty list.

Personally, I believe the "anything goes" default is a bad one, but I did not address that in this change. This PR should be backwards compatible except in the case that someone explicitly specified an empty list with the expectation that Ansible would create the `0.0.0.0/0` rule in its place.

Now you are able to set up a rule like:

``` yaml
- name: Set up security group for package clients
  local_action:
    module: ec2_group
    name: 'package-client'
    description: Can retrieve packages from package servers
    vpc_id: '{{vpc_res.vpc.id}}'
    region: '{{vpc_res.vpc.region}}'
    rules: []
    rules_egress:
      - proto: tcp
        from_port: 80
        to_port: 80
        group_name: 'package-server'
        group_desc: Build server and apt repository security group
      - proto: tcp
        from_port: 443
        to_port: 443
        group_name: 'package-server'
```

Which will create a security group with _only_ the rules specified.
