### PR TITLE
Docker, extended checking of changes in named conainers

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -821,7 +821,7 @@ class DockerManager(object):
             if conf_in_container_port in container_ports:
                 container_host_info = container_ports[conf_in_container_port]
                 #nullcheck when port is exposed in Dockerfile but not mapped to host
-                if null != container_host_info:
+                if container_host_info is not None:
                     if "auto" == conf_host_port:
                         #auto assigned host port, any entry is sufficient
                         found = True
@@ -860,10 +860,10 @@ class DockerManager(object):
 
         configuration_envs = self.module.params.get('env') or {};
 
-        for k,v in existing_container_envs.iteritems():
-            if not k in configuration_envs:
-                return True
-            if v != configuration_envs[k]:
+        for k,v in configuration_envs.iteritems():
+            if not k in existing_container_envs:
+                 return True
+            if v != existing_container_envs[k]:
                 return True
 
         return False


### PR DESCRIPTION
Checking if running named container has changed (is different than defined in ansible playbook docker module entry). Checks image repository+name+tag, declared envs, mapped ports and mounted volumes.

In my current working environment, when i have over 15 different docker images and ansible playbooks to manage them, it saves a lot of time, when i'm only changing envs of container or change port mapping.

Repository+name+tag - must be exact match
Envs - running container must have all envs defined in playbook
Mapped ports - running container must have all mappings defined in playbook
Volumes - must be exact match
