### PR TITLE
route53 module retry_interval needs to be a float before passing to time.sleep

### DIFF
--- a/cloud/amazon/route53.py
+++ b/cloud/amazon/route53.py
@@ -160,7 +160,7 @@ def commit(changes, retry_interval):
             code = code.split("</Code>")[0]
             if code != 'PriorRequestNotComplete' or retry < 0:
                 raise e
-            time.sleep(retry_interval)
+            time.sleep(float(retry_interval))
 
 def main():
     argument_spec = ec2_argument_spec()


### PR DESCRIPTION
The retry_interval argument currently comes in as a string, causing a TypeError.
