### PR TITLE
Fixes version check for docker-py

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -443,7 +443,7 @@ def get_docker_py_versioninfo():
         # than 0.3.0 so it's okay to lie here.
         version = (0,)
 
-    return version
+    return tuple(version)
 
 def check_dependencies(module):
     """


### PR DESCRIPTION
get_docker_py_versioninfo() did not always return a tuple as a version number, but sometimes a list. The comparison of a list and tuple fails, which causes newer docker-py versions than (0, 3, 0) to fail.

This bugfix makes sure that always a tuple is returned.

Tested on OSX 10.9.5
