### PR TITLE
user module: added HP-UX subclass

### DIFF
--- a/system/user.py
+++ b/system/user.py
@@ -1821,6 +1821,158 @@ class AIX(User):
 
 # ===========================================
 
+class HPUX(User):
+    """
+    This is a HP-UX User manipulation class.
+
+    This overrides the following methods from the generic class:-
+      - create_user()
+      - remove_user()
+      - modify_user()
+    """
+
+    platform = 'HP-UX'
+    distribution = None
+    SHADOWFILE = '/etc/shadow'
+
+    def create_user(self):
+        cmd = ['/usr/sam/lbin/useradd.sam']
+
+        if self.uid is not None:
+            cmd.append('-u')
+            cmd.append(self.uid)
+
+            if self.non_unique:
+                cmd.append('-o')
+
+        if self.group is not None:
+            if not self.group_exists(self.group):
+                self.module.fail_json(msg="Group %s does not exist" % self.group)
+            cmd.append('-g')
+            cmd.append(self.group)
+
+        if self.groups is not None and len(self.groups):
+            groups = self.get_groups_set()
+            cmd.append('-G')
+            cmd.append(','.join(groups))
+
+        if self.comment is not None:
+            cmd.append('-c')
+            cmd.append(self.comment)
+
+        if self.home is not None:
+            cmd.append('-d')
+            cmd.append(self.home)
+
+        if self.shell is not None:
+            cmd.append('-s')
+            cmd.append(self.shell)
+
+        if self.password is not None:
+            cmd.append('-p')
+            cmd.append(self.password)
+
+        if self.createhome:
+            cmd.append('-m')
+        else:
+            cmd.append('-M')
+
+        if self.system:
+            cmd.append('-r')
+
+        cmd.append(self.name)
+        return self.execute_command(cmd)
+
+    def remove_user(self):
+        cmd = ['/usr/sam/lbin/userdel.sam']
+        if self.force:
+            cmd.append('-F')
+        if self.remove:
+            cmd.append('-r')
+        cmd.append(self.name)
+        return self.execute_command(cmd)
+
+    def modify_user(self):
+        cmd = ['/usr/sam/lbin/usermod.sam']
+        info = self.user_info()
+        has_append = self._check_usermod_append()
+
+        if self.uid is not None and info[2] != int(self.uid):
+            cmd.append('-u')
+            cmd.append(self.uid)
+
+            if self.non_unique:
+                cmd.append('-o')
+
+        if self.group is not None:
+            if not self.group_exists(self.group):
+                self.module.fail_json(msg="Group %s does not exist" % self.group)
+            ginfo = self.group_info(self.group)
+            if info[3] != ginfo[2]:
+                cmd.append('-g')
+                cmd.append(self.group)
+
+        if self.groups is not None:
+            current_groups = self.user_group_membership()
+            groups_need_mod = False
+            groups = []
+
+            if self.groups == '':
+                if current_groups and not self.append:
+                    groups_need_mod = True
+            else:
+                groups = self.get_groups_set(remove_existing=False)
+                group_diff = set(current_groups).symmetric_difference(groups)
+
+                if group_diff:
+                    if self.append:
+                        for g in groups:
+                            if g in group_diff:
+                                if has_append:
+                                    cmd.append('-a')
+                                groups_need_mod = True
+                                break
+                    else:
+                        groups_need_mod = True
+
+            if groups_need_mod:
+                if self.append and not has_append:
+                    cmd.append('-A')
+                    cmd.append(','.join(group_diff))
+                else:
+                    cmd.append('-G')
+                    cmd.append(','.join(groups))
+
+
+        if self.comment is not None and info[4] != self.comment:
+            cmd.append('-c')
+            cmd.append(self.comment)
+
+        if self.home is not None and info[5] != self.home:
+            cmd.append('-d')
+            cmd.append(self.home)
+            if self.move_home:
+                cmd.append('-m')
+
+        if self.shell is not None and info[6] != self.shell:
+            cmd.append('-s')
+            cmd.append(self.shell)
+
+        if self.update_password == 'always' and self.password is not None and info[1] != self.password:
+            cmd.append('-p')
+            cmd.append(self.password)
+
+        # skip if no changes to be made
+        if len(cmd) == 1:
+            return (None, '', '')
+        elif self.module.check_mode:
+            return (0, '', '')
+
+        cmd.append(self.name)
+        return self.execute_command(cmd)
+
+# ===========================================
+
 def main():
     ssh_defaults = {
             'bits': '2048',


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

devel
##### Environment:

ansible running on RHEL 5 to manage HP-UX servers
##### Summary:

Fix for issue #603 

Added HP-UX subclass to user module to use *.sam instead 'useradd/usermod/userdel' commands:

```
/usr/sam/lbin/useradd.sam -> /usr/sbin/useradd
/usr/sam/lbin/usermod.sam -> /usr/sbin/usermod
/usr/sam/lbin/userdel.sam -> /usr/sbin/userdel
```

These files are links to standard binaries in /usr/sbin but have more options (like '-p' to change user password).
This patch works on HP-UX 11.23 and 11.31
##### Steps To Reproduce:

```
ansible server -m user -a 'name=user1 password="******"' 
```
##### Expected Results:

```
user1 created with provided password.
```
##### Actual Results:

```
server | FAILED >> {
    "failed": true,
    "msg": "Unrecognized Option 'p'\nUsage: /usr/sbin/useradd [-u <uid> [-o]] [-g <group>] [-G <group>[,<group...>]] [-d <dir>] [-s <shell>] [-c <comment>] [-m [-k <skel dir>]] [-f <inactive>] [-e <expire>] [-r <yes|no>] <login>\nUsage: /usr/sbin/useradd -D [-g <group>] [-b <base dir>] [-f <inactive>] [-e <expire>] [-r <yes|no>]\n",
    "name": "user1",
    "rc": 2
}
```
