### PR TITLE
vpc_zone_identifier must be a csv string when an asg is updated.

### DIFF
--- a/cloud/amazon/ec2_asg.py
+++ b/cloud/amazon/ec2_asg.py
@@ -326,6 +326,8 @@ def create_autoscaling_group(connection, module):
         for attr in ASG_ATTRIBUTES:
             if module.params.get(attr):
                 module_attr = module.params.get(attr)
+                if attr == 'vpc_zone_identifier':
+                    module_attr = ','.join(module_attr)
                 group_attr = getattr(as_group, attr)
                 # we do this because AWS and the module may return the same list
                 # sorted differently


### PR DESCRIPTION
This fixes a bug introduced in cf24e7d56c6981cf489f931e580f5d5673687401, and fixes #486.  That commit makes vpc_zone_identifier a list parameter.  It works fine on an initial creation of an ASG, but subsequent runs would fail:

```
TASK: [rolling_asg | create autoscale groups] *********************************
<fancyapp-rolling> REMOTE_MODULE ec2_asg health_check_type=ELB max_size=10 launch_config_name=rollingAMI-2 vpc_zone_identifier=subnet-6812da43 desired_capacity=5 min_size=5 region=us-east-1 name=rollingAMI
failed: [fancyapp-rolling] => {"failed": true}
msg: BotoServerError: 400 Bad Request
<ErrorResponse xmlns="http://autoscaling.amazonaws.com/doc/2011-01-01/">
  <Error>
    <Type>Sender</Type>
    <Code>ValidationError</Code>
    <Message>The subnet ID '['subnet-6812da43']' does not exist</Message>
  </Error>
  <RequestId>339b08e9-95cd-11e4-a3e5-5771b0508bdd</RequestId>
</ErrorResponse>
```

This patch fixes that problem.
