### PR TITLE
django_manage: expand ~ in app_path parameter

### DIFF
--- a/web_infrastructure/django_manage.py
+++ b/web_infrastructure/django_manage.py
@@ -218,7 +218,7 @@ def main():
     )
 
     command = module.params['command']
-    app_path = module.params['app_path']
+    app_path = os.path.expanduser(module.params['app_path'])
     virtualenv = module.params['virtualenv']
 
     for param in specific_params:


### PR DESCRIPTION
Allow users to specify `app_path` parameter that contains `~`, for example:

```
app_path=~/myproject
```
