### PR TITLE
Potential fix for 640

### DIFF
--- a/cloud/amazon/elasticache.py
+++ b/cloud/amazon/elasticache.py
@@ -357,7 +357,9 @@ class ElastiCacheManager(object):
             'modifying': 'available',
             'deleting': 'gone'
         }
-
+        if self.status == awaited_status:
+            # No need to wait, we're already done
+            return
         if status_map[self.status] != awaited_status:
             msg = "Invalid awaited status. '%s' cannot transition to '%s'"
             self.module.fail_json(msg=msg % (self.status, awaited_status))


### PR DESCRIPTION
There's several ways we could end up with self.status = 'available' and calling _wait_for_status().  This closes an obvious and likely way that we could be ending up there (the task has already completed and the status has been updated to the new state) but it's possible that a different race condition is bringing us to this error.

Hopefully fixes #640
