### PR TITLE
Add option docker_user for docker module.

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -160,6 +160,13 @@ options:
         specified by docker-py.
     default: docker-py default remote API version
     version_added: "1.8"
+  docker_user:
+    description:
+      - Username or UID to use within the container
+    required: false
+    default:
+    aliases: []
+    version_added: "2.0"
   username:
     description:
       - Remote API username.
@@ -1303,6 +1310,7 @@ class DockerManager(object):
                   'stdin_open':   self.module.params.get('stdin_open'),
                   'tty':          self.module.params.get('tty'),
                   'host_config':  self.create_host_config(),
+                  'user':         self.module.params.get('docker_user'),
                   }
 
         def do_create(count, params):
@@ -1495,6 +1503,7 @@ def main():
             tls_ca_cert     = dict(required=False, default=None, type='str'),
             tls_hostname    = dict(required=False, type='str', default=None),
             docker_api_version = dict(required=False, default=DEFAULT_DOCKER_API_VERSION, type='str'),
+            docker_user     = dict(default=None),
             username        = dict(default=None),
             password        = dict(),
             email           = dict(),


### PR DESCRIPTION
docker_user can be used to specify the user or UID to use within the
container.

Fixes #352 
