### PR TITLE
now actually adds usable name for systemd when using init scripts

### DIFF
--- a/system/service.py
+++ b/system/service.py
@@ -420,6 +420,7 @@ class LinuxService(Service):
             if not systemd_enabled:
                 return False
 
+            originalname = name
             # default to .service if the unit type is not specified
             if name.find('.') > 0:
                 unit_name, unit_type = name.rsplit('.', 1)
@@ -446,6 +447,7 @@ class LinuxService(Service):
 
             # systemd also handles init scripts (and is enabled at this point)
             if initscript:
+                self.__systemd_unit = originalname
                 return True
 
             return False


### PR DESCRIPTION
previous update allowed init scripts to be managed by systemd tools but did not set the name for those tools to use.
