### PR TITLE
Merged from openstack-ansible: Implements host_routes option for neutron subnet

### DIFF
--- a/cloud/openstack/quantum_subnet.py
+++ b/cloud/openstack/quantum_subnet.py
@@ -114,6 +114,11 @@ options:
         - From the subnet pool the last IP that should be assigned to the virtual machines
      required: false
      default: None
+   host_routes:
+     description:
+        - Host routes for this subnet, list of dictionaries, e.g. [{destination: 0.0.0.0/0, nexthop: 123.456.78.9}, {destination: 192.168.0.0/24, nexthop: 192.168.0.1}]
+     required: false
+     default: None
 requirements: ["quantumclient", "neutronclient", "keystoneclient"]
 '''
 
@@ -220,6 +225,7 @@ def _create_subnet(module, neutron):
             'dns_nameservers': module.params['dns_nameservers'],
             'network_id':      _os_network_id,
             'cidr':            module.params['cidr'],
+            'host_routes':     module.params['host_routes'],
     }
     if module.params['allocation_pool_start'] and module.params['allocation_pool_end']:
         allocation_pools = [
@@ -235,6 +241,8 @@ def _create_subnet(module, neutron):
         subnet['dns_nameservers'] = module.params['dns_nameservers'].split(',')
     else:
         subnet.pop('dns_nameservers')
+    if not module.params['host_routes']:
+        subnet.pop('host_routes')
     try:
         new_subnet = neutron.create_subnet(dict(subnet=subnet))
     except Exception, e:
@@ -265,6 +273,7 @@ def main():
             dns_nameservers         = dict(default=None),
             allocation_pool_start   = dict(default=None),
             allocation_pool_end     = dict(default=None),
+            host_routes             = dict(default=None),
     ))
     module = AnsibleModule(argument_spec=argument_spec)
     neutron = _get_neutron_client(module, module.params)


### PR DESCRIPTION
I merged cdwertmann commit to quantum_subnet. 

I understand that there is a major rework going on with OpenStack modules, but this is a minor fix.

Conflicts:
    cloud/openstack/quantum_subnet.py
