### PR TITLE
Expose canonical hosted zone name and id in elb_lb

### DIFF
--- a/cloud/amazon/ec2_elb_lb.py
+++ b/cloud/amazon/ec2_elb_lb.py
@@ -324,6 +324,8 @@ class ElbManager(object):
             info = {
                 'name': check_elb.name,
                 'dns_name': check_elb.dns_name,
+                'canonical_hosted_zone_name': check_elb.canonical_hosted_zone_name,
+                'canonical_hosted_zone_name_id': check_elb.canonical_hosted_zone_name_id,
                 'zones': check_elb.availability_zones,
                 'security_group_ids': check_elb.security_groups,
                 'status': self.status,


### PR DESCRIPTION
These values are needed to create a route53 alias record set via cloudformation. I think the "name" is the same as "dns_name", but these are exposed separately in boto so I decided to play it safe and just use the same property names.
