### PR TITLE
Deleting images now does work with name parameter. (no need for supplying image_id)

### DIFF
--- a/cloud/amazon/ec2_ami.py
+++ b/cloud/amazon/ec2_ami.py
@@ -20,7 +20,7 @@ module: ec2_ami
 version_added: "1.3"
 short_description: create or destroy an image in ec2
 description:
-     - Creates or deletes ec2 images.
+     - Creates or deletes ec2 images. 
 options:
   instance_id:
     description:


### PR DESCRIPTION
This commit makes it possible to delete AMI's by their name. This is useful for scenarios like baking AMI's on each deployment and keeping the same name for the new AMI.
