### PR TITLE
ec2_lc - include all launch config properties in the return

### DIFF
--- a/cloud/amazon/ec2_lc.py
+++ b/cloud/amazon/ec2_lc.py
@@ -225,7 +225,8 @@ def create_launch_config(connection, module):
 
     module.exit_json(changed=changed, name=result.name, created_time=str(result.created_time),
                      image_id=result.image_id, arn=result.launch_configuration_arn,
-                     security_groups=result.security_groups, instance_type=instance_type)
+                     security_groups=result.security_groups, instance_type=result.instance_type, 
+                     result=result)
 
 
 def delete_launch_config(connection, module):


### PR DESCRIPTION
make all properties available when registering the result
which is useful when wanting to launch a stand-alone instance based upon
an existing Launch Config.
