### PR TITLE
forcing git fetch if sha1 are equal between repos but branch exists only...

### DIFF
--- a/source_control/git.py
+++ b/source_control/git.py
@@ -718,7 +718,8 @@ def main():
                 if version in get_tags(git_path, module, dest):
                     repo_updated = False
             else:
-                repo_updated = False
+                if version in get_branches(git_path, module, dest):
+                    repo_updated = False
         if repo_updated is None:
             if module.check_mode:
                 module.exit_json(changed=True, before=before, after=remote_head)


### PR DESCRIPTION
forcing git fetch if sha1 are equal between repos but branch exists only at remote end

A fix for issue reported in ansible engine repo
https://github.com/ansible/ansible/issues/9876
