### PR TITLE
~ Add missing documentation for option `email`

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -126,6 +126,12 @@ options:
     required: false
     default: null
     aliases: []
+  email:
+    description:
+      - Set remote API email
+    required: false
+    default: null
+    aliases: []
   hostname:
     description:
       - Set container hostname


### PR DESCRIPTION
`username`, `password` and `registry` are documented, only `email` is not.
I am not sure in which version it's added though, so I did not add `version_added`.
