### PR TITLE
mysql_user module: Added support for 'REQUIRE SSL' grant option

### DIFF
--- a/database/mysql/mysql_user.py
+++ b/database/mysql/mysql_user.py
@@ -317,10 +317,7 @@ def privileges_revoke(cursor, user,host,db_table,grant_option):
     query = ["REVOKE ALL PRIVILEGES ON %s" % mysql_quote_identifier(db_table, 'table')]
     query.append("FROM %s@%s")
     query = ' '.join(query)
-    try:
-        cursor.execute(query, (user, host))
-    except Exception, e:
-        raise Exception("%s. Query=\"%s\"" % (str(e), query % (user, host)))
+    cursor.execute(query, (user, host))
 
 def privileges_grant(cursor, user,host,db_table,priv):
     # Escape '%' since mysql db.execute uses a format string and the
@@ -330,16 +327,11 @@ def privileges_grant(cursor, user,host,db_table,priv):
     query = ["GRANT %s ON %s" % (priv_string, mysql_quote_identifier(db_table, 'table'))]
     query.append("TO %s@%s")
     if 'GRANT' in priv:
-        query.append(" WITH GRANT OPTION")
+        query.append("WITH GRANT OPTION")
     if 'REQUIRESSL' in priv:
-        query.append(" REQUIRE SSL")
+        query.append("REQUIRE SSL")
     query = ' '.join(query)
-    try:
-        cursor.execute(query, (user, host))
-    except Exception, e:
-        raise Exception("%s. Query=\"%s\"" % (str(e), query % (user, host)))
-
-
+    cursor.execute(query, (user, host))
 
 def strip_quotes(s):
     """ Remove surrounding single or double quotes


### PR DESCRIPTION
##### Issue Type: Feature Pull Request
##### Ansible Version:

ansible 1.8 (devel 43eb821d3f) last updated 2015/01/07 20:16:03 (GMT +000)
  lib/ansible/modules/core: (detached HEAD db5668b84c) last updated 2015/01/07 20:16:14 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD 110250d344) last updated 2015/01/07 20:16:20 (GMT +000)
##### Environment:

N/A
##### Summary:

This pull request adds the ability to enforce SSL on user connections.  
##### Steps To Reproduce:

```
    - local_action: mysql_user
                user=foo
                host='%'
                password=bar
                state=present
                append_privs=yes
                login_host=mysqlhost
                login_user=mysqlroot
                login_password=mysqlpass
                priv='*.*:REQUIRESSL'
```
##### Expected Results:

When invoked as above then the mysql command "SHOW GRANTS FOR 'foo'@'%';" should return something like this:

GRANT USAGE ON *.* TO 'foo'@'%' IDENTIFIED BY PASSWORD <REDACTED> REQUIRE SSL
##### Actual Results:

Currently the mysql_user module has no way of adding the "REQUIRE SSL" option to users.
