### PR TITLE
Remove --force-yes from install_deb options

### DIFF
--- a/packaging/os/apt.py
+++ b/packaging/os/apt.py
@@ -382,8 +382,6 @@ def install_deb(m, debs, cache, force, install_recommends, dpkg_options):
         options = ' '.join(["--%s"% x for x in dpkg_options.split(",")])
         if m.check_mode:
             options += " --simulate"
-        if force:
-            options += " --force-yes"
 
         cmd = "dpkg %s -i %s" % (options, " ".join(pkgs_to_install))
         rc, out, err = m.run_command(cmd)


### PR DESCRIPTION
Dpkg does not have the option "--force-yes", so don't supply it. Fixes https://github.com/ansible/ansible-modules-core/issues/327.
