### PR TITLE
digital_ocean: Add note about using API v1

### DIFF
--- a/cloud/digital_ocean/digital_ocean.py
+++ b/cloud/digital_ocean/digital_ocean.py
@@ -96,6 +96,7 @@ options:
 
 notes:
   - Two environment variables can be used, DO_CLIENT_ID and DO_API_KEY.
+  - Version 1 of DigitalOcean API is used.
 requirements: [ dopy ]
 '''
 

--- a/cloud/digital_ocean/digital_ocean_domain.py
+++ b/cloud/digital_ocean/digital_ocean_domain.py
@@ -46,6 +46,7 @@ options:
 
 notes:
   - Two environment variables can be used, DO_CLIENT_ID and DO_API_KEY.
+  - Version 1 of DigitalOcean API is used.
 '''
 
 

--- a/cloud/digital_ocean/digital_ocean_sshkey.py
+++ b/cloud/digital_ocean/digital_ocean_sshkey.py
@@ -46,6 +46,7 @@ options:
 
 notes:
   - Two environment variables can be used, DO_CLIENT_ID and DO_API_KEY.
+  - Version 1 of DigitalOcean API is used.
 '''
 
 


### PR DESCRIPTION
This was not referenced in docs, which caused confusion since v2 is now the standard.

Let me know if you want to make any changes rephrasing it.
