### PR TITLE
Add warning to docs about parallel use of add_host

### DIFF
--- a/inventory/add_host.py
+++ b/inventory/add_host.py
@@ -7,6 +7,9 @@ short_description: add a host (and alternatively a group) to the ansible-playboo
 description:
   - Use variables to create new hosts and groups in inventory for use in later plays of the same playbook. 
     Takes variables so you can define the new hosts more fully.
+notes:
+  - Behaviour may be unpredictable if run on multiple hosts simultaneously. 
+    Plays using 'add_host' may also benefit from using 'serial: 1'.
 version_added: "0.9"
 options:
   name:


### PR DESCRIPTION
add_host can behave unpredictably (at least from a user's point of view) when run on multiple machines simultaneously - not all instances will succeed in making a change that persists into the future.

After spending many hours yesterday discovering this the hard way, I thought adding a warning note to the documentation was worthwhile, to the effect that 'serial:1' is a good idea.
