### PR TITLE
Build the db connection on `"postgres"` instead of `"template1"`

### DIFF
--- a/database/postgresql/postgresql_db.py
+++ b/database/postgresql/postgresql_db.py
@@ -275,7 +275,7 @@ def main():
         kw["host"] = module.params["login_unix_socket"]
 
     try:
-        db_connection = psycopg2.connect(database="template1", **kw)
+        db_connection = psycopg2.connect(database="postgres", **kw)
         # Enable autocommit so we can create databases
         if psycopg2.__version__ >= '2.4.2':
             db_connection.autocommit = True


### PR DESCRIPTION
According to the [postgresql docs](http://www.postgresql.org/docs/9.1/static/manage-ag-templatedbs.html), you should not have a connection with
`"template1"` when copying multiple databases.

In my case I wanted to create around 20 databases in parallel but only one was able to succeed because postgres saw the other connections to the `"template1"` database and (rightfully) prevented duplicating it. This change solved that problem for me. I don't know the rationale for the original choice (it was in the initial commit for this module), so I may be missing something.
