### PR TITLE
password required

### DIFF
--- a/cloud/azure/azure.py
+++ b/cloud/azure/azure.py
@@ -442,6 +442,8 @@ def main():
             module.fail_json(msg='location parameter is required for new instance')
         if not module.params.get('storage_account'):
             module.fail_json(msg='storage_account parameter is required for new instance')
+        if not module.params.get('password'):
+            module.fail_json(msg='password parameter is required for new instance')
         (changed, public_dns_name, deployment) = create_virtual_machine(module, azure)
 
     module.exit_json(changed=changed, public_dns_name=public_dns_name, deployment=json.loads(json.dumps(deployment, default=lambda o: o.__dict__)))


### PR DESCRIPTION
this playbook (without password):

<pre><code>
# azure_provision.yml

---
- name: testing
  hosts: local
  tasks:
    - local_action:
        module: azure
        subscription_id: [subscription id]
        management_cert_path: [cert path]
        storage_account: teststorage
        location: 'East US'
        name: TEST-ansible
        role_size: Basic_A0
        image: b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-12_04_5-LTS-amd64-server-20140927-en-us-30GB
        user: testbot
        wait: yes
        state: present
</code></pre>


results in:

<pre><code>
failed: [localhost -> 127.0.0.1] => {"failed": true}
msg: failed to create the new virtual machine, error was: Unknown error (Bad Request)
&lt;Error xmlns=&quot;http://schemas.microsoft.com/windowsazure&quot; xmlns:i=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;&gt;&lt;Code&gt;BadRequest&lt;/Code&gt;&lt;Message&gt;The UserPassword property must be specified.&lt;/Message&gt;&lt;/Error&gt;

FATAL: all hosts have already failed -- aborting
</code></pre>
