### PR TITLE
Split out route table and subnet functionality from VPC module.

### DIFF
--- a/cloud/amazon/ec2_vpc.py
+++ b/cloud/amazon/ec2_vpc.py
@@ -61,11 +61,11 @@ options:
   resource_tags:
     description:
       - 'A dictionary array of resource tags of the form: { tag1: value1,'''
-''' tag2: value2 }. Tags in this list are used in conjunction with CIDR block'''
-''' to uniquely identify a VPC in lieu of vpc_id. Therefore, if CIDR/Tag'''
-''' combination does not exits, a new VPC will be created.  VPC tags not on'''
-''' this list will be ignored. Prior to 1.7, specifying a resource tag was'''
-''' optional.'
+''' tag2: value2 }. Tags in this list are used in conjunction with CIDR'''
+''' block to uniquely identify a VPC in lieu of vpc_id. Therefore, if'''
+''' CIDR/Tag combination does not exits, a new VPC will be created.  VPC'''
+''' tags not on this list will be ignored. Prior to 1.7, specifying a'''
+''' resource tag was optional.'
     required: true
     default: null
     aliases: []
@@ -158,8 +158,8 @@ EXAMPLES = '''
         state: absent
         vpc_id: vpc-aaaaaaa
         region: us-west-2
-If you have added elements not managed by this module, e.g. instances, NATs, etc
-then the delete will fail until those dependencies are removed.
+If you have added elements not managed by this module, e.g. instances, NATs,
+etc. then the delete will fail until those dependencies are removed.
 '''
 
 
