### PR TITLE
set network_config.public_ips attribute

### DIFF
--- a/cloud/azure/azure.py
+++ b/cloud/azure/azure.py
@@ -281,6 +281,7 @@ def create_virtual_machine(module, azure):
         network_config = ConfigurationSetInputEndpoints()
         network_config.configuration_set_type = 'NetworkConfiguration'
         network_config.subnet_names = []
+        network_config.public_ips = None
         for port in endpoints:
             network_config.input_endpoints.append(ConfigurationSetInputEndpoint(name='TCP-%s' % port,
                                                                                 protocol='TCP',


### PR DESCRIPTION
The azure module doesn't currently have the capacity to accept and assign a public IP to a vm instance.

When creating a new vm deployment, if the public_ips attribute is not set on the ConfigurationSetInputEndpoints object, azure's python sdk throws this:

AttributeError: 'ConfigurationSetInputEndpoints' object has no attribute 'public_ips'
