### PR TITLE
[mysql_user] GRANT OPTION should be GRANT

### DIFF
--- a/database/mysql/mysql_user.py
+++ b/database/mysql/mysql_user.py
@@ -151,7 +151,7 @@ except ImportError:
 else:
     mysqldb_found = True
 
-VALID_PRIVS = frozenset(('CREATE', 'DROP', 'GRANT OPTION', 'LOCK TABLES',
+VALID_PRIVS = frozenset(('CREATE', 'DROP', 'GRANT', 'LOCK TABLES',
                          'REFERENCES', 'EVENT', 'ALTER', 'DELETE', 'INDEX',
                          'INSERT', 'SELECT', 'UPDATE',
                          'CREATE TEMPORARY TABLES', 'TRIGGER', 'CREATE VIEW',


### PR DESCRIPTION
Ansible Version:

```
ansible 1.8 (detached HEAD dece0c3f08) last updated 2014/11/26 10:30:34 (GMT +900)
  lib/ansible/modules/core: (detached HEAD 922a2ebb7a) last updated 2014/11/26 10:30:38 (GMT +900)
  lib/ansible/modules/extras: (detached HEAD ca94781d5c) last updated 2014/11/26 10:30:41 (GMT +900)
```

---

Since https://github.com/ansible/ansible-modules-core/commit/10ebcccedb542c7e1c499e77a1f53da98d373bc3, it's no longer possible to use `mysql_user: name="username" priv="*.*:ALL,GRANT"`.

If I specify `GRANT OPTION`, I get:

```
[11:56:20] Traceback (most recent call last):
[11:56:20]   File "<stdin>", line 2199, in <module>
[11:56:20]   File "<stdin>", line 486, in main
[11:56:20]   File "<stdin>", line 228, in user_mod
[11:56:20]   File "<stdin>", line 319, in privileges_grant
[11:56:20]   File "/usr/lib64/python2.6/site-packages/MySQLdb/cursors.py", line 173, in execute
[11:56:20]     self.errorhandler(self, exc, value)
[11:56:20]   File "/usr/lib64/python2.6/site-packages/MySQLdb/connections.py", line 36, in defaulterrorhandler
[11:56:20]     raise errorclass, errorvalue
[11:56:20] _mysql_exceptions.ProgrammingError: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'GRANT OPTION ON *.* TO 'root'@'localhost'' at line 1")
```

Considering the module logic, I replaced `GRANT OPTION` by `GRANT` in the `VALID_PRIVS` list.