@@ -180,7 +180,6 @@ def vpc_json(vpc):
     Retrieves vpc information from an instance
     ID and returns it as a dictionary
     """
-
     return({
         'id': vpc.id,
         'cidr_block': vpc.cidr_block,
@@ -236,8 +235,8 @@ def find_vpc(vpc_conn, resource_tags=None, vpc_id=None, cidr=None):
                         for t in vpc_conn.get_all_tags(
                             filters={'resource-id': vpc.id})}
 
-            # If the supplied list of ID Tags match a subset of the VPC Tags, we
-            # found our VPC
+            # If the supplied list of ID Tags match a subset of the VPC Tags,
+            # we found our VPC
             if all((k in vpc_tags and vpc_tags[k] == v
                     for k, v in resource_tags.items())):
                 found_vpcs.append(vpc)
@@ -320,7 +319,8 @@ def ensure_vpc_present(vpc_conn, vpc_id, cidr_block, instance_tenancy,
 
     # Add resource tags
     vpc_tags = {t.name: t.value
-                for t in vpc_conn.get_all_tags(filters={'resource-id': vpc.id})}
+                for t in vpc_conn.get_all_tags(
+                    filters={'resource-id': vpc.id})}
 
     if (resource_tags and
             not set(resource_tags.items()).issubset(set(vpc_tags.items()))):

--- a/cloud/amazon/ec2_vpc.py
+++ b/cloud/amazon/ec2_vpc.py
@@ -204,9 +204,9 @@ def subnet_json(vpc_conn, subnet):
     Ansible JSON result.
     """
     return {
-        'resource_tags': {t.name: t.value
-                          for t in vpc_conn.get_all_tags(
-                              filters={'resource-id': subnet.id})},
+        'resource_tags': dict(((t.name, t.value)
+                               for t in vpc_conn.get_all_tags(
+                                   filters={'resource-id': subnet.id}))),
         'cidr': subnet.cidr_block,
         'az': subnet.availability_zone,
         'id': subnet.id,
@@ -245,8 +245,8 @@ def find_vpc(vpc_conn, vpc_id, vpc_name, cidr, resource_tags):
 
     if not found_vpcs and (cidr and resource_tags):
         filters = {'cidr': cidr, 'state': 'available'}
-        filters.update({'tag:{}'.format(t): v
-                        for t, v in resource_tags.iteritems()})
+        filters.update(dict((('tag:{0}'.format(t), v)
+                             for t, v in resource_tags.iteritems())))
         found_vpcs = vpc_conn.get_all_vpcs(filters=filters)
 
     if not found_vpcs:
@@ -327,19 +327,19 @@ def ensure_vpc_present(vpc_conn, vpc_id, vpc_name, cidr_block, resource_tags,
                     time.sleep(5)
             if wait and wait_timeout <= time.time():
                 raise AnsibleVPCException(
-                    'Wait for VPC availability timeout on {}'
+                    'Wait for VPC availability timeout on {0}'
                     .format(time.asctime())
                 )
         except boto.exception.BotoServerError, e:
             raise AnsibleVPCException(
-                '{}: {}'.format(e.error_code, e.error_message))
+                '{0}: {1}'.format(e.error_code, e.error_message))
 
     # Done with base VPC, now change to attributes and features.
 
     # Add resource tags
-    vpc_tags = {t.name: t.value
-                for t in vpc_conn.get_all_tags(
-                    filters={'resource-id': vpc.id})}
+    vpc_tags = dict(((t.name, t.value)
+                     for t in vpc_conn.get_all_tags(
+                         filters={'resource-id': vpc.id})))
 
     if (resource_tags and
             not set(resource_tags.items()).issubset(set(vpc_tags.items()))):

--- a/cloud/amazon/ec2_vpc.py
+++ b/cloud/amazon/ec2_vpc.py
@@ -163,16 +163,18 @@ etc. then the delete will fail until those dependencies are removed.
 '''
 
 
-import sys
+import sys  # noqa
 import time
 
 try:
     import boto.ec2
     import boto.vpc
     from boto.exception import EC2ResponseError
+    HAS_BOTO = True
 except ImportError:
-    print "failed=True msg='boto required for this module'"
-    sys.exit(1)
+    HAS_BOTO = False
+    if __name__ != '__main__':
+        raise
 
 
 def vpc_json(vpc):
@@ -507,6 +509,8 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
     )
+    if not HAS_BOTO:
+        module.fail_json(msg='boto is required for this module')
 
     vpc_id = module.params.get('vpc_id')
     cidr_block = module.params.get('cidr_block')

--- a/cloud/amazon/ec2_vpc_route_table.py
+++ b/cloud/amazon/ec2_vpc_route_table.py
@@ -50,8 +50,8 @@ options:
     aliases: []
   subnets:
     description:
-      - An array of subnets to add to this route table. Subnets may either be'''
-''' specified by subnet ID or by a CIDR such as '10.0.0.0/24'.
+      - An array of subnets to add to this route table. Subnets may either'''
+''' be specified by subnet ID or by a CIDR such as '10.0.0.0/24'.
     required: true
     aliases: []
   wait:

--- a/cloud/amazon/ec2_vpc_route_table.py
+++ b/cloud/amazon/ec2_vpc_route_table.py
@@ -145,15 +145,17 @@ EXAMPLES = '''
 '''
 
 
-import sys
+import sys  # noqa
 
 try:
     import boto.ec2
     import boto.vpc
     from boto.exception import EC2ResponseError
+    HAS_BOTO = True
 except ImportError:
-    print "failed=True msg='boto required for this module'"
-    sys.exit(1)
+    HAS_BOTO = False
+    if __name__ != '__main__':
+        raise
 
 
 class AnsibleRouteTableException(Exception):
@@ -432,6 +434,8 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
     )
+    if not HAS_BOTO:
+        module.fail_json(msg='boto is required for this module')
 
     ec2_url, aws_access_key, aws_secret_key, region = get_ec2_creds(module)
     if not region:

--- a/cloud/amazon/ec2_vpc_route_table.py
+++ b/cloud/amazon/ec2_vpc_route_table.py
@@ -200,8 +200,8 @@ def get_route_table_by_id(vpc_conn, vpc_id, route_table_id):
 
 def get_route_table_by_tags(vpc_conn, vpc_id, tags):
     filters = {'vpc_id': vpc_id}
-    filters.update({'tag:{}'.format(t): v
-                   for t, v in tags.iteritems()})
+    filters.update(dict((('tag:{0}'.format(t), v)
+                         for t, v in tags.iteritems())))
     route_tables = vpc_conn.get_all_route_tables(filters=filters)
 
     if not route_tables:

--- a/cloud/amazon/ec2_vpc_route_table.py
+++ b/cloud/amazon/ec2_vpc_route_table.py
@@ -172,8 +172,8 @@ class AnsibleTagCreationException(AnsibleRouteTableException):
 
 
 def get_resource_tags(vpc_conn, resource_id):
-    return {t.name: t.value for t in
-            vpc_conn.get_all_tags(filters={'resource-id': resource_id})}
+    return dict((t.name, t.value) for t in
+                vpc_conn.get_all_tags(filters={'resource-id': resource_id}))
 
 
 def tags_match(match_tags, candidate_tags):
@@ -187,11 +187,11 @@ def ensure_tags(vpc_conn, resource_id, tags, add_only, check_mode):
         if tags == cur_tags:
             return {'changed': False, 'tags': cur_tags}
 
-        to_delete = {k: cur_tags[k] for k in cur_tags if k not in tags}
+        to_delete = dict((k, cur_tags[k]) for k in cur_tags if k not in tags)
         if to_delete and not add_only:
             vpc_conn.delete_tags(resource_id, to_delete, dry_run=check_mode)
 
-        to_add = {k: tags[k] for k in tags if k not in cur_tags}
+        to_add = dict((k, tags[k]) for k in tags if k not in cur_tags)
         if to_add:
             vpc_conn.create_tags(resource_id, to_add, dry_run=check_mode)
 

--- a/cloud/amazon/ec2_vpc_route_table.py
+++ b/cloud/amazon/ec2_vpc_route_table.py
@@ -176,6 +176,11 @@ def get_resource_tags(vpc_conn, resource_id):
             vpc_conn.get_all_tags(filters={'resource-id': resource_id})}
 
 
+def tags_match(match_tags, candidate_tags):
+    return all((k in candidate_tags and candidate_tags[k] == v
+                for k, v in match_tags.iteritems()))
+
+
 def ensure_tags(vpc_conn, resource_id, tags, add_only, check_mode):
     try:
         cur_tags = get_resource_tags(vpc_conn, resource_id)
@@ -204,18 +209,11 @@ def get_route_table_by_id(vpc_conn, vpc_id, route_table_id):
 
 
 def get_route_table_by_tags(vpc_conn, vpc_id, tags):
-    filters = {'vpc_id': vpc_id}
-    filters.update(dict((('tag:{0}'.format(t), v)
-                         for t, v in tags.iteritems())))
-    route_tables = vpc_conn.get_all_route_tables(filters=filters)
-
-    if not route_tables:
-        return None
-    elif len(route_tables) == 1:
-        return route_tables[0]
-
-    raise RouteTableException(
-        'Found more than one route table based on the supplied tags, aborting')
+    route_tables = vpc_conn.get_all_route_tables(filters={'vpc_id': vpc_id})
+    for route_table in route_tables:
+        this_tags = get_resource_tags(vpc_conn, route_table.id)
+        if tags_match(tags, this_tags):
+            return route_table
 
 
 def route_spec_matches_route(route_spec, route):

--- a/cloud/amazon/ec2_vpc_route_table.py
+++ b/cloud/amazon/ec2_vpc_route_table.py
@@ -1,0 +1,498 @@
+#!/usr/bin/python
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: ec2_vpc_route_table
+short_description: Configure route tables for AWS virtual private clouds
+description:
+    - Create or removes route tables from AWS virtual private clouds.'''
+'''This module has a dependency on python-boto.
+version_added: "1.8"
+options:
+  vpc_id:
+    description:
+      - "The VPC in which to create the route table."
+    required: true
+  route_table_id:
+    description:
+      - "The ID of the route table to update or delete."
+    required: false
+    default: null
+  resource_tags:
+    description:
+      - 'A dictionary array of resource tags of the form: { tag1: value1,'''
+''' tag2: value2 }. Tags in this list are used to uniquely identify route'''
+''' tables within a VPC when the route_table_id is not supplied.
+    required: false
+    default: null
+    aliases: []
+    version_added: "1.6"
+  routes:
+    description:
+      - List of routes in the route table. Routes are specified'''
+''' as dicts containing the keys 'dest' and one of 'gateway_id','''
+''' 'instance_id', 'interface_id', or 'vpc_peering_connection'.
+    required: true
+    aliases: []
+  subnets:
+    description:
+      - An array of subnets to add to this route table. Subnets may either be'''
+''' specified by subnet ID or by a CIDR such as '10.0.0.0/24'.
+    required: true
+    aliases: []
+  wait:
+    description:
+      - wait for the VPC to be in state 'available' before returning
+    required: false
+    default: "no"
+    choices: [ "yes", "no" ]
+    aliases: []
+  wait_timeout:
+    description:
+      - how long before wait gives up, in seconds
+    default: 300
+    aliases: []
+  state:
+    description:
+      - Create or terminate the VPC
+    required: true
+    default: present
+    aliases: []
+  region:
+    description:
+      - region in which the resource exists.
+    required: false
+    default: null
+    aliases: ['aws_region', 'ec2_region']
+  aws_secret_key:
+    description:
+      - AWS secret key. If not set then the value of the AWS_SECRET_KEY'''
+''' environment variable is used.
+    required: false
+    default: None
+    aliases: ['ec2_secret_key', 'secret_key' ]
+  aws_access_key:
+    description:
+      - AWS access key. If not set then the value of the AWS_ACCESS_KEY'''
+''' environment variable is used.
+    required: false
+    default: None
+    aliases: ['ec2_access_key', 'access_key' ]
+  validate_certs:
+    description:
+      - When set to "no", SSL certificates will not be validated for boto'''
+''' versions >= 2.6.0.
+    required: false
+    default: "yes"
+    choices: ["yes", "no"]
+    aliases: []
+    version_added: "1.5"
+
+requirements: [ "boto" ]
+author: Robert Estelle
+'''
+
+EXAMPLES = '''
+# Note: None of these examples set aws_access_key, aws_secret_key, or region.
+# It is assumed that their matching environment variables are set.
+
+# Basic creation example:
+- name: Set up public subnet route table
+  local_action:
+    module: ec2_vpc_route_table
+    vpc_id: vpc-1245678
+    region: us-west-1
+    resource_tags:
+      Name: Public
+    subnets:
+      - '{{jumpbox_subnet.subnet_id}}'
+      - '{{frontend_subnet.subnet_id}}'
+      - '{{vpn_subnet.subnet_id}}'
+    routes:
+      - dest: 0.0.0.0/0
+        gateway_id: '{{igw.gateway_id}}'
+  register: public_route_table
+
+- name: Set up NAT-protected route table
+  local_action:
+    module: ec2_vpc_route_table
+    vpc_id: vpc-1245678
+    region: us-west-1
+    resource_tags:
+      - Name: Internal
+    subnets:
+      - '{{application_subnet.subnet_id}}'
+      - '{{database_subnet.subnet_id}}'
+      - '{{splunk_subnet.subnet_id}}'
+    routes:
+      - dest: 0.0.0.0/0
+        instance_id: '{{nat.instance_id}}'
+  register: nat_route_table
+'''
+
+
+import sys
+
+try:
+    import boto.ec2
+    import boto.vpc
+    from boto.exception import EC2ResponseError
+except ImportError:
+    print "failed=True msg='boto required for this module'"
+    sys.exit(1)
+
+
+class RouteTableException(Exception):
+    pass
+
+
+class TagCreationException(RouteTableException):
+    pass
+
+
+def get_resource_tags(vpc_conn, resource_id):
+    return {t.name: t.value for t in
+            vpc_conn.get_all_tags(filters={'resource-id': resource_id})}
+
+
+def dict_diff(old, new):
+    x = {}
+    old_keys = set(old.keys())
+    new_keys = set(new.keys())
+
+    for k in old_keys.difference(new_keys):
+        x[k] = {'old': old[k]}
+
+    for k in new_keys.difference(old_keys):
+        x[k] = {'new': new[k]}
+
+    for k in new_keys.intersection(old_keys):
+        if new[k] != old[k]:
+            x[k] = {'new': new[k], 'old': old[k]}
+
+    return x
+
+
+def tags_match(match_tags, candidate_tags):
+    return all((k in candidate_tags and candidate_tags[k] == v
+                for k, v in match_tags.iteritems()))
+
+
+def ensure_tags(vpc_conn, resource_id, tags, add_only, dry_run):
+    try:
+        cur_tags = get_resource_tags(vpc_conn, resource_id)
+        diff = dict_diff(cur_tags, tags)
+        if not diff:
+            return {'changed': False, 'tags': cur_tags}
+
+        to_delete = {k: diff[k]['old'] for k in diff if 'new' not in diff[k]}
+        if to_delete and not add_only:
+            vpc_conn.delete_tags(resource_id, to_delete, dry_run=dry_run)
+
+        to_add = {k: diff[k]['new'] for k in diff if 'old' not in diff[k]}
+        if to_add:
+            vpc_conn.create_tags(resource_id, to_add, dry_run=dry_run)
+
+        latest_tags = get_resource_tags(vpc_conn, resource_id)
+        return {'changed': True, 'tags': latest_tags}
+    except EC2ResponseError as e:
+        raise TagCreationException('Unable to update tags for {0}, error: {1}'
+                                   .format(resource_id, e))
+
+
+def get_route_table_by_id(vpc_conn, vpc_id, route_table_id):
+    route_tables = vpc_conn.get_all_route_tables(
+        route_table_ids=[route_table_id], filters={'vpc_id': vpc_id})
+    return route_tables[0] if route_tables else None
+
+
+def get_route_table_by_tags(vpc_conn, vpc_id, tags):
+    route_tables = vpc_conn.get_all_route_tables(filters={'vpc_id': vpc_id})
+    for route_table in route_tables:
+        this_tags = get_resource_tags(vpc_conn, route_table.id)
+        if tags_match(tags, this_tags):
+            return route_table
+
+
+def route_spec_matches_route(route_spec, route):
+    key_attr_map = {
+        'destination_cidr_block': 'destination_cidr_block',
+        'gateway_id': 'gateway_id',
+        'instance_id': 'instance_id',
+        'interface_id': 'interface_id',
+        'vpc_peering_connection_id': 'vpc_peering_connection_id',
+    }
+    for k in key_attr_map.iterkeys():
+        if k in route_spec:
+            if route_spec[k] != getattr(route, k):
+                return False
+    return True
+
+
+def rename_key(d, old_key, new_key):
+    d[new_key] = d[old_key]
+    del d[old_key]
+
+
+def index_of_matching_route(route_spec, routes_to_match):
+    for i, route in enumerate(routes_to_match):
+        if route_spec_matches_route(route_spec, route):
+            return i
+
+
+def ensure_routes(vpc_conn, route_table, route_specs, check_mode):
+    routes_to_match = list(route_table.routes)
+    route_specs_to_create = []
+    for route_spec in route_specs:
+        i = index_of_matching_route(route_spec, routes_to_match)
+        if i is None:
+            route_specs_to_create.append(route_spec)
+        else:
+            del routes_to_match[i]
+    routes_to_delete = [r for r in routes_to_match
+                        if r.gateway_id != 'local']
+
+    changed = routes_to_delete or route_specs_to_create
+    if check_mode and changed:
+        return {'changed': True}
+    elif changed:
+        for route_spec in route_specs_to_create:
+            vpc_conn.create_route(route_table.id, **route_spec)
+
+        for route in routes_to_delete:
+            vpc_conn.delete_route(route_table.id, route.destination_cidr_block)
+        return {'changed': True}
+    else:
+        return {'changed': False}
+
+
+def get_subnet_by_cidr(vpc_conn, vpc_id, cidr):
+    subnets = vpc_conn.get_all_subnets(
+        filters={'cidr': cidr, 'vpc_id': vpc_id})
+    if len(subnets) != 1:
+        raise RouteTableException(
+            'Subnet with CIDR {0} has {1} matches'.format(cidr, len(subnets))
+        )
+    return subnets[0]
+
+
+def get_subnet_by_id(vpc_conn, vpc_id, subnet_id):
+    subnets = vpc_conn.get_all_subnets(filters={'subnet-id': subnet_id})
+    if len(subnets) != 1:
+        raise RouteTableException(
+            'Subnet with ID {0} has {1} matches'.format(subnet_id, len(subnets))
+        )
+    return subnets[0]
+
+
+def ensure_subnet_association(vpc_conn, vpc_id, route_table_id, subnet_id,
+                              check_mode):
+    route_tables = vpc_conn.get_all_route_tables(
+        filters={'association.subnet_id': subnet_id, 'vpc_id': vpc_id}
+    )
+    for route_table in route_tables:
+        if route_table.id is None:
+            continue
+        for a in route_table.associations:
+            if a.subnet_id == subnet_id:
+                if route_table.id == route_table_id:
+                    return {'changed': False, 'association_id': a.id}
+                else:
+                    if check_mode:
+                        return {'changed': True}
+                    vpc_conn.disassociate_route_table(a.id)
+
+    association_id = vpc_conn.associate_route_table(route_table_id, subnet_id)
+    return {'changed': True, 'association_id': association_id}
+
+
+def ensure_subnet_associations(vpc_conn, vpc_id, route_table, subnets,
+                               check_mode):
+    current_association_ids = [a.id for a in route_table.associations]
+    new_association_ids = []
+    changed = False
+    for subnet in subnets:
+        result = ensure_subnet_association(
+            vpc_conn, vpc_id, route_table.id, subnet.id, check_mode)
+        changed = changed or result['changed']
+        if changed and check_mode:
+            return {'changed': True}
+        new_association_ids.append(result['association_id'])
+
+    to_delete = [a_id for a_id in current_association_ids
+                 if a_id not in new_association_ids]
+
+    for a_id in to_delete:
+        if check_mode:
+            return {'changed': True}
+        changed = True
+        vpc_conn.disassociate_route_table(a_id)
+
+    return {'changed': changed}
+
+
+def ensure_route_table_absent(vpc_conn, vpc_id, route_table_id, resource_tags,
+                              check_mode):
+    if route_table_id:
+        route_table = get_route_table_by_id(vpc_conn, vpc_id, route_table_id)
+    elif resource_tags:
+        route_table = get_route_table_by_tags(vpc_conn, vpc_id, resource_tags)
+    else:
+        raise RouteTableException(
+            'must provide route_table_id or resource_tags')
+
+    if route_table is None:
+        return {'changed': False}
+
+    if check_mode:
+        return {'changed': True}
+
+    vpc_conn.delete_route_table(route_table.id)
+    return {'changed': True}
+
+
+def ensure_route_table_present(vpc_conn, vpc_id, route_table_id, resource_tags,
+                               routes, subnets, check_mode):
+    changed = False
+    tags_valid = False
+    if route_table_id:
+        route_table = get_route_table_by_id(vpc_conn, vpc_id, route_table_id)
+    elif resource_tags:
+        route_table = get_route_table_by_tags(vpc_conn, vpc_id, resource_tags)
+        tags_valid = route_table is not None
+    else:
+        raise RouteTableException(
+            'must provide route_table_id or resource_tags')
+
+    if check_mode and route_table is None:
+        return {'changed': True}
+
+    if route_table is None:
+        try:
+            route_table = vpc_conn.create_route_table(vpc_id)
+        except EC2ResponseError as e:
+            raise RouteTableException(
+                'Unable to create route table {0}, error: {1}'
+                .format(route_table_id or resource_tags, e)
+            )
+
+    if not tags_valid and resource_tags is not None:
+        result = ensure_tags(vpc_conn, route_table.id, resource_tags,
+                             add_only=True, dry_run=check_mode)
+        changed = changed or result['changed']
+
+    if routes is not None:
+        try:
+            result = ensure_routes(vpc_conn, route_table, routes, check_mode)
+            changed = changed or result['changed']
+        except EC2ResponseError as e:
+            raise RouteTableException(
+                'Unable to ensure routes for route table {0}, error: {1}'
+                .format(route_table, e)
+            )
+
+    if subnets:
+        associated_subnets = []
+        try:
+            for subnet_name in subnets:
+                if ('.' in subnet_name) and ('/' in subnet_name):
+                    subnet = get_subnet_by_cidr(vpc_conn, vpc_id, subnet_name)
+                else:
+                    subnet = get_subnet_by_id(vpc_conn, vpc_id, subnet_name)
+                associated_subnets.append(subnet)
+        except EC2ResponseError as e:
+            raise RouteTableException(
+                'Unable to find subnets for route table {0}, error: {1}'
+                .format(route_table, e)
+            )
+
+        try:
+            result = ensure_subnet_associations(
+                vpc_conn, vpc_id, route_table, associated_subnets, check_mode)
+            changed = changed or result['changed']
+        except EC2ResponseError as e:
+            raise RouteTableException(
+                'Unable to associate subnets for route table {0}, error: {1}'
+                .format(route_table, e)
+            )
+
+    return {
+        'changed': changed,
+        'route_table_id': route_table.id,
+    }
+
+
+def main():
+    argument_spec = ec2_argument_spec()
+    argument_spec.update({
+        'vpc_id': {'required': True},
+        'route_table_id': {'required': False},
+        'resource_tags': {'type': 'dict', 'required': False},
+        'routes': {'type': 'list', 'required': False},
+        'subnets': {'type': 'list', 'required': False},
+        'state': {'choices': ['present', 'absent'], 'default': 'present'},
+    })
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    ec2_url, aws_access_key, aws_secret_key, region = get_ec2_creds(module)
+    if not region:
+        module.fail_json(msg='Region must be specified')
+
+    try:
+        vpc_conn = boto.vpc.connect_to_region(
+            region,
+            aws_access_key_id=aws_access_key,
+            aws_secret_access_key=aws_secret_key
+        )
+    except boto.exception.NoAuthHandlerFound as e:
+        module.fail_json(msg=str(e))
+
+    vpc_id = module.params.get('vpc_id')
+    route_table_id = module.params.get('route_table_id')
+    resource_tags = module.params.get('resource_tags')
+
+    routes = module.params.get('routes')
+    for route_spec in routes:
+        rename_key(route_spec, 'dest', 'destination_cidr_block')
+
+    subnets = module.params.get('subnets')
+    state = module.params.get('state', 'present')
+
+    try:
+        if state == 'present':
+            result = ensure_route_table_present(
+                vpc_conn, vpc_id, route_table_id, resource_tags,
+                routes, subnets, module.check_mode
+            )
+        elif state == 'absent':
+            result = ensure_route_table_absent(
+                vpc_conn, vpc_id, route_table_id, resource_tags,
+                module.check_mode
+            )
+    except RouteTableException as e:
+        module.fail_json(msg=str(e))
+
+    module.exit_json(**result)
+
+from ansible.module_utils.basic import *  # noqa
+from ansible.module_utils.ec2 import *  # noqa
+
+if __name__ == '__main__':
+    main()

--- a/cloud/amazon/ec2_vpc_subnet.py
+++ b/cloud/amazon/ec2_vpc_subnet.py
@@ -111,16 +111,18 @@ EXAMPLES = '''
 '''
 
 
-import sys
+import sys  # noqa
 import time
 
 try:
     import boto.ec2
     import boto.vpc
     from boto.exception import EC2ResponseError
+    HAS_BOTO = True
 except ImportError:
-    print "failed=True msg='boto required for this module'"
-    sys.exit(1)
+    HAS_BOTO = False
+    if __name__ != '__main__':
+        raise
 
 
 class AnsibleVPCSubnetException(Exception):
@@ -249,6 +251,8 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
     )
