### PR TITLE
Added ability to use url as key source

### DIFF
--- a/system/authorized_key.py
+++ b/system/authorized_key.py
@@ -118,6 +118,7 @@ import os.path
 import tempfile
 import re
 import shlex
+import urllib2
 
 class keydict(dict):
 
@@ -332,6 +333,14 @@ def enforce_state(module, params):
     manage_dir  = params.get("manage_dir", True)
     state       = params.get("state", "present")
     key_options = params.get("key_options", None)
+
+    if key.startswith("http"):
+        try:
+        gh_key = urllib2.urlopen(key).read()
+    except urllib2.URLError, e:
+        module.fail_json(msg="no key found at: %s" % key)
+
+    key = gh_key
 
     # extract individual keys into an array, skipping blank lines and comments
     key = [s for s in key.splitlines() if s and not s.startswith('#')]

--- a/system/authorized_key.py
+++ b/system/authorized_key.py
@@ -37,7 +37,7 @@ options:
     aliases: []
   key:
     description:
-      - The SSH public key, as a string
+      - The SSH public key(s), as a string or url (https://github.com/username.keys)
     required: true
     default: null
   path:
@@ -79,6 +79,9 @@ EXAMPLES = '''
 # Example using key data from a local file on the management machine
 - authorized_key: user=charlie key="{{ lookup('file', '/home/charlie/.ssh/id_rsa.pub') }}"
 
+# Using github url as key source
+- authorized_key: user=charlie key=https://github.com/charlie.keys
+
 # Using alternate directory locations:
 - authorized_key: user=charlie
                   key="{{ lookup('file', '/home/charlie/.ssh/id_rsa.pub') }}"
@@ -97,6 +100,7 @@ EXAMPLES = '''
 - authorized_key: user=charlie
                   key="{{ lookup('file', '/home/charlie/.ssh/id_rsa.pub') }}"
                   key_options='no-port-forwarding,host="10.0.1.1"'
+
 '''
 
 # Makes sure the public key line is present or absent in the user's .ssh/authorized_keys.


### PR DESCRIPTION
I have a feeling this first implementation is too naive, but I figured I would give it a shot.

Github provides the ability to pull public keys associated with a user via https://github.com/username.keys

I have wanted to use this multiple times, but didn't find it to be possible with the current implementation of authorized_key module. I probably should update the documentation to reflect that a url is allowed, but I wanted to see what the feedback was like, in case I need to change the implementation significantly.
