### PR TITLE
git doc: don't prepend ssh:// for ssh repo

### DIFF
--- a/source_control/git.py
+++ b/source_control/git.py
@@ -155,7 +155,7 @@ EXAMPLES = '''
        version=release-0.22
 
 # Example read-write git checkout from github
-- git: repo=ssh://git@github.com/mylogin/hello.git dest=/home/mylogin/hello
+- git: repo=git@github.com/mylogin/hello.git dest=/home/mylogin/hello
 
 # Example just ensuring the repo checkout exists
 - git: repo=git://foosball.example.org/path/to/repo.git dest=/srv/checkout update=no


### PR DESCRIPTION
The github ssh example has ssh:// at the beginning of the url. However, this
doesn't work. It does work if the ssh:// is removed.
