### PR TITLE
Feature: provision azure vm with different public and local ports for an...

### DIFF
--- a/cloud/azure/azure.py
+++ b/cloud/azure/azure.py
@@ -58,7 +58,7 @@ options:
     default: Small
   endpoints:
     description:
-      - a comma-separated list of TCP ports to expose on the virtual machine (e.g., "22,80")
+      - a comma-separated list of TCP ports to expose on the virtual machine (e.g., "22,80"). If you want to change the public port, use a pipe-delimited pair in the format "public|local". For example if you want to expose ssh on port 88822, use: "88822|22,80".
     required: false
     default: 22
   user:
@@ -281,11 +281,17 @@ def create_virtual_machine(module, azure):
         network_config = ConfigurationSetInputEndpoints()
         network_config.configuration_set_type = 'NetworkConfiguration'
         network_config.subnet_names = []
-        for port in endpoints:
+        for port_pair in endpoints:
+            port_list = port_pair.split('|')
+            port = port_list[0]
+            try:
+                local_port = port_list[1]
+            except IndexError:
+                local_port = port_list[0]
             network_config.input_endpoints.append(ConfigurationSetInputEndpoint(name='TCP-%s' % port,
                                                                                 protocol='TCP',
                                                                                 port=port,
-                                                                                local_port=port))
+                                                                                local_port=local_port))
 
         # First determine where to store disk
         today = datetime.date.today().strftime('%Y-%m-%d')


### PR DESCRIPTION
Currently, when provisioning azure vm's, each endpoint must have the same port number for the public and local port.

Currently opening ssh, http and https is done like this:

<pre><code>
endpoints: "22,80,443"
</code></pre>


This commit will allow you, for instance, to assign the ssh port to 88822 by setting the local port as 22 and the public port as 88822.

This commit will allow the following to set ssh as 88822 externally:

<pre><code>
endpoints: "88822|22,80,443"
</code></pre>


This commit won't break any endpoint definitions that currently work.  `"22,80,443"` will still work fine.
