### PR TITLE
EC2: move logic about terminated instances up (#423)

### DIFF
--- a/cloud/amazon/ec2.py
+++ b/cloud/amazon/ec2.py
@@ -915,6 +915,17 @@ def create_instances(module, ec2, override_count=None):
                             continue
                         else:
                             module.fail_json(msg = str(e))
+
+                # The instances returned through ec2.run_instances above can be in
+                # terminated state due to idempotency. See commit 7f11c3d for a complete
+                # explanation.
+                terminated_instances = [ str(instance.id) for instance in res.instances
+                                        if instance.state == 'terminated' ]
+                if terminated_instances:
+                    module.fail_json(msg = "Instances with id(s) %s " % terminated_instances +
+                                        "were created previously but have since been terminated - " +
+                                        "use a (possibly different) 'instanceid' parameter")
+
             else:
                 if private_ip:
                     module.fail_json(
@@ -951,15 +962,6 @@ def create_instances(module, ec2, override_count=None):
                     instids = spot_req_inst_ids.values()
         except boto.exception.BotoServerError, e:
             module.fail_json(msg = "Instance creation failed => %s: %s" % (e.error_code, e.error_message))
-
-        # The instances returned through run_instances can be in
-        # terminated state due to idempotency.
-        terminated_instances = [ str(instance.id) for instance in res.instances
-                                 if instance.state == 'terminated' ]
-        if terminated_instances:
-            module.fail_json(msg = "Instances with id(s) %s " % terminated_instances +
-                                   "were created previously but have since been terminated - " +
-                                   "use a (possibly different) 'instanceid' parameter")
 
         # wait here until the instances are up
         num_running = 0

--- a/cloud/amazon/ec2.py
+++ b/cloud/amazon/ec2.py
@@ -919,12 +919,13 @@ def create_instances(module, ec2, override_count=None):
                 # The instances returned through ec2.run_instances above can be in
                 # terminated state due to idempotency. See commit 7f11c3d for a complete
                 # explanation.
-                terminated_instances = [ str(instance.id) for instance in res.instances
-                                        if instance.state == 'terminated' ]
+                terminated_instances = [
+                    str(instance.id) for instance in res.instances if instance.state == 'terminated'
+                ]
                 if terminated_instances:
                     module.fail_json(msg = "Instances with id(s) %s " % terminated_instances +
-                                        "were created previously but have since been terminated - " +
-                                        "use a (possibly different) 'instanceid' parameter")
+                                           "were created previously but have since been terminated - " +
+                                           "use a (possibly different) 'instanceid' parameter")
 
             else:
                 if private_ip:


### PR DESCRIPTION
As stated in #423, the commit 7f11c3d broke ec2 spot instance launching
after 1.7.2. This is because it acts on the 'res' variable which have 2
different types in the method, and in case we request spot instances,
the resulting object is not a result of `ec2.run_instances()` but
`ec2.request_spot_instances()`. Actually this fix doesn't seem to be
relevant in the spot instances case, because by construction we won't
retrieve 'terminated' instances in the end.
