### PR TITLE
Create SSH Keys always after creating $HOME

### DIFF
--- a/system/user.py
+++ b/system/user.py
@@ -1917,6 +1917,16 @@ def main():
         if user.groups is not None:
             result['groups'] = user.groups
 
+        # handle missing homedirs
+        info = user.user_info()
+        if user.home is None:
+            user.home = info[5]
+        if not os.path.exists(user.home) and user.createhome:
+            if not module.check_mode:
+                user.create_homedir(user.home)
+                user.chown_homedir(info[2], info[3], user.home)
+            result['changed'] = True
+
         # deal with ssh key
         if user.sshkeygen:
             (rc, out, err) = user.ssh_key_gen()
@@ -1931,16 +1941,6 @@ def main():
                 result['ssh_fingerprint'] = err.strip()
             result['ssh_key_file'] = user.get_ssh_key_path()
             result['ssh_public_key'] = user.get_ssh_public_key()
-
-        # handle missing homedirs
-        info = user.user_info()
-        if user.home is None:
-            user.home = info[5]
-        if not os.path.exists(user.home) and user.createhome:
-            if not module.check_mode:
-                user.create_homedir(user.home)
-                user.chown_homedir(info[2], info[3], user.home)
-            result['changed'] = True
 
     module.exit_json(**result)
 


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

ansible 1.8.2
##### Environment:

Arch Linux 64-Bit
##### Summary:

Ansible should always create a $HOME before trying to create an SSH Key.
##### Steps To Reproduce:

Change $HOME of an existing User and enable generate_ssh_key for this User, ansible will fail with this simple task because we try to generate ans SSH Key before creating $HOME.
##### Expected Results:

Ansible creates $HOME before SSH Key.
##### Actual Results:

Changing a Users Name or $HOME fails.
