### PR TITLE
Fix #370

### DIFF
--- a/source_control/subversion.py
+++ b/source_control/subversion.py
@@ -199,7 +199,7 @@ def main():
     os.environ['LANG'] = 'C'
     svn = Subversion(module, dest, repo, revision, username, password, svn_path)
 
-    if not os.path.exists(dest):
+    if export or not os.path.exists(dest):
         before = None
         local_mods = False
         if module.check_mode:
@@ -227,9 +227,12 @@ def main():
     else:
         module.fail_json(msg="ERROR: %s folder already exists, but its not a subversion repository." % (dest, ))
 
-    after = svn.get_revision()
-    changed = before != after or local_mods
-    module.exit_json(changed=changed, before=before, after=after)
+    if export:
+        module.exit_json(changed=True)
+    else:
+        after = svn.get_revision()
+        changed = before != after or local_mods
+        module.exit_json(changed=changed, before=before, after=after)
 
 # import module snippets
 from ansible.module_utils.basic import *

--- a/source_control/subversion.py
+++ b/source_control/subversion.py
@@ -123,7 +123,12 @@ class Subversion(object):
 		
     def export(self, force=False):
         '''Export svn repo to directory'''
-        self._exec(["export", "-r", self.revision, self.repo, self.dest])
+        cmd = ["export"]
+        if force:
+            cmd.append("--force")
+        cmd.extend(["-r", self.revision, self.repo, self.dest])
+
+        self._exec(cmd)
 
     def switch(self):
         '''Change working directory's repo.'''
@@ -173,7 +178,7 @@ def main():
             dest=dict(required=True),
             repo=dict(required=True, aliases=['name', 'repository']),
             revision=dict(default='HEAD', aliases=['rev', 'version']),
-            force=dict(default='yes', type='bool'),
+            force=dict(default='no', type='bool'),
             username=dict(required=False),
             password=dict(required=False),
             executable=dict(default=None),
@@ -202,7 +207,7 @@ def main():
         if not export:
             svn.checkout()
         else:
-            svn.export()
+            svn.export(force=force)
     elif os.path.exists("%s/.svn" % (dest, )):
         # Order matters. Need to get local mods before switch to avoid false
         # positives. Need to switch before revert to ensure we are reverting to


### PR DESCRIPTION
Use the currently ignored and unused force parameters to explicitly say we want to push over a existing repository, following subversion convention. Fix issue #370 
