### PR TITLE
re-enable AIX password setting

### DIFF
--- a/system/user.py
+++ b/system/user.py
@@ -262,12 +262,12 @@ class User(object):
         # select whether we dump additional debug info through syslog
         self.syslogging = False
 
-    def execute_command(self, cmd):
+    def execute_command(self, cmd, use_unsafe_shell=False):
         if self.syslogging:
             syslog.openlog('ansible-%s' % os.path.basename(__file__))
             syslog.syslog(syslog.LOG_NOTICE, 'Command %s' % '|'.join(cmd))
 
-        return self.module.run_command(cmd)
+        return self.module.run_command(cmd, use_unsafe_shell=use_unsafe_shell)
 
     def remove_user_userdel(self):
         cmd = [self.module.get_bin_path('userdel', True)]
@@ -1367,11 +1367,11 @@ class AIX(User):
         # set password with chpasswd
         if self.password is not None:
             cmd = []
-            cmd.append('echo "'+self.name+':'+self.password+'" |')
+            cmd.append('echo \''+self.name+':'+self.password+'\' |')
             cmd.append(self.module.get_bin_path('chpasswd', True))
             cmd.append('-e')
             cmd.append('-c')
-            self.execute_command(' '.join(cmd))
+            self.execute_command(' '.join(cmd), use_unsafe_shell=True)
 
         return (rc, out, err)
 
@@ -1443,11 +1443,11 @@ class AIX(User):
         # set password with chpasswd
         if self.update_password == 'always' and self.password is not None and info[1] != self.password:
             cmd = []
-            cmd.append('echo "'+self.name+':'+self.password+'" |')
+            cmd.append('echo \''+self.name+':'+self.password+'\' |')
             cmd.append(self.module.get_bin_path('chpasswd', True))
             cmd.append('-e')
             cmd.append('-c')
-            (rc2, out2, err2) = self.execute_command(' '.join(cmd))
+            (rc2, out2, err2) = self.execute_command(' '.join(cmd), use_unsafe_shell=True)
         else:
             (rc2, out2, err2) = (None, '', '')
 


### PR DESCRIPTION
the AIX class uses a unsafe shell for setting the user password (containing a pipe in the command). This patch adopts to the new behavior of module_utils/basic.py (since somewhere around 1.7).

besides it changes the qoutes for the echo command from double to single, because password-hashes contain $-signs and one would not have this variables expanded.
