### PR TITLE
Add new flavor_name parameter

### DIFF
--- a/cloud/openstack/nova_compute.py
+++ b/cloud/openstack/nova_compute.py
@@ -92,6 +92,11 @@ options:
         - The id of the flavor in which the new VM has to be created. Mutually exclusive with flavor_ram
      required: false
      default: 1
+   flavor_name:
+     description:
+        - The name of the flavor in which the new VM has to be created. Mutually exclusive with flavor_id and flavor_ram
+     required: false
+     default: None
    flavor_ram:
      description:
         - The minimum amount of ram in MB that the flavor in which the new VM has to be created must have. Mutually exclusive with flavor_id
@@ -400,12 +405,17 @@ def _get_image_id(module, nova):
 
 
 def _get_flavor_id(module, nova):
-    if module.params['flavor_ram']:
+    if module.params['flavor_name']:
+        for flavor in nova.flavors.list():
+            if flavor.name == module.params['flavor_name']:
+                return flavor.id
+        module.fail_json(msg = "Error finding flavor with name %s" % module.params['flavor_name'])
+    elif module.params['flavor_ram']:
         for flavor in sorted(nova.flavors.list(), key=operator.attrgetter('ram')):
             if (flavor.ram >= module.params['flavor_ram'] and
                     (not module.params['flavor_include'] or module.params['flavor_include'] in flavor.name)):
                 return flavor.id
-            module.fail_json(msg = "Error finding flavor with %sMB of RAM" % module.params['flavor_ram'])
+        module.fail_json(msg = "Error finding flavor with %sMB of RAM" % module.params['flavor_ram'])
     return module.params['flavor_id']
 
 
@@ -529,6 +539,7 @@ def main():
         image_name                      = dict(default=None),
         image_exclude                   = dict(default='(deprecated)'),
         flavor_id                       = dict(default=1),
+        flavor_name                     = dict(default=None),
         flavor_ram                      = dict(default=None, type='int'),
         flavor_include                  = dict(default=None),
         key_name                        = dict(default=None),
@@ -552,6 +563,8 @@ def main():
             ['floating_ips','floating_ip_pools'],
             ['image_id','image_name'],
             ['flavor_id','flavor_ram'],
+            ['flavor_id','flavor_name'],
+            ['flavor_ram','flavor_name'],
         ],
     )
 


### PR DESCRIPTION
[Resubmitting a change that I originally submitted in #315, but where I screwed up by using the wrong git branch...]

Allow the instance flavor to be specified by name rather than id.

Specifying objects by name is much more human-friendly and portable
between systems than specifying by id.

The nova_compute module already allows images to be specified by name
or id, so this is just providing equivalent function for flavors.

OpenStack does not (unfortunately) enforce that names are unique.
However, any users who have the same name for different flavors are
asking for trouble!  If there are multiple flavors with the same name,
the first one returned by nova.flavors.list() is used.
