### PR TITLE
Strip white space to support multiline permissions in YAML

### DIFF
--- a/database/mysql/mysql_user.py
+++ b/database/mysql/mysql_user.py
@@ -277,8 +277,8 @@ def privileges_unpack(priv):
     not specified in the string, as MySQL will always provide this by default.
     """
     output = {}
-    for item in priv.split('/'):
-        pieces = item.split(':')
+    for item in priv.strip().split('/'):
+        pieces = item.strip().split(':')
         if '.' in pieces[0]:
             pieces[0] = pieces[0].split('.')
             for idx, piece in enumerate(pieces):


### PR DESCRIPTION
Tested at [Oscar](https://www.hioscar.com) using a variant of the following snipit

```

---
- hosts: tag_primary_role_mysql:&tag_secondary_role_master:&tag_environment_development
  gather_facts: false
  tasks:
    - name: create drnonsense user
      tags: mysql_users
      mysql_user:
        name: drnonsense
        state: present
        priv: >
          web.*:SELECT,INSERT,UPDATE,DELETE,DROP,ALTER,ALTER ROUTINE,CREATE,REFERENCES,INDEX,EXECUTE,CREATE VIEW,SHOW VIEW,CREATE ROUTINE,TRIGGER/
          feeds.*:SELECT/
          claims.*:SELECT/
          vendors.view_once_password:SELECT,UPDATE
        password: "foo"
        host: '%'
```
