### PR TITLE
Fix typo of "rules_egress"

### DIFF
--- a/cloud/amazon/ec2_group.py
+++ b/cloud/amazon/ec2_group.py
@@ -55,7 +55,7 @@ options:
   purge_rules_egress:
     version_added: "1.8"
     description:
-      - Purge existing rules_egree on security group that are not found in rules_egress
+      - Purge existing rules_egress on security group that are not found in rules_egress
     required: false
     default: 'true'
     aliases: []


### PR DESCRIPTION
Or is "rules_egree" supposed to be a plural? The sentence is difficult to parse.

Maybe the correct fix is to "Purge existing rules on security group that are not found in rules_egress"?
