### PR TITLE
Remove unused option in yum's repoquery call

### DIFF
--- a/packaging/os/yum.py
+++ b/packaging/os/yum.py
@@ -450,7 +450,7 @@ def repolist(module, repoq, qf="%{repoid}"):
 def list_stuff(module, conf_file, stuff):
 
     qf = "%{name}|%{epoch}|%{version}|%{release}|%{arch}|%{repoid}"
-    repoq = [repoquery, '--show-duplicates', '--plugins', '--quiet', '-q']
+    repoq = [repoquery, '--show-duplicates', '--plugins', '--quiet']
     if conf_file and os.path.exists(conf_file):
         repoq += ['-c', conf_file]
 
@@ -733,7 +733,7 @@ def ensure(module, state, pkgspec, conf_file, enablerepo, disablerepo,
     if not repoquery:
         repoq = None
     else:
-        repoq = [repoquery, '--show-duplicates', '--plugins', '--quiet', '-q']
+        repoq = [repoquery, '--show-duplicates', '--plugins', '--quiet']
 
     if conf_file and os.path.exists(conf_file):
         yum_basecmd += ['-c', conf_file]


### PR DESCRIPTION
Citing the man page:
       -q, --query
              For rpmquery compatibility, doesn't do anything.
