### PR TITLE
vsphere_guest fix for KeyError: folder message

### DIFF
--- a/cloud/vmware/vsphere_guest.py
+++ b/cloud/vmware/vsphere_guest.py
@@ -684,7 +684,7 @@ def create_vm(vsphere_client, module, esxi, resource_pool, cluster_name, guest, 
     hfmor = dcprops.hostFolder._obj
 
     # virtualmachineFolder managed object reference
-    if vm_extra_config['folder']:
+    if vm_extra_config.get('folder'):
         if vm_extra_config['folder'] not in vsphere_client._get_managed_objects(MORTypes.Folder).values():
             vsphere_client.disconnect()
             module.fail_json(msg="Cannot find folder named: %s" % vm_extra_config['folder'])


### PR DESCRIPTION
Testing this module in devel branch earlier I was getting an error message when trying to spin up a new VM:

```
TASK: [Spin up new VM] ********************************************************
failed: [local] => {"failed": true, "parsed": false}
Traceback (most recent call last):
  File "/home/markp/.ansible/tmp/ansible-tmp-1419422975.12-211889611989018/vsphere_guest", line 2887, in <module>
    main()
  File "/home/markp/.ansible/tmp/ansible-tmp-1419422975.12-211889611989018/vsphere_guest", line 1310, in main
    state=state
  File "/home/markp/.ansible/tmp/ansible-tmp-1419422975.12-211889611989018/vsphere_guest", line 687, in create_vm
    if vm_extra_config['folder']:
KeyError: 'folder'
```

Taking a look at [stewrutledge's original branch](https://github.com/stewrutledge/ansible-modules-core/commit/38884a01943d36aa32512d8db36a6eae3539143b) for this functionality, I could see that this line was [different to the template pull request](https://github.com/ansible/ansible-modules-core/pull/72). 

So this pull fixes the module so it works again. I've tested creating a VM in a folder that exists, and doesn't exist, and also when the vm_extra_config dict doesn't exist.
