### PR TITLE
Improved AMI search using EC2 image directory.

### DIFF
--- a/cloud/amazon/_ec2_ami_search.py
+++ b/cloud/amazon/_ec2_ami_search.py
@@ -234,7 +234,7 @@ def main():
             aws_access_key_id=aws_access_key,
             aws_secret_access_key=aws_secret_key,
         )
-    except NoAuthHandlerFound as e:
+    except NoAuthHandlerFound, e:
         module.fail_json(msg=str(e))
 
     try:
@@ -247,7 +247,7 @@ def main():
             store=module.params.get('store'),
             virt=module.params.get('virt'),
             filters=module.params.get('filters'))
-    except EC2ResponseError as e:
+    except EC2ResponseError, e:
         module.fail_json(msg=str(e))
 
     if not images:


### PR DESCRIPTION
This improves the `ec2_ami_search` module to search the entire EC2 AMI repository, allowing for things like running Amazon-provided AMIs (NATs, etc.), other third party AMIs (WordPress, etc.) as well as official Ubuntu AMIs as before. There are some additional filtering options that were not present before.

The previous module interface _only_ supported Ubuntu images by scraping an Ubuntu-specific datasource.

The new module interface is similar to the earlier one, but **not entirely compatible** (e.g. there is no standard way to search for `distro` or `stream` in the EC2 AMI directory). Examples are given for both Ubuntu and Amazon AMIs.
