### PR TITLE
Update django_manage to add database option for migrate

### DIFF
--- a/web_infrastructure/django_manage.py
+++ b/web_infrastructure/django_manage.py
@@ -170,7 +170,7 @@ def main():
         syncdb=('database', ),
         test=('failfast', 'testrunner', 'liveserver', 'apps', ),
         validate=(),
-        migrate=('apps', 'skip', 'merge'),
+        migrate=('apps', 'skip', 'merge', 'database',),
         collectstatic=('link', ),
         )
 


### PR DESCRIPTION
Allow passing the database option to the django_manage module for migrations. This is usefull in situations where multiple databases are used by a django application.
