### PR TITLE
Add support for listing keys in a specific S3 bucket

### DIFF
--- a/cloud/amazon/s3.py
+++ b/cloud/amazon/s3.py
@@ -237,7 +237,7 @@ def get_bucket(module, s3, bucket):
 def list_keys(module, bucket_object, prefix, marker, max_keys):
     all_keys = bucket_object.get_all_keys(prefix=prefix, marker=marker, max_keys=max_keys)
 
-    keys = map((lambda x: x.key), all_keys)
+    keys = [x.key for x in all_keys]
 
     module.exit_json(msg="LIST operation complete", s3_keys=keys)
 

--- a/cloud/amazon/s3.py
+++ b/cloud/amazon/s3.py
@@ -56,6 +56,18 @@ options:
     required: false
     default: 600
     aliases: []
+  marker:
+    description:
+      - Specifies the key to start with when using list mode. Object keys are returned in alphabetical order, starting with key after the marker in order.
+    required: false
+    default: null
+    version_added: "2.0"
+  max_keys:
+    description:
+      - Max number of results to return in list mode, set this if you want to retrieve fewer than the default 1000 keys.
+    required: false
+    default: 1000
+    version_added: "2.0"
   metadata:
     description:
       - Metadata for PUT operation, as a dictionary of 'key=value' and 'key=value,key=value'.
@@ -64,7 +76,7 @@ options:
     version_added: "1.6"
   mode:
     description:
-      - Switches the module behaviour between put (upload), get (download), geturl (return download url (Ansible 1.3+), getstr (download object as string (1.3+)), list (list keys), create (bucket), delete (bucket), and delobj (delete object).
+      - Switches the module behaviour between put (upload), get (download), geturl (return download url (Ansible 1.3+), getstr (download object as string (1.3+)), list (list keys (2.0+)), create (bucket), delete (bucket), and delobj (delete object).
     required: true
     default: null
     aliases: []
@@ -73,6 +85,12 @@ options:
       - Keyname of the object inside the bucket. Can be used to create "virtual directories", see examples.
     required: false
     default: null
+  prefix:
+    description:
+      - Limits the response to keys that begin with the specified prefix for list mode
+    required: false
+    default: null
+    version_added: "2.0"
   version:
     description:
       - Version ID of the object inside the bucket. Can be used to get a specific version of a file if versioning is enabled in the target bucket.


### PR DESCRIPTION
Includes support for specifying a `prefix`, `marker`, and/or `max_keys`. These three options are optional. `max_keys` does default to 1000. I chose to use `get_all_keys` over `list` for the ability to specify `max_keys`.

The main part of the response body is a list of key names (strings).

This is my first foray into ansible and Python so if I'm breaking conventions please let me know.
