### PR TITLE
Fixed broken volumes_from for client API >= 1.10

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -731,6 +731,8 @@ class DockerManager(object):
                   'dns':          self.module.params.get('dns'),
                   'volumes_from': self.module.params.get('volumes_from'),
                   }
+        if docker.utils.compare_version('1.10', self.client.version()['ApiVersion']) >= 0:
+            params['volumes_from'] = ""
 
         if params['dns'] is not None:
             self.ensure_capability('dns')


### PR DESCRIPTION
This patch fixes "volumes_from" parameter which was broken for API >= 1.10
According bug https://github.com/ansible/ansible-modules-core/issues/693
