### PR TITLE
Don't pass volumes_from to create_container

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -727,14 +727,10 @@ class DockerManager(object):
                   'stdin_open':   self.module.params.get('stdin_open'),
                   'tty':          self.module.params.get('tty'),
                   'dns':          self.module.params.get('dns'),
-                  'volumes_from': self.module.params.get('volumes_from'),
                   }
 
         if params['dns'] is not None:
             self.ensure_capability('dns')
-
-        if params['volumes_from'] is not None:
-            self.ensure_capability('volumes_from')
 
         extra_params = {}
         if self.module.params.get('insecure_registry'):


### PR DESCRIPTION
Don't pass the `volumes_from` argument to the Docker `create_container` method.

If the `volumes_from` argument is passed to the `create_container` method, Docker
raises the following exception:

```
docker.errors.DockerException: 'volumes_from' parameter has no effect on
create_container(). It has been moved to start()
```

Tested on:

Docker 1.4.1
docker-py 0.7.0
