### PR TITLE
fix uri modul for JSON-escape quotation marks

### DIFF
--- a/network/basics/uri.py
+++ b/network/basics/uri.py
@@ -304,7 +304,7 @@ def uri(module, url, dest, user, password, body, method, headers, redirects, soc
         r.update(resp_redir)
         r.update(resp)
         try:
-            return r, unicode(content.decode('unicode_escape')), dest
+            return r, unicode(content.decode('raw_unicode_escape')), dest
         except:
             return r, content, dest
     except httplib2.RedirectMissingLocation:


### PR DESCRIPTION
consider the following response body (content) of a REST/JSON webservice containing escaped quotation marks:

``` json
{ "key": "\"works\"" }
```

decoding this string not as raw will lose the backslash as JSON escape. later json.loads will fail to parse.

Inspired by [this thread](https://groups.google.com/forum/#!topic/ansible-project/kymtiloDme4) on the mailing list and the following python shell code:

``` python
import json
string=r'{ "key": "\"works\"" }'
json.loads(string)
json.loads(string.decode('raw_unicode_escape'))
json.loads(string.decode('unicode_escape'))
```
