### PR TITLE
Correct check mode for pip in virtualenv.

### DIFF
--- a/packaging/language/pip.py
+++ b/packaging/language/pip.py
@@ -314,7 +314,7 @@ def main():
         this_dir = os.path.join(this_dir, chdir)
 
     if module.check_mode:
-        if env or extra_args or requirements or state == 'latest' or not name:
+        if extra_args or requirements or state == 'latest' or not name:
             module.exit_json(changed=True)
         elif name.startswith('svn+') or name.startswith('git+') or \
                 name.startswith('hg+') or name.startswith('bzr+'):


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request for #412.

d3cb2d38b7d4b9585adfd4f1ceece1896c2cc952 added better support for check mode, but if the target is in a virtualenv, then it always returned `True`.  Since by that point in the code, we have already verified that we have a valid virtualenv, the pip freeze command will work correctly, so there should be no need to exit early.
