### PR TITLE
Fix appending to a user's group on Solaris

### DIFF
--- a/system/user.py
+++ b/system/user.py
@@ -1255,7 +1255,7 @@ class SunOS(User):
                 cmd.append('-G')
                 new_groups = groups
                 if self.append:
-                    new_groups.extend(current_groups)
+                    new_groups.update(current_groups)
                 cmd.append(','.join(new_groups))
 
         if self.comment is not None and info[4] != self.comment:


### PR DESCRIPTION
Without this change, you get:

```
AttributeError: 'set' object has no attribute 'extend'
```

Tested on a Solaris 11.2 client with the included Python 2.6.8.
