### PR TITLE
Fix auto_floating_ip documentation

### DIFF
--- a/cloud/openstack/nova_compute.py
+++ b/cloud/openstack/nova_compute.py
@@ -121,7 +121,7 @@ options:
      description:
         - Should a floating ip be auto created and assigned
      required: false
-     default: 'yes'
+     default: 'no'
      version_added: "1.8"
    floating_ips:
      description:


### PR DESCRIPTION
The default value is 'no' instead of the currently documented 'yes'.

See cloud/openstack/nova_compute.py line 543:

```
    auto_floating_ip                = dict(default=False, type='bool'),
```
