### PR TITLE
Refactor and improve the EC2 Elastic IP module.

### DIFF
--- a/cloud/amazon/ec2_eip.py
+++ b/cloud/amazon/ec2_eip.py
@@ -228,7 +228,7 @@ def ensure_present(ec2, domain, address, instance_id,
     return {'changed': changed, 'public_ip': address.public_ip}
 
 
-def ensure_absent(ec2, domain, address, check_mode):
+def ensure_absent(ec2, domain, address, instance_id, check_mode):
     if not address:
         return {'changed': False}
 
@@ -279,7 +279,7 @@ def main():
                                     reuse_existing_ip_allowed,
                                     module.check_mode)
         else:
-            result = ensure_absent(ec2, domain, address, module.check_mode)
+            result = ensure_absent(ec2, domain, address, instance_id, module.check_mode)
     except (boto.exception.EC2ResponseError, EIPException) as e:
         module.fail_json(msg=str(e))
 


### PR DESCRIPTION
This includes the style cleanups from #325. I separated them out into separate requests as this is a larger change.

This refactor substantially reduces the number of long boto calls. Additionally, it will more intelligently match existing Elastic IP associations when an `instance_id` is provided and will skip unnecessary changes. (So providing an `instance_id` causes this module to be idempotent).

It also (I believe) obsoletes the need for `wait_timeout` functionality, as the `address` object does not need to be searched for repeatedly.
