### PR TITLE
Fixed copy when dest is directory and force=no

### DIFF
--- a/files/copy.py
+++ b/files/copy.py
@@ -195,13 +195,13 @@ def main():
     if os.path.exists(dest):
         if os.path.islink(dest) and follow:
             dest = os.path.realpath(dest)
-        if not force:
-            module.exit_json(msg="file already exists", src=src, dest=dest, changed=False)
         if (os.path.isdir(dest)):
             basename = os.path.basename(src)
             if original_basename:
                 basename = original_basename
             dest = os.path.join(dest, basename)
+        if (not force) and os.path.exists(dest):
+            module.exit_json(msg="file already exists", src=src, dest=dest, changed=False)
         if os.access(dest, os.R_OK):
             checksum_dest = module.sha1(dest)
     else:


### PR DESCRIPTION
If the copy module is used to copy files with dest=[directory] and
force=yes (or omitted - this is the default), then the files are copied
as expected.

If force=no (only transfer file if destination does not exist), then
the files are NOT copied.  This is because the current code is
erroneously checking for the existence of the destination directory
rather than the destination files.

Example playbook that demonstrates the problem…

```

---
- hosts: localhost
  gather_facts: no

  tasks:
    - name: Copy files
      local_action: copy >
        src="{{ item }}"
        dest=target_dir
        force=no
      with_items:
        - test1.txt
        - test2.txt
```

Also create test1,txt, test2.txt files, and “target_dir” directory.
Expected result is that test1.txt and test2.txt are copied to dest_dir.