+    if not HAS_BOTO:
+        module.fail_json(msg='boto is required for this module')
 
     ec2_url, aws_access_key, aws_secret_key, region = get_ec2_creds(module)
     if not region:

--- a/cloud/amazon/ec2_vpc_subnet.py
+++ b/cloud/amazon/ec2_vpc_subnet.py
@@ -164,36 +164,17 @@ def get_resource_tags(vpc_conn, resource_id):
             vpc_conn.get_all_tags(filters={'resource-id': resource_id})}
 
 
-def dict_diff(old, new):
-    x = {}
-    old_keys = set(old.keys())
-    new_keys = set(new.keys())
-
-    for k in old_keys.difference(new_keys):
-        x[k] = {'old': old[k]}
-
-    for k in new_keys.difference(old_keys):
-        x[k] = {'new': new[k]}
-
-    for k in new_keys.intersection(old_keys):
-        if new[k] != old[k]:
-            x[k] = {'new': new[k], 'old': old[k]}
-
-    return x
-
-
 def ensure_tags(vpc_conn, resource_id, tags, add_only, dry_run):
     try:
         cur_tags = get_resource_tags(vpc_conn, resource_id)
-        diff = dict_diff(cur_tags, tags)
-        if not diff:
+        if cur_tags == tags:
             return {'changed': False, 'tags': cur_tags}
 
