### PR TITLE
[service doc] Clarify supported init systems.

### DIFF
--- a/system/service.py
+++ b/system/service.py
@@ -25,7 +25,8 @@ author: Michael DeHaan
 version_added: "0.1"
 short_description:  Manage services.
 description:
-    - Controls services on remote hosts.
+    - Controls services on remote hosts. Supported init systems are: BSD init,
+      OpenRC, SysV, systemd, upstart.
 options:
     name:
         required: true


### PR DESCRIPTION
It should be stated which init services are supported. Hope I didn't left any out.
