### PR TITLE
Updating rubygems --no-document param

### DIFF
--- a/packaging/language/gem.py
+++ b/packaging/language/gem.py
@@ -182,8 +182,7 @@ def install(module):
         cmd.append('--no-user-install')
     if module.params['pre_release']:
         cmd.append('--pre')
-    cmd.append('--no-rdoc')
-    cmd.append('--no-ri')
+    cmd.append('--no-document')
     cmd.append(module.params['gem_source'])
     module.run_command(cmd, check_rc=True)
 

--- a/packaging/language/gem.py
+++ b/packaging/language/gem.py
@@ -84,7 +84,7 @@ options:
       - Allow adding build flags for gem compilation
     required: false
     version_added: "2.0"
-author: 
+author:
     - "Ansible Core Team"
     - "Johan Wiren"
 '''
@@ -196,7 +196,11 @@ def install(module):
     if module.params['pre_release']:
         cmd.append('--pre')
     if not module.params['include_doc']:
-        cmd.append('--no-document')
+        if major and major < 2:
+            cmd.append('--no-rdoc')
+            cmd.append('--no-ri')
+        else:
+            cmd.append('--no-document')
     cmd.append(module.params['gem_source'])
     if module.params['build_flags']:
         cmd.extend([ '--', module.params['build_flags'] ])


### PR DESCRIPTION
`--no-rdoc` and `--no-ri` are deprecated: http://guides.rubygems.org/command-reference/#gem-install
