### PR TITLE
Fixes docker.errors.DockerException: 'dns' parameter has no effect on create_container()...

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -726,12 +726,8 @@ class DockerManager(object):
                   'name':         self.module.params.get('name'),
                   'stdin_open':   self.module.params.get('stdin_open'),
                   'tty':          self.module.params.get('tty'),
-                  'dns':          self.module.params.get('dns'),
                   'volumes_from': self.module.params.get('volumes_from'),
                   }
-
-        if params['dns'] is not None:
-            self.ensure_capability('dns')
 
         if params['volumes_from'] is not None:
             self.ensure_capability('volumes_from')


### PR DESCRIPTION
... It has been moved to start()

IssueType: Bugfix Pull Request

Fixes docker error when creating container with custom dns settings.

```
Traceback (most recent call last):                                                                                                                           
  File "/home/ansible/.ansible/tmp/ansible-tmp-1421843714.61-185859873535519/docker", line 2654, in <module>                                                 
    main()                                                                                                                                                   
  File "/home/ansible/.ansible/tmp/ansible-tmp-1421843714.61-185859873535519/docker", line 1028, in main                                                     
    containers = manager.create_containers(1)                                                                                                                
  File "/home/ansible/.ansible/tmp/ansible-tmp-1421843714.61-185859873535519/docker", line 788, in create_containers                                         
    containers = do_create(count, params)                                                                                                                    
  File "/home/ansible/.ansible/tmp/ansible-tmp-1421843714.61-185859873535519/docker", line 754, in do_create                                                 
    result = self.client.create_container(**params)                                                                                                          
  File "/usr/lib/python2.6/site-packages/docker/client.py", line 540, in create_container                                                                    
    memswap_limit, cpuset                                                                                                                                    
  File "/usr/lib/python2.6/site-packages/docker/client.py", line 195, in _container_config                                                                   
    raise errors.DockerException(message.format('dns'))                                                                                                      
docker.errors.DockerException: 'dns' parameter has no effect on create_container(). It has been moved to start() 
```
