### PR TITLE
Fix breakage in lineinfile check mode when target file does not exist.

### DIFF
--- a/files/lineinfile.py
+++ b/files/lineinfile.py
@@ -192,7 +192,7 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
         if not create:
             module.fail_json(rc=257, msg='Destination %s does not exist !' % dest)
         destpath = os.path.dirname(dest)
-        if not os.path.exists(destpath):
+        if not os.path.exists(destpath) and not module.check_mode:
             os.makedirs(destpath)
         lines = []
     else:
@@ -281,6 +281,9 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
         if backup and os.path.exists(dest):
             backupdest = module.backup_local(dest)
         write_changes(module, lines, dest)
+
+    if module.check_mode and not os.path.exists(dest):
+        module.exit_json(changed=changed, msg=msg, backup=backupdest)
 
     msg, changed = check_file_attrs(module, changed, msg)
     module.exit_json(changed=changed, msg=msg, backup=backupdest)


### PR DESCRIPTION
Similarly to https://github.com/ansible/ansible/issues/6182, checking of the file attributes should be avoided in check mode when the file didn't originally exist.

Also, avoid creating parent directories in check mode.

Fixes https://github.com/ansible/ansible/issues/9546
