### PR TITLE
Name parameter should not be marked as mandatory

### DIFF
--- a/system/cron.py
+++ b/system/cron.py
@@ -46,7 +46,7 @@ options:
     description:
       - Description of a crontab entry.
     default: null
-    required: true
+    required: false
   user:
     description:
       - The specific user whose crontab should be modified.
@@ -397,7 +397,7 @@ def main():
 
     module = AnsibleModule(
         argument_spec = dict(
-            name=dict(required=True),
+            name=dict(required=False),
             user=dict(required=False),
             job=dict(required=False),
             cron_file=dict(required=False),


### PR DESCRIPTION
The `name` parameter should only be required when performing an install. When uninstalling, requiring the parameter actually makes uninstalling a cron_file impossible.

I have only made the parameter optional for the following reasons:
- In the case of an install, a check is already being performed to make sure that the parameter is provided (https://github.com/aseigneurin/ansible-modules-core/blob/devel/system/cron.py#L459)
- In the case of an uninstall, the name param should _not_ be set, as per the doc (https://github.com/aseigneurin/ansible-modules-core/blob/devel/system/cron.py#L142) and per the code (https://github.com/aseigneurin/ansible-modules-core/blob/devel/system/cron.py#L479)
