### PR TITLE
postgresql_privs: Fix quoting of function identifiers

### DIFF
--- a/database/postgresql/postgresql_privs.py
+++ b/database/postgresql/postgresql_privs.py
@@ -474,10 +474,13 @@ class Connection(object):
         if obj_type == 'group':
             set_what = ','.join(pg_quote_identifier(i, 'role') for i in obj_ids)
         else:
+            # function types are already quoted above
+            if obj_type != 'function':
+                obj_ids = [pg_quote_identifier(i, 'table') for i in obj_ids]
             # Note: obj_type has been checked against a set of string literals
             # and privs was escaped when it was parsed
             set_what = '%s ON %s %s' % (','.join(privs), obj_type,
-                                        ','.join(pg_quote_identifier(i, 'table') for i in obj_ids))
+                                        ','.join(obj_ids))
 
         # for_whom: SQL-fragment specifying for whom to set the above
         if roles == 'PUBLIC':


### PR DESCRIPTION
For `type=function`, there is already specific quoting code further up the function. Input like `objs=function_name(int:varchar)` is correctly transformed into `"schema_name"."function_name"(int,varchar)`.

Quoting again with `pg_quote_identifier` breaks with "User escaped identifiers must escape extra quotes" and is unnecessary, so removing in this PR.
