### PR TITLE
Make it (even more) obvious you can supply any appropriate variable to `add_host`

### DIFF
--- a/inventory/add_host.py
+++ b/inventory/add_host.py
@@ -19,6 +19,8 @@ options:
     description:
     - The groups to add the hostname to, comma separated.
     required: false
+  **variable**:
+    description: Any variable required to define the new host more fully. e.g. ansible_ssh_private_key_file
 author: Seth Vidal
 '''
 


### PR DESCRIPTION
I managed to miss the sentence "Takes variables so you can define the new hosts more fully" when reading the docs for `add_host`.

This is pretty important functionality and I think it would be good if it was spelled out in the "glance-able" Options section.

I realise the examples also show this in practice but from looking at the Options section alone I think it should be possible to tell there can be more options supplied than "groups and name".
