### PR TITLE
distutils is not available on some non-Linux OS's

### DIFF
--- a/system/service.py
+++ b/system/service.py
@@ -106,7 +106,8 @@ import select
 import time
 import string
 
-if platform.system() == 'Linux':
+# The distutils module is not shipped with SUNWPython on Solaris.
+if platform.system() != 'SunOS':
     from distutils.version import LooseVersion
 
 class Service(object):

--- a/system/service.py
+++ b/system/service.py
@@ -106,7 +106,8 @@ import select
 import time
 import string
 
-from distutils.version import LooseVersion
+if platform.system() == 'Linux':
+    from distutils.version import LooseVersion
 
 class Service(object):
     """


### PR DESCRIPTION
##### Issue Type:  Bugfix Pull Request
##### Ansible Version:  tested on v1.8.2.  can reproduce on devel if required.
##### Environment:  Solaris
##### Summary:

The "service" module is broken on Solaris since 30d6713.

distutils.LooseService() is only referenced in the LinuxService class, this ensures it's only loaded on Linux platforms.

After this patch the service module works again on Solaris.
##### Steps To Reproduce:

Use the service module on a Solaris machine:

```
service: name=/network/ntp state=restarted
```
##### Expected Results:

ntp daemon is restarted
##### Actual Results:

```
ImportError: No module named distutils.version
```
