### PR TITLE
rax_keypair / rax_network: Clean up some required argument logic

### DIFF
--- a/cloud/rackspace/rax_keypair.py
+++ b/cloud/rackspace/rax_keypair.py
@@ -104,7 +104,7 @@ def rax_keypair(module, name, public_key, state):
     keypair = {}
 
     if state == 'present':
-        if os.path.isfile(public_key):
+        if public_key and os.path.isfile(public_key):
             try:
                 f = open(public_key)
                 public_key = f.read()
@@ -143,7 +143,7 @@ def main():
     argument_spec = rax_argument_spec()
     argument_spec.update(
         dict(
-            name=dict(),
+            name=dict(required=True),
             public_key=dict(),
             state=dict(default='present', choices=['absent', 'present']),
         )

--- a/cloud/rackspace/rax_network.py
+++ b/cloud/rackspace/rax_network.py
@@ -65,10 +65,6 @@ except ImportError:
 
 
 def cloud_network(module, state, label, cidr):
-    for arg in (state, label, cidr):
-        if not arg:
-            module.fail_json(msg='%s is required for cloud_networks' % arg)
-
     changed = False
     network = None
     networks = []
@@ -79,6 +75,9 @@ def cloud_network(module, state, label, cidr):
                              'incorrectly capitalized region name.')
 
     if state == 'present':
+        if not cidr:
+            module.fail_json(msg='missing required arguments: cidr')
+
         try:
             network = pyrax.cloud_networks.find_network_by_label(label)
         except pyrax.exceptions.NetworkNotFound:
@@ -115,7 +114,7 @@ def main():
         dict(
             state=dict(default='present',
                        choices=['present', 'absent']),
-            label=dict(),
+            label=dict(required=True),
             cidr=dict()
         )
     )


### PR DESCRIPTION
This PR cleans up some required argument logic in `rax_keypair` and `rax_network` to properly indicate when an argument is required.
