### PR TITLE
fix documentation

### DIFF
--- a/cloud/amazon/ec2_elb_lb.py
+++ b/cloud/amazon/ec2_elb_lb.py
@@ -215,7 +215,7 @@ EXAMPLES = """
     name: 'New ELB'
     security_group_ids: 'sg-123456, sg-67890'
     region: us-west-2
-    subnets: 'subnet-123456, subnet-67890'
+    subnets: 'subnet-123456,subnet-67890'
     purge_subnets: yes
     listeners:
       - protocol: http


### PR DESCRIPTION
AWS does not recognize the subnet if it is presented in a comma delimited format with spaces. you must remove the space for Amazon to recognize the second subnet.
