### PR TITLE
Handle the case where a Cloudformation stack rollback fails.

### DIFF
--- a/cloud/amazon/cloudformation.py
+++ b/cloud/amazon/cloudformation.py
@@ -185,6 +185,11 @@ def stack_operation(cfn, stack_name, operation):
                           events = map(str, list(stack.describe_events())),
                           output = 'Stack %s failed' % operation)
             break
+        elif '%s_ROLLBACK_FAILED' % operation == stack.stack_status:
+            result = dict(changed=True, failed=True,
+                          events = map(str, list(stack.describe_events())),
+                          output = 'Stack %s rollback failed' % operation)
+            break
         else:
             time.sleep(5)
     return result


### PR DESCRIPTION
In rare cases a stack rollback might fail.
Currently this will lead to ansible sleeping indefinitely.
This PR fixes this issue.
