### PR TITLE
fix for allowing permissions on hard links and soft links + follow=yes

### DIFF
--- a/files/file.py
+++ b/files/file.py
@@ -218,7 +218,15 @@ def main():
             module.exit_json(path=path, changed=False)
 
     elif state == 'file':
+
         if state != prev_state:
+            if follow and prev_state == 'link':
+                # follow symlink and operate on original
+                path = os.readlink(path)
+                prev_state = get_state(path)
+                file_args['path'] = path
+
+        if prev_state not in ['file','hard']:
             # file is not absent and any other state is a conflict
             module.fail_json(path=path, msg='file (%s) is %s, cannot continue' % (path, prev_state))
 


### PR DESCRIPTION
corner case in which you specify state=file and want to change permissions  and used to fail if state was 'hard' or 'link', 'link' requires follow=yes to work, 'hard' is treated as 'file' and will set permissions.
