### PR TITLE
module cloudformation: include a CFN stack's resources in the result

### DIFF
--- a/cloud/amazon/cloudformation.py
+++ b/cloud/amazon/cloudformation.py
@@ -292,6 +292,16 @@ def main():
         for output in stack.outputs:
             stack_outputs[output.key] = output.value
         result['stack_outputs'] = stack_outputs
+        stack_resources = [] 
+        for res in cfn.list_stack_resources(stack_name):
+            stack_resources.append({
+                "last_updated_time": res.last_updated_time,
+                "logical_resource_id": res.logical_resource_id,
+                "physical_resource_id": res.physical_resource_id,
+                "status": res.resource_status,
+                "status_reason": res.resource_status_reason,
+                "resource_type": res.resource_type })
+        result['stack_resources'] = stack_resources
 
     # absent state is different because of the way delete_stack works.
     # problem is it it doesn't give an error if stack isn't found


### PR DESCRIPTION
WIth this change, when registering the results of a task which uses the Cloudformation module, one can access the resources as a list.

Results: 

```
TASK: [route53-healthcheck | CloudFormation Results] **************************
ok: [iv-staging-1.us-east-1.lincx.la] => {
    "result_cfn": {
        "changed": true,
        "events": [
            "StackEvent AWS::CloudFormation::Stack healthcheck-staging CREATE_COMPLETE",
            "StackEvent AWS::Route53::HealthCheck mywebsite_A CREATE_COMPLETE",
            "StackEvent AWS::Route53::HealthCheck mywebsite_B CREATE_COMPLETE",
            "StackEvent AWS::CloudFormation::Stack healthcheck-staging CREATE_IN_PROGRESS"
        ],                                                                                                                   
        "invocation": {
            "module_args": "",
            "module_name": "cloudformation"
        },
        "output": "Stack CREATE complete",
        "stack_outputs": {},
        "stack_resources": [
            { 
                "logical_resource_id": "mywebsite_A",
                "last_updated_time": null,
                "physical_resource_id": "3e123449-dead-486b-910d-ff676f4eaab2",
                "resource_type": "AWS::Route53::HealthCheck",
                "status": "CREATE_COMPLETE",
                "status_reason": ""
            },
            {
                "logical_resource_id": "mywebsite_B",
                "last_updated_time": null,
                "physical_resource_id": "12347945-beef-4cc1-a5a5-43ad8c595a69",
                "resource_type": "AWS::Route53::HealthCheck",
                "status": "CREATE_COMPLETE",
                "status_reason": ""
            },
        ]
    }
}
```