-        to_delete = {k: diff[k]['old'] for k in diff if 'new' not in diff[k]}
+        to_delete = {k: cur_tags[k] for k in cur_tags if k not in tags}
         if to_delete and not add_only:
             vpc_conn.delete_tags(resource_id, to_delete, dry_run=dry_run)
 
-        to_add = {k: diff[k]['new'] for k in diff if 'old' not in diff[k]}
+        to_add = {k: tags[k] for k in tags if k not in cur_tags}
         if to_add:
             vpc_conn.create_tags(resource_id, to_add, dry_run=dry_run)
 

--- a/cloud/amazon/ec2_vpc_subnet.py
+++ b/cloud/amazon/ec2_vpc_subnet.py
@@ -162,8 +162,8 @@ def create_subnet(vpc_conn, vpc_id, cidr, az):
 
 
 def get_resource_tags(vpc_conn, resource_id):
-    return {t.name: t.value for t in
-            vpc_conn.get_all_tags(filters={'resource-id': resource_id})}
+    return dict((t.name, t.value) for t in
+                vpc_conn.get_all_tags(filters={'resource-id': resource_id}))
 
 
 def ensure_tags(vpc_conn, resource_id, tags, add_only, check_mode):
@@ -172,11 +172,11 @@ def ensure_tags(vpc_conn, resource_id, tags, add_only, check_mode):
         if cur_tags == tags:
             return {'changed': False, 'tags': cur_tags}
 
