### PR TITLE
Remove unused code

### DIFF
--- a/packaging/os/yum.py
+++ b/packaging/os/yum.py
@@ -149,21 +149,13 @@ def log(msg):
     syslog.openlog('ansible-yum', 0, syslog.LOG_USER)
     syslog.syslog(syslog.LOG_NOTICE, msg)
 
-def yum_base(conf_file=None, cachedir=False):
+def yum_base(conf_file=None):
 
     my = yum.YumBase()
     my.preconf.debuglevel=0
     my.preconf.errorlevel=0
     if conf_file and os.path.exists(conf_file):
         my.preconf.fn = conf_file
-    if cachedir or os.geteuid() != 0:
-        if hasattr(my, 'setCacheDir'):
-            my.setCacheDir()
-        else:
-            cachedir = yum.misc.getCacheDir()
-            my.repos.setCacheDir(cachedir)
-            my.conf.cache = 0 
-
     return my
 
 def install_yum_utils(module):


### PR DESCRIPTION
There is no call to yum_base using 'cachedir' argument, so
while it work fine from a cursory look, that's useless code,
and so should be removed to clarify the code.
