### PR TITLE
now handles non string values for sysctl

### DIFF
--- a/system/sysctl.py
+++ b/system/sysctl.py
@@ -185,12 +185,20 @@ class SysctlModule(object):
     def _parse_value(self, value):
         if value is None:
             return ''
-        elif value.lower() in BOOLEANS_TRUE:
-            return '1'
-        elif value.lower() in BOOLEANS_FALSE:
-            return '0'
+        elif isinstance(value, bool):
+            if value:
+                return '1'
+            else:
+                return '0'
+        elif isinstance(value, basestring):
+            if value.lower() in BOOLEANS_TRUE:
+                return '1'
+            elif value.lower() in BOOLEANS_FALSE:
+                return '0'
+            else:
+                return value.strip()
         else:
-            return value.strip()
+            return value
 
     # ==============================================================
     #   SYSCTL COMMAND MANAGEMENT


### PR DESCRIPTION
should fix issues with passing value: # and other non string types.
