### PR TITLE
Add lucid compatibility

### DIFF
--- a/packaging/os/apt.py
+++ b/packaging/os/apt.py
@@ -327,10 +327,10 @@ def install_deb(m, debs, cache, force, install_recommends, dpkg_options):
     deps_to_install = []
     pkgs_to_install = []
     for deb_file in debs.split(','):
-        pkg = apt.debfile.DebPackage(deb_file)
+        pkg = apt.debfile.DebPackage(deb_file, cache=cache)
 
         # Check if it's already installed
-        if pkg.compare_to_version_in_cache() == pkg.VERSION_SAME:
+        if pkg.compare_to_version_in_cache() == getattr(pkg, 'VERSION_SAME', getattr(apt.debfile, 'VERSION_SAME', None)):
             continue
         # Check if package is installable
         if not pkg.check() and not force:


### PR DESCRIPTION
This has been working OK for me for a while on precise & lucid, and I'm firing off this pull request in case others would like it. 

There was a brief discussion on the <a href="https://groups.google.com/forum/#!searchin/ansible-devel/lucid/ansible-devel/FIZyrcb79bQ/Tw-GrINt5AoJ">mailing list</a>, and there was cautious acceptance of it.

I do not believe trusty's copy of `python-apt` changed the API again, although I don't test much there.

In some ways, I think the best solution would be to drop `python-apt`, and vendor the dpkg parsing code (it's gpl2+). The magic 'install python-apt under the hood' thing seems a little scary to me, and the validation code is more strict than I would like (See my other recent apt-related pull requests).
