### PR TITLE
docker: Add support for cpuset

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -273,7 +273,7 @@ options:
         docker-py >= 0.5.0.
     default: false
     version_added: "1.9"
-  cpuset:
+  cpu_set:
     description:
       - CPUs in which to allow execution. Requires docker-py >= 0.6.0.
     required: false
@@ -1589,7 +1589,7 @@ def main():
             pid             = dict(default=None),
             insecure_registry = dict(default=False, type='bool'),
             log_driver      = dict(default=None, choices=['json-file', 'none', 'syslog']),
-            cpuset          = dict(default=None),
+            cpu_set         = dict(default=None),
         ),
         required_together = (
             ['tls_client_cert', 'tls_client_key'],

--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -278,7 +278,7 @@ options:
       - CPUs in which to allow execution. Requires docker-py >= 0.6.0.
     required: false
     default: null
-    version_added: "1.8"
+    version_added: "1.9"
 
 author:
     - "Cove Schneider (@cove)"

--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -273,8 +273,14 @@ options:
         docker-py >= 0.5.0.
     default: false
     version_added: "1.9"
+  cpuset:
+    description:
+      - CPUs in which to allow execution. Requires docker-py >= 0.6.0.
+    required: false
+    default: null
+    version_added: "1.8"
 
-author: 
+author:
     - "Cove Schneider (@cove)"
     - "Joshua Conner (@joshuaconner)"
     - "Pavel Antonov (@softzilla)"
@@ -1583,6 +1589,7 @@ def main():
             pid             = dict(default=None),
             insecure_registry = dict(default=False, type='bool'),
             log_driver      = dict(default=None, choices=['json-file', 'none', 'syslog']),
+            cpuset          = dict(default=None),
         ),
         required_together = (
             ['tls_client_cert', 'tls_client_key'],

--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -537,6 +537,7 @@ class DockerManager(object):
             'pid': ((1, 0, 0), '1.17'),
             'log_driver': ((1, 2, 0), '1.18'),
             'host_config': ((0, 7, 0), '1.15'),
+            'cpu_set': ((0, 6, 0), '1.14'),
             # Clientside only
             'insecure_registry': ((0, 5, 0), '0.0')
             }
@@ -559,7 +560,7 @@ class DockerManager(object):
                 elif 2 <= len(parts) <= 3:
                     # default to read-write
                     ro = False
-                    # with supplied bind mode 
+                    # with supplied bind mode
                     if len(parts) == 3:
                         if parts[2] not in ['ro', 'rw']:
                             self.module.fail_json(msg='bind mode needs to either be "ro" or "rw"')
@@ -1356,6 +1357,8 @@ class DockerManager(object):
                   'name':         self.module.params.get('name'),
                   'stdin_open':   self.module.params.get('stdin_open'),
                   'tty':          self.module.params.get('tty'),
+                  'cpuset':       self.module.params.get('cpu_set'),
+                  'host_config':  self.create_host_config(),
                   }
 
         if self.ensure_capability('host_config', fail=False):


### PR DESCRIPTION
Requires docker-py >= 0.6.0. Will only pass the parameter when matching docker-py is available.
