### PR TITLE
Add support for the profile parameter when connecting to s3

### DIFF
--- a/cloud/amazon/s3.py
+++ b/cloud/amazon/s3.py
@@ -136,6 +136,12 @@ options:
     default: null
     aliases: []
     version_added: "1.3"
+  profile:
+    description:
+     - "Use a boto profile for authentication"
+    required: false
+    default: null
+    version_added: "1.9"
 
 requirements: [ "boto" ]
 author:


### PR DESCRIPTION
##### Issue Type:

“Bug Report”, “Bugfix Pull Request”
##### Ansible Version:

1.8.2
##### Summary:

The `profile` parameter is not used when connecting to the s3 module
##### Steps To Reproduce:

Run a playbook using the s3 module with the boto `profile` argument 

```
- name: EC2 Start Instances
  hosts: localhost
  gather_facts: no
  sudo: no
  tasks:
    - name: Create s3 buckets
      s3: profile=my_boto_profile region=eu-west-1 bucket=my-bucket action=create
```
##### Expected Results:

The module would use the given boto profile to connect and create the bucket
##### Actual Results:

```
Failed: [localhost] => (item={'region': 'eu-west-1', 'bucket': 'my-bucket'}) => {"failed": true, "item": {"bucket": "my-bucket", "region": "eu-west-1"}}
msg: No handler was ready to authenticate. 1 handlers were checked. ['HmacAuthV1Handler'] Check your credentials
```

This depends on the https://github.com/ansible/ansible/pull/10083 PR to be merged
