### PR TITLE
Retry apt cache updates

### DIFF
--- a/packaging/os/apt.py
+++ b/packaging/os/apt.py
@@ -706,7 +706,15 @@ def main():
                         updated_cache_time = int(time.mktime(mtimestamp.timetuple()))
 
             if cache_valid is not True:
-                cache.update()
+                for retry in xrange(3):
+                    try:
+                        cache.update()
+                        break
+                    except apt.cache.FetchFailedException:
+                        pass
+                else:
+                    #out of retries, pass on the exception
+                    raise
                 cache.open(progress=None)
                 updated_cache = True
                 updated_cache_time = int(time.mktime(now.timetuple()))


### PR DESCRIPTION
##### Issue Type: Feature Pull Request
##### Ansible Version: Devel
##### Environment: N/A
##### Summary: Apt cache updates sometimes fail with hashsum mismatch, add an option to retry in that case.
##### Steps To Reproduce: Do an apt cache update across a fleet of machines
##### Expected Results: Apt cache update succeeds
##### Actual Results: Sometimes, some machines fail with a hashsum mismatch related error.

For example:

```
16:53:29 TASK: [dev-packages | Update package cache] *********************************** 
16:53:50 failed: [node24] => {"failed": true, "parsed": false}
16:53:50 invalid output was: Traceback (most recent call last):
16:53:50   File "<stdin>", line 1907, in <module>
16:53:50   File "<stdin>", line 507, in main
16:53:50   File "/usr/lib/python2.7/dist-packages/apt/cache.py", line 440, in update
16:53:50     raise FetchFailedException(e)
16:53:50 apt.cache.FetchFailedException: W:Failed to fetch http://10.127.52.2:3142/ubuntu/dists/trusty-updates/universe/i18n/Translation-en  Hash Sum mismatch
16:53:50 , E:Some index files failed to download. They have been ignored, or old ones used instead.
```

The repo in the above link is valid and the update succeeded on other servers.
