### PR TITLE
Quantum network

### DIFF
--- a/cloud/openstack/quantum_network.py
+++ b/cloud/openstack/quantum_network.py
@@ -50,7 +50,12 @@ options:
      default: 'yes'
    tenant_name:
      description:
-        - The name of the tenant for whom the network is created
+        - The name of the tenant for whom the network is created. Mutually exclusive with tenant_id
+     required: false
+     default: None
+   tenant_id:
+     description:
+        - The id of the tenant for whom the network is created. Mutually exclusive with tenant_name
      required: false
      default: None
    auth_url:
@@ -234,6 +239,7 @@ def main():
     argument_spec.update(dict(
             name                            = dict(required=True),
             tenant_name                     = dict(default=None),
+            tenant_id                       = dict(default=None),
             provider_network_type           = dict(default=None, choices=['local', 'vlan', 'flat', 'gre']),
             provider_physical_network       = dict(default=None),
             provider_segmentation_id        = dict(default=None),
@@ -254,7 +260,10 @@ def main():
 
     neutron = _get_neutron_client(module, module.params)
 
-    _set_tenant_id(module)
+    if module.params['tenant_id']:
+        _os_tenant_id = module.params['tenant_id']
+    else:
+        _set_tenant_id(module)
 
     if module.params['state'] == 'present':
         network_id = _get_net_id(neutron, module)

--- a/cloud/openstack/quantum_network.py
+++ b/cloud/openstack/quantum_network.py
@@ -203,6 +203,12 @@ def _create_network(module, neutron):
         'shared':                    module.params.get('shared'),
         'admin_state_up':            module.params.get('admin_state_up'),
     }
+    if _os_tenant_id == _os_keystone.tenant_id:
+        network.pop('tenant_id', None)
+
+    if not module.params['router_external']:
+        # router:external requires admin rights if specified. Remove if default.
+        network.pop('router:external', None)
 
     if module.params['provider_network_type'] == 'local':
         network.pop('provider:physical_network', None)
@@ -261,6 +267,7 @@ def main():
     neutron = _get_neutron_client(module, module.params)
 
     if module.params['tenant_id']:
+        global _os_tenant_id
         _os_tenant_id = module.params['tenant_id']
     else:
         _set_tenant_id(module)
@@ -285,4 +292,3 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.openstack import *
 main()
-

--- a/cloud/openstack/quantum_network.py
+++ b/cloud/openstack/quantum_network.py
@@ -58,6 +58,7 @@ options:
         - The id of the tenant for whom the network is created. Mutually exclusive with tenant_name
      required: false
      default: None
+     version_added: "1.9"
    auth_url:
      description:
         - The keystone url for authentication

--- a/cloud/openstack/quantum_router.py
+++ b/cloud/openstack/quantum_router.py
@@ -73,6 +73,12 @@ options:
         - Name of the tenant for which the router has to be created, if none router would be created for the login tenant.
      required: false
      default: None
+   tenant_id:
+     description:
+        - The id of the tenant for which the router has to be created, if none router would be created for the login tenant.
+     required: false
+     default: None
+     version_added: "1.9"
    admin_state_up:
      description:
         - desired admin state of the created router .

--- a/cloud/openstack/quantum_router.py
+++ b/cloud/openstack/quantum_router.py
@@ -179,13 +179,18 @@ def main():
     argument_spec.update(dict(
         name                            = dict(required=True),
         tenant_name                     = dict(default=None),
+        tenant_id                     = dict(default=None),
         state                           = dict(default='present', choices=['absent', 'present']),
         admin_state_up                  = dict(type='bool', default=True),
     ))
     module = AnsibleModule(argument_spec=argument_spec)
 
     neutron = _get_neutron_client(module, module.params)
-    _set_tenant_id(module)
+    if module.params['tenant_id']:
+        global _os_tenant_id
+        _os_tenant_id = module.params['tenant_id']
+    else:
+        _set_tenant_id(module)
 
     if module.params['state'] == 'present':
         router_id = _get_router_id(module, neutron)
@@ -207,4 +212,3 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.openstack import *
 main()
-

--- a/cloud/openstack/quantum_router_interface.py
+++ b/cloud/openstack/quantum_router_interface.py
@@ -77,6 +77,11 @@ options:
         - Name of the tenant whose subnet has to be attached.
      required: false
      default: None
+   tenant_name:
+     description:
+        - ID of the tenant whose subnet has to be attached.
+     required: false
+     default: None
 requirements: ["quantumclient", "keystoneclient"]
 '''
 
@@ -213,12 +218,17 @@ def main():
             router_name                     = dict(required=True),
             subnet_name                     = dict(required=True),
             tenant_name                     = dict(default=None),
+            tenant_id                       = dict(default=None),
             state                           = dict(default='present', choices=['absent', 'present']),
     ))
     module = AnsibleModule(argument_spec=argument_spec)
 
     neutron = _get_neutron_client(module, module.params)
-    _set_tenant_id(module)
+    if module.params['tenant_id']:
+        global _os_tenant_id
+        _os_tenant_id = module.params['tenant_id']
+    else:
+        _set_tenant_id(module)
 
     router_id = _get_router_id(module, neutron)
     if not router_id:
@@ -246,4 +256,3 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.openstack import *
 main()
-

--- a/cloud/openstack/quantum_router_interface.py
+++ b/cloud/openstack/quantum_router_interface.py
@@ -77,11 +77,12 @@ options:
         - Name of the tenant whose subnet has to be attached.
      required: false
      default: None
-   tenant_name:
+   tenant_id:
      description:
         - ID of the tenant whose subnet has to be attached.
      required: false
      default: None
+     version_added: "1.9"
 requirements: ["quantumclient", "keystoneclient"]
 '''
 

--- a/cloud/openstack/quantum_subnet.py
+++ b/cloud/openstack/quantum_subnet.py
@@ -83,6 +83,11 @@ options:
         - The name of the tenant for whom the subnet should be created
      required: false
      default: None
+   tenant_id:
+     description:
+        - The id of the tenant for whom the subnet should be created
+     required: false
+     default: None
    ip_version:
      description:
         - The IP version of the subnet 4 or 6
@@ -258,6 +263,7 @@ def main():
             network_name            = dict(required=True),
             cidr                    = dict(required=True),
             tenant_name             = dict(default=None),
+            tenant_id               = dict(default=None),
             state                   = dict(default='present', choices=['absent', 'present']),
             ip_version              = dict(default='4', choices=['4', '6']),
             enable_dhcp             = dict(default='true', type='bool'),
@@ -268,7 +274,11 @@ def main():
     ))
     module = AnsibleModule(argument_spec=argument_spec)
     neutron = _get_neutron_client(module, module.params)
-    _set_tenant_id(module)
+    if module.params['tenant_id']:
+        global _os_tenant_id
+        _os_tenant_id = module.params['tenant_id']
+    else:
+        _set_tenant_id(module)
     if module.params['state'] == 'present':
         subnet_id = _get_subnet_id(module, neutron)
         if not subnet_id:
@@ -288,4 +298,3 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.openstack import *
 main()
-

--- a/cloud/openstack/quantum_subnet.py
+++ b/cloud/openstack/quantum_subnet.py
@@ -88,6 +88,7 @@ options:
         - The id of the tenant for whom the subnet should be created
      required: false
      default: None
+     version_added: "1.9"
    ip_version:
      description:
         - The IP version of the subnet 4 or 6


### PR DESCRIPTION
Allows to directly set the tenant id instead of discovering it by querying keystone.

This is useful on deployments where access to the keystone admin API is restricted.
