### PR TITLE
Fix 'wait_for' doesn't work with ipv6only host

### DIFF
--- a/utilities/logic/wait_for.py
+++ b/utilities/logic/wait_for.py
@@ -351,10 +351,8 @@ def main():
                 except IOError:
                     break
             elif port:
-                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                s.settimeout(connect_timeout)
                 try:
-                    s.connect( (host, port) )
+                    s = socket.create_connection( (host, port), connect_timeout)
                     s.shutdown(socket.SHUT_RDWR)
                     s.close()
                     time.sleep(1)
@@ -397,10 +395,8 @@ def main():
                         elapsed = datetime.datetime.now() - start
                         module.fail_json(msg="Failed to stat %s, %s" % (path, e.strerror), elapsed=elapsed.seconds)
             elif port:
-                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                s.settimeout(connect_timeout)
                 try:
-                    s.connect( (host, port) )
+                    s = socket.create_connection( (host, port), connect_timeout)
                     if search_regex:
                         data = ''
                         matched = False

--- a/utilities/logic/wait_for.py
+++ b/utilities/logic/wait_for.py
@@ -293,6 +293,25 @@ def _little_endian_convert_32bit(block):
     # which lets us start at the end of the string block and work to the begining
     return "".join([ block[x:x+2] for x in xrange(6, -2, -2) ])
 
+def _create_connection( (host, port), connect_timeout):
+    """
+    Connect to a 2-tuple (host, port) and return
+    the socket object.
+
+    Args:
+        2-tuple (host, port) and connection timeout
+    Returns:
+        Socket object
+    """
+    if sys.version_info < (2, 6):
+        (family, _) = _convert_host_to_ip(host)
+        connect_socket = socket.socket(family, socket.SOCK_STREAM)
+        connect_socket.settimeout(connect_timeout)
+        connect_socket.connect( (host, port) )
+    else:
+        connect_socket = socket.create_connection( (host, port), connect_timeout)
+    return connect_socket
+
 def main():
 
     module = AnsibleModule(
@@ -352,7 +371,7 @@ def main():
                     break
             elif port:
                 try:
-                    s = socket.create_connection( (host, port), connect_timeout)
+                    s = _create_connection( (host, port), connect_timeout)
                     s.shutdown(socket.SHUT_RDWR)
                     s.close()
                     time.sleep(1)
@@ -396,7 +415,7 @@ def main():
                         module.fail_json(msg="Failed to stat %s, %s" % (path, e.strerror), elapsed=elapsed.seconds)
             elif port:
                 try:
-                    s = socket.create_connection( (host, port), connect_timeout)
+                    s = _create_connection( (host, port), connect_timeout)
                     if search_regex:
                         data = ''
                         matched = False


### PR DESCRIPTION
If host ipv6only module 'wait_for' works incorrectly, because `socket.AF_INET` is used.
The function `socket.create_connection()` is used instead of `socket.connect()` in this patch.
