### PR TITLE
Files module: Allow touch on hardlinks

### DIFF
--- a/files/file.py
+++ b/files/file.py
@@ -332,13 +332,13 @@ def main():
                     open(path, 'w').close()
                 except OSError, e:
                     module.fail_json(path=path, msg='Error, could not touch target: %s' % str(e))
-            elif prev_state in ['file', 'directory']:
+            elif prev_state in ['file', 'directory', 'hard']:
                 try:
                     os.utime(path, None)
                 except OSError, e:
                     module.fail_json(path=path, msg='Error while touching existing target: %s' % str(e))
             else:
-                module.fail_json(msg='Cannot touch other than files and directories')
+                module.fail_json(msg='Cannot touch other than files, directories, and hardlinks (%s is %s)' % (path, prev_state))
             try:
                 module.set_fs_attributes_if_different(file_args, True)
             except SystemExit, e:


### PR DESCRIPTION
I recently ran into an issue where an Ansible playbook failed to touch a file, with the error: "Cannot touch other than files and directories"

After a bit of investigation, I realized that the file was a hard link. I see no reason why `touch` shouldn't work against hard links, so I made the change.

I've also made an integration test, but that's in the top `ansible` git submodule. I'll issue a separate PR for the test against that project.
