### PR TITLE
ttl should always be used during a delete

### DIFF
--- a/cloud/amazon/route53.py
+++ b/cloud/amazon/route53.py
@@ -113,6 +113,7 @@ EXAMPLES = '''
       command: delete
       zone: foo.com
       record: "{{ rec.set.record }}"
+      ttl: "{{ rec.set.ttl }}"
       type: "{{ rec.set.type }}"
       value: "{{ rec.set.value }}"
 


### PR DESCRIPTION
As discussed on https://github.com/ansible/ansible-modules-core/issues/551 it wasn't obvious from the documentation that the ttl value had to match during a delete. The workaround is to just always specify the value (as you know it will be correct from the previous get command)