-        to_delete = {k: cur_tags[k] for k in cur_tags if k not in tags}
+        to_delete = dict((k, cur_tags[k]) for k in cur_tags if k not in tags)
         if to_delete and not add_only:
             vpc_conn.delete_tags(resource_id, to_delete, dry_run=check_mode)
 
-        to_add = {k: tags[k] for k in tags if k not in cur_tags}
+        to_add = dict((k, tags[k]) for k in tags if k not in cur_tags)
         if to_add:
             vpc_conn.create_tags(resource_id, to_add, dry_run=check_mode)
 

--- a/cloud/amazon/ec2_vpc_subnet.py
+++ b/cloud/amazon/ec2_vpc_subnet.py
@@ -123,19 +123,19 @@ except ImportError:
     sys.exit(1)
 
 
-class VPCSubnetException(Exception):
+class AnsibleVPCSubnetException(Exception):
     pass
 
 
-class VPCSubnetCreationException(VPCSubnetException):
+class AnsibleVPCSubnetCreationException(AnsibleVPCSubnetException):
     pass
 
 
-class VPCSubnetDeletionException(VPCSubnetException):
+class AnsibleVPCSubnetDeletionException(AnsibleVPCSubnetException):
     pass
 
 
-class TagCreationException(VPCSubnetException):
+class AnsibleTagCreationException(AnsibleVPCSubnetException):
     pass
 
 
