### PR TITLE
Fix compatibility issues with python-apt < 0.7.9

### DIFF
--- a/packaging/os/apt.py
+++ b/packaging/os/apt.py
@@ -206,7 +206,12 @@ def package_status(m, pkgname, version, cache, state):
             package_is_installed = pkg.isInstalled
 
     if version:
-        avail_upgrades = fnmatch.filter((p.version for p in pkg.versions), version)
+        try:
+            avail_upgrades = fnmatch.filter((p.version for p in pkg.versions), version)
+        except AttributeError:
+            # assume older version of python-apt is installed
+            # apt.package.Package#versions require python-apt >= 0.7.9.
+            avail_upgrades = []
 
         if package_is_installed:
             try:


### PR DESCRIPTION
### This patch fix the apt module using python-apt 0.7.4 (ubutun 8.04 - hardy)

When installing a specific package version ansible will fail while try to access `apt.package.Package#versions` witch is only available after 0.7.9.

see :
http://apt.alioth.debian.org/python-apt-doc/library/apt.package.html#apt.package.Package.versions
#### apt: name=foo=1.00 state=present

```
Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-tmp-1419437723.99-201671988715310/apt", line 2167, in <module>
    main()
  File "/root/.ansible/tmp/ansible-tmp-1419437723.99-201671988715310/apt", line 586, in main
    dpkg_options=dpkg_options)
  File "/root/.ansible/tmp/ansible-tmp-1419437723.99-201671988715310/apt", line 283, in install
    installed, upgradable, has_files = package_status(m, name, version, cache, state='install')
  File "/root/.ansible/tmp/ansible-tmp-1419437723.99-201671988715310/apt", line 209, in package_status
    avail_upgrades = fnmatch.filter((p.version for p in pkg.versions), version)
AttributeError: 'Package' object has no attribute 'versions'
```
#### lsb_release -a

```
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 8.04
Release:    8.04
Codename:   hardy
```
#### dpkg -l | grep python

```
ii  python                 2.5.2-0ubuntu1
ii  python-apt             0.7.4ubuntu7
ii  python-central         0.6.5ubuntu1
ii  python-gdbm            2.5.2-0ubuntu2
ii  python-gnupginterface  0.3.2-9ubuntu1
ii  python-minimal         2.5.2-0ubuntu1
ii  python-simplejson      1.7.3-1
ii  python-support         0.7.5ubuntu1
ii  python2.5              2.5.2-2ubuntu4
ii  python2.5-minimal      2.5.2-2ubuntu4
```
