### PR TITLE
apt_repository: fix file mode

### DIFF
--- a/packaging/os/apt_repository.py
+++ b/packaging/os/apt_repository.py
@@ -238,10 +238,6 @@ class SourcesList(object):
                 d, fn = os.path.split(filename)
                 fd, tmp_path = tempfile.mkstemp(prefix=".%s-" % fn, dir=d)
 
-                # allow the user to override the default mode
-                this_mode = module.params['mode']
-                module.set_mode_if_different(tmp_path, this_mode, False)
-
                 f = os.fdopen(fd, 'w')
                 for n, valid, enabled, source, comment in sources:
                     chunks = []
@@ -259,6 +255,10 @@ class SourcesList(object):
                     except IOError, err:
                         module.fail_json(msg="Failed to write to file %s: %s" % (tmp_path, unicode(err)))
                 module.atomic_move(tmp_path, filename)
+
+                # allow the user to override the default mode
+                this_mode = module.params['mode']
+                module.set_mode_if_different(filename, this_mode, False)
             else:
                 del self.files[filename]
                 if os.path.exists(filename):


### PR DESCRIPTION
'set_mode_if_different' method should be called on destination filename (not temporary filename) and after
'atomic_move' method.

This one allows me to find ansible/ansible#9565.
