### PR TITLE
fixes #529 ec2_group module bug

### DIFF
--- a/cloud/amazon/ec2_group.py
+++ b/cloud/amazon/ec2_group.py
@@ -117,9 +117,9 @@ except ImportError:
 def make_rule_key(prefix, rule, group_id, cidr_ip):
     """Creates a unique key for an individual group rule"""
     if isinstance(rule, dict):
-        proto, from_port, to_port = (rule.get(x, None) for x in ('proto', 'from_port', 'to_port'))
+        proto, from_port, to_port = [rule.get(x, None) for x in ('proto', 'from_port', 'to_port')]
     else:  # isinstance boto.ec2.securitygroup.IPPermissions
-        proto, from_port, to_port = (getattr(rule, x, None) for x in ('ip_protocol', 'from_port', 'to_port'))
+        proto, from_port, to_port = [getattr(rule, x, None) for x in ('ip_protocol', 'from_port', 'to_port')]
 
     key = "%s-%s-%s-%s-%s-%s" % (prefix, proto, from_port, to_port, group_id, cidr_ip)
     return key.lower().replace('-none', '-None')


### PR DESCRIPTION
The problem was ultimately various capitalization mismatches between the rules lookup dictionary keys.  The least-invasive fix I think was to factor out the key creation into a function, and then make sure it's consistent for all possible inputs.

As it turns out, using a lowercase protocol (`icmp` in my case), instead of uppercase in the playbook also fixes the problem.  But boto accepts both upper and lower case so ansible should too.

fix for #529 
