### PR TITLE
Preventing Nonetype is not iterable error when no tags are set for new ASG

### DIFF
--- a/cloud/amazon/ec2_asg.py
+++ b/cloud/amazon/ec2_asg.py
@@ -248,7 +248,7 @@ def get_properties(autoscaling_group):
         properties['instance_facts'] = instance_facts
     properties['load_balancers'] = autoscaling_group.load_balancers
 
-    if hasattr(autoscaling_group, "tags"):
+    if getattr(autoscaling_group, "tags", None):
         properties['tags'] = dict((t.key, t.value) for t in autoscaling_group.tags)
 
     return properties


### PR DESCRIPTION
Here is a stacktrace I am receiving when attempting to create an ASG with no tags:

Traceback (most recent call last):
  File "/home/ubuntu/.ansible/tmp/ansible-tmp-1418056860.13-158369179935640/ec2_asg", line 2355, in <module>
    main()
  File "/home/ubuntu/.ansible/tmp/ansible-tmp-1418056860.13-158369179935640/ec2_asg", line 2345, in main
    create_changed, asg_properties=create_autoscaling_group(connection, module)
  File "/home/ubuntu/.ansible/tmp/ansible-tmp-1418056860.13-158369179935640/ec2_asg", line 2072, in create_autoscaling_group
    asg_properties = get_properties(ag)
  File "/home/ubuntu/.ansible/tmp/ansible-tmp-1418056860.13-158369179935640/ec2_asg", line 2008, in get_properties
    properties['tags'] = dict((t.key, t.value) for t in autoscaling_group.tags)
TypeError: 'NoneType' object is not iterable

boto.ec2.autoscale.AutoScalingGroup instantiated with 'tags' parameter that is an empty list returns an object with the tags attribute that is None.

When this happens if hasattr(autoscaling_group, "tags"): is True therefore it attempts to iterate through the None .tags attribute which throws an error.

With my edit this error will not happen, because it compares the value, which is None, so no attempt to iterate is done.  This will also allow for the tags attribute to be completely missing.
