### PR TITLE
check keys is in dim2 before evaluating

### DIFF
--- a/cloud/amazon/ec2_metric_alarm.py
+++ b/cloud/amazon/ec2_metric_alarm.py
@@ -190,7 +190,7 @@ def create_metric_alarm(connection, module):
         for keys in dim1:
             if not isinstance(dim1[keys], list):
                 dim1[keys] = [dim1[keys]]
-            if dim1[keys] != dim2[keys]:
+            if keys not in dim2 or dim1[keys] != dim2[keys]:
                 changed=True
                 setattr(alarm, 'dimensions', dim1)
 


### PR DESCRIPTION
If the alarm is set up to use different keys, this check would fail. We changed the key from `DBInstance-Identifier` to `DBInstanceIdentifier` and this error was caught.

```
failed: [localhost] => (item={'comparison': '<', 'alarm_actions': [u'arn:aws:sns:us-east-1:1234567890:alerts'], 'description': 'Send message on low freeable memory', 'evaluation_periods': 10, 'metric': 'FreeableMemory', 'namespace': 'AWS/RDS', 'period': 60, 'name': u'rds-notification-low-freeable-memory-prod', 'statistic': 'Minimum', 'threshold': 500000000, 'unit': 'Bytes', 'dimensions': {'DBInstanceIdentifier': u'prod-rds'}}) => {"failed": true, "item": {"alarm_actions": ["arn:aws:sns:us-east-1:1234567890:alerts"], "comparison": "<", "description": "Send message on low freeable memory", "dimensions": {"DBInstanceIdentifier": "-prod-rds"}, "evaluation_periods": 10, "metric": "FreeableMemory", "name": "rds-notification-low-freeable-memory-prod", "namespace": "AWS/RDS", "period": 60, "statistic": "Minimum", "threshold": 500000000, "unit": "Bytes"}, "parsed": false}
invalid output was: Traceback (most recent call last):
  File "/var/lib/jenkins/.ansible/tmp/ansible-tmp-1422566742.32-191017998124524/ec2_metric_alarm", line 1817, in <module>
    main()
  File "/var/lib/jenkins/.ansible/tmp/ansible-tmp-1422566742.32-191017998124524/ec2_metric_alarm", line 1813, in main
    create_metric_alarm(connection, module)
  File "/var/lib/jenkins/.ansible/tmp/ansible-tmp-1422566742.32-191017998124524/ec2_metric_alarm", line 1728, in create_metric_alarm
    if dim1[keys] != dim2[keys]:
KeyError: u'DBInstanceIdentifier'
```

Tested and confirmed that this fixes the issue.
