### PR TITLE
Note that `rsync` must be installed on both local & remote machine

### DIFF
--- a/files/synchronize.py
+++ b/files/synchronize.py
@@ -145,6 +145,7 @@ options:
     required: false
     version_added: "1.6"
 notes:
+   - `rsync` must be installed on both the local and remote machine.
    - Inspect the verbose output to validate the destination user/host/path
      are what was expected.
    - The remote user for the dest path will always be the remote_user, not


### PR DESCRIPTION
For `synchronize` to work `rsync` must be installed on both local & remote machine (as appropriate for source/destination) when SSH is used as the transport.

In particular, if `rsync` is not installed on the remote machine the following error message will be encountered:

```
"rsync error: remote command not found"
```
