### PR TITLE
Fixed formatting in cloudformation example

### DIFF
--- a/cloud/amazon/cloudformation.py
+++ b/cloud/amazon/cloudformation.py
@@ -100,7 +100,8 @@ tasks:
   cloudformation:
     stack_name: "ansible-cloudformation" 
     state: "present"
-    region: "us-east-1 disable_rollback=true"
+    region: "us-east-1" 
+    disable_rollback: true
     template: "files/cloudformation-example.json"
     template_parameters:
       KeyName: "jmartin"


### PR DESCRIPTION
The example was using mixed shorthand and long form yaml (region: "us-east-1 disable_rollback=true")

I modified the entire example to be long form.