@@ -154,7 +154,7 @@ def create_subnet(vpc_conn, vpc_id, cidr, az):
         while not subnet_exists(vpc_conn, new_subnet.id):
             time.sleep(0.1)
     except EC2ResponseError as e:
-        raise VPCSubnetCreationException(
+        raise AnsibleVPCSubnetCreationException(
             'Unable to create subnet {0}, error: {1}'.format(cidr, e))
     return new_subnet
 
@@ -181,8 +181,8 @@ def ensure_tags(vpc_conn, resource_id, tags, add_only, dry_run):
         latest_tags = get_resource_tags(vpc_conn, resource_id)
         return {'changed': True, 'tags': latest_tags}
     except EC2ResponseError as e:
-        raise TagCreationException('Unable to update tags for {0}, error: {1}'
-                                   .format(resource_id, e))
+        raise AnsibleTagCreationException(
+            'Unable to update tags for {0}, error: {1}'.format(resource_id, e))
 
 
 def get_matching_subnet(vpc_conn, vpc_id, cidr):
@@ -231,7 +231,7 @@ def ensure_subnet_absent(vpc_conn, vpc_id, cidr, check_mode):
         vpc_conn.delete_subnet(subnet.id)
         return {'changed': True}
     except EC2ResponseError as e:
-        raise VPCSubnetDeletionException(
+        raise AnsibleVPCSubnetDeletionException(
             'Unable to delete subnet {0}, error: {1}'
             .format(subnet.cidr_block, e))
 
@@ -276,7 +276,7 @@ def main():
         elif state == 'absent':
             result = ensure_subnet_absent(vpc_conn, vpc_id, cidr,
                                           check_mode=module.check_mode)
-    except VPCSubnetException as e:
+    except AnsibleVPCSubnetException as e:
         module.fail_json(msg=str(e))
 
     module.exit_json(**result)

--- a/cloud/amazon/ec2_vpc_subnet.py
+++ b/cloud/amazon/ec2_vpc_subnet.py
@@ -242,7 +242,7 @@ def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update({
         'vpc_id': {'required': True},
-        'resource_tags': {'type': 'dict', 'required': True},
+        'resource_tags': {'type': 'dict', 'required': False},
         'cidr': {'required': True},
         'az': {},
         'state': {'choices': ['present', 'absent'], 'default': 'present'},

--- a/cloud/amazon/ec2_vpc_subnet.py
+++ b/cloud/amazon/ec2_vpc_subnet.py
@@ -1,0 +1,307 @@
+#!/usr/bin/python
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: ec2_vpc_subnet
+short_description: Configure subnets in AWS virtual private clouds.
+description:
+    - Create or removes AWS subnets in a VPC.  This module has a'''
+''' dependency on python-boto.
+version_added: "1.8"
+options:
+  vpc_id:
+    description:
+      - A VPC id in which the subnet resides
+    required: false
+    default: null
+    aliases: []
+  resource_tags:
+    description:
+      - 'A dictionary array of resource tags of the form: { tag1: value1,'''
+''' tag2: value2 }. This module identifies a subnet by CIDR and will update'''
+''' the subnet's tags to match. Tags not in this list will be ignored.
+    required: false
+    default: null
+    aliases: []
+  cidr:
+    description:
+      - "The cidr block for the subnet, e.g. 10.0.0.0/16"
+    required: false, unless state=present
+  az:
+    description:
+      - "The availability zone for the subnet"
+    required: false, unless state=present
+  region:
+    description:
+      - region in which the resource exists.
+    required: false
+    default: null
+    aliases: ['aws_region', 'ec2_region']
+  state:
+    description:
+      - Create or remove the subnet
+    required: true
+    default: present
+    aliases: []
+  aws_secret_key:
+    description:
+      - AWS secret key. If not set then the value of the AWS_SECRET_KEY'''
+''' environment variable is used.
+    required: false
+    default: None
+    aliases: ['ec2_secret_key', 'secret_key' ]
+  aws_access_key:
+    description:
+      - AWS access key. If not set then the value of the AWS_ACCESS_KEY'''
+''' environment variable is used.
+    required: false
+    default: None
+    aliases: ['ec2_access_key', 'access_key' ]
+  validate_certs:
+    description:
+      - When set to "no", SSL certificates will not be validated for'''
+''' boto versions >= 2.6.0.
+    required: false
+    default: "yes"
+    choices: ["yes", "no"]
+    aliases: []
+
+requirements: ["boto"]
+author: Robert Estelle
+'''
+
+EXAMPLES = '''
+# Note: None of these examples set aws_access_key, aws_secret_key, or region.
+# It is assumed that their matching environment variables are set.
+
+# Basic creation example:
+- name: Set up the subnet for database servers
+  local_action:
+    module: ec2_vpc_subnet
+    state: present
+    vpc_id: vpc-123456
+    region: us-west-1
+    cidr: 10.0.1.16/28
+    resource_tags:
+      Name: Database Subnet
+  register: database_subnet
+
+# Removal of a VPC by id
+- name: Set up the subnet for database servers
+  local_action:
+    module: ec2_vpc
+    state: absent
+    vpc_id: vpc-123456
+    region: us-west-1
+    cidr: 10.0.1.16/28
+'''
+
+
+import sys
+import time
+
+try:
+    import boto.ec2
+    import boto.vpc
+    from boto.exception import EC2ResponseError
+except ImportError:
+    print "failed=True msg='boto required for this module'"
+    sys.exit(1)
+
+
+class VPCSubnetException(Exception):
+    pass
+
+
+class VPCSubnetCreationException(VPCSubnetException):
+    pass
+
+
+class VPCSubnetDeletionException(VPCSubnetException):
+    pass
+
+
+class TagCreationException(VPCSubnetException):
+    pass
+
+
+def subnet_exists(vpc_conn, subnet_id):
+    filters = {'subnet-id': subnet_id}
+    return len(vpc_conn.get_all_subnets(filters=filters)) > 0
+
+
+def create_subnet(vpc_conn, vpc_id, cidr, az):
+    try:
+        new_subnet = vpc_conn.create_subnet(vpc_id, cidr, az)
+        # Sometimes AWS takes its time to create a subnet and so using
+        # new subnets's id to do things like create tags results in
+        # exception.  boto doesn't seem to refresh 'state' of the newly
+        # created subnet, i.e.: it's always 'pending'.
+        while not subnet_exists(vpc_conn, new_subnet.id):
+            time.sleep(0.1)
+    except EC2ResponseError as e:
+        raise VPCSubnetCreationException(
+            'Unable to create subnet {0}, error: {1}'.format(cidr, e))
+    return new_subnet
+
+
+def get_resource_tags(vpc_conn, resource_id):
+    return {t.name: t.value for t in
+            vpc_conn.get_all_tags(filters={'resource-id': resource_id})}
+
+
+def dict_diff(old, new):
+    x = {}
+    old_keys = set(old.keys())
+    new_keys = set(new.keys())
+
+    for k in old_keys.difference(new_keys):
+        x[k] = {'old': old[k]}
+
+    for k in new_keys.difference(old_keys):
+        x[k] = {'new': new[k]}
+
+    for k in new_keys.intersection(old_keys):
+        if new[k] != old[k]:
+            x[k] = {'new': new[k], 'old': old[k]}
+
+    return x
+
+
+def ensure_tags(vpc_conn, resource_id, tags, add_only, dry_run):
+    try:
+        cur_tags = get_resource_tags(vpc_conn, resource_id)
+        diff = dict_diff(cur_tags, tags)
+        if not diff:
+            return {'changed': False, 'tags': cur_tags}
+
+        to_delete = {k: diff[k]['old'] for k in diff if 'new' not in diff[k]}
+        if to_delete and not add_only:
+            vpc_conn.delete_tags(resource_id, to_delete, dry_run=dry_run)
+
+        to_add = {k: diff[k]['new'] for k in diff if 'old' not in diff[k]}
+        if to_add:
+            vpc_conn.create_tags(resource_id, to_add, dry_run=dry_run)
+
+        latest_tags = get_resource_tags(vpc_conn, resource_id)
+        return {'changed': True, 'tags': latest_tags}
+    except EC2ResponseError as e:
+        raise TagCreationException('Unable to update tags for {0}, error: {1}'
+                                   .format(resource_id, e))
+
+
+def get_matching_subnet(vpc_conn, vpc_id, cidr):
+    subnets = vpc_conn.get_all_subnets(filters={'vpc_id': vpc_id})
+    return next((s for s in subnets if s.cidr_block == cidr), None)
+
+
+def ensure_subnet_present(vpc_conn, vpc_id, cidr, az, tags, check_mode):
+    subnet = get_matching_subnet(vpc_conn, vpc_id, cidr)
+    changed = False
+    if subnet is None:
+        if check_mode:
+            return {'changed': True, 'subnet_id': None, 'subnet': {}}
+
+        subnet = create_subnet(vpc_conn, vpc_id, cidr, az)
+        changed = True
+
+    if tags is not None:
+        tag_result = ensure_tags(vpc_conn, subnet.id, tags, add_only=True,
+                                 dry_run=check_mode)
+        tags = tag_result['tags']
+        changed = changed or tag_result['changed']
+    else:
+        tags = get_resource_tags(vpc_conn, subnet.id)
+
+    return {
+        'changed': changed,
+        'subnet_id': subnet.id,
+        'subnet': {
+            'tags': tags,
+            'cidr': subnet.cidr_block,
+            'az': subnet.availability_zone,
+            'id': subnet.id,
+        }
+    }
+
+
+def ensure_subnet_absent(vpc_conn, vpc_id, cidr, check_mode):
+    subnet = get_matching_subnet(vpc_conn, vpc_id, cidr)
+    if subnet is None:
+        return {'changed': False}
+    elif check_mode:
+        return {'changed': True}
+
+    try:
+        vpc_conn.delete_subnet(subnet.id)
+        return {'changed': True}
+    except EC2ResponseError as e:
+        raise VPCSubnetDeletionException(
+            'Unable to delete subnet {0}, error: {1}'
+            .format(subnet.cidr_block, e))
+
+
+def main():
+    argument_spec = ec2_argument_spec()
+    argument_spec.update({
+        'vpc_id': {'required': True},
+        'resource_tags': {'type': 'dict', 'required': True},
+        'cidr': {'required': True},
+        'az': {},
+        'state': {'choices': ['present', 'absent'], 'default': 'present'},
+    })
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    ec2_url, aws_access_key, aws_secret_key, region = get_ec2_creds(module)
+    if not region:
+        module.fail_json(msg='Region must be specified')
+
+    try:
+        vpc_conn = boto.vpc.connect_to_region(
+            region,
+            aws_access_key_id=aws_access_key,
+            aws_secret_access_key=aws_secret_key
+        )
+    except boto.exception.NoAuthHandlerFound as e:
+        module.fail_json(msg=str(e))
+
+    vpc_id = module.params.get('vpc_id')
+    tags = module.params.get('resource_tags')
+    cidr = module.params.get('cidr')
+    az = module.params.get('az')
+    state = module.params.get('state', 'present')
+
+    try:
+        if state == 'present':
+            result = ensure_subnet_present(vpc_conn, vpc_id, cidr, az, tags,
+                                           check_mode=module.check_mode)
+        elif state == 'absent':
+            result = ensure_subnet_absent(vpc_conn, vpc_id, cidr,
+                                          check_mode=module.check_mode)
+    except VPCSubnetException as e:
+        module.fail_json(msg=str(e))
+
+    module.exit_json(**result)
+
+from ansible.module_utils.basic import *  # noqa
+from ansible.module_utils.ec2 import *  # noqa
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This change factors out subnet and route table creation from the creation of the VPC itself. This changes the interface of the `ec2_vpc` module to take in subnet IDs and route table IDs, rather than large inline definitions.

This is a fairly large change. This PR I believe supersedes the functionality of #258, from which it was developed independently. It makes sense to be merged along with #321, which is still okay on its own.

The `ec2_vpc` module now supports check mode, as do the new `ec2_vpc_subnet` and `ec2_vpc_route_table` modules.

The basic premise was: the `ec2_vpc` module does too much monolithically, and is both inflexible and difficult to use. (For example: getting meaningful subnet IDs out of the VPC creation in order to provision EC2 instances on that subnet was nigh impossible). The code was very stateful and could not support check mode.

These refactorings:
1. Make idempotent playbooks easier. Route tables are not always replaced anymore.
2. Make check mode possible for VPC setup.
3. Make it easier to refactor playbooks for VPC setup. (Subnets, route tables, etc.)
4. More easily allow advanced configurations such as instance allocation on specific subnets.
5. Clean up the stateful code considerably.
6. Generally make this module set more "ansible"-like, I believe, by splitting the configuration into finer-grained verifiable tasks.
