### PR TITLE
Add ec2 instance tags and groups info

### DIFF
--- a/cloud/amazon/ec2.py
+++ b/cloud/amazon/ec2.py
@@ -590,7 +590,9 @@ def get_instance_info(inst):
                      'root_device_type': inst.root_device_type,
                      'root_device_name': inst.root_device_name,
                      'state': inst.state,
-                     'hypervisor': inst.hypervisor}
+                     'hypervisor': inst.hypervisor,
+                     'tags': inst.tags,
+                     'groups': {group.id: group.name for group in inst.groups}}
     try:
         instance_info['virtualization_type'] = getattr(inst,'virtualization_type')
     except AttributeError:


### PR DESCRIPTION
### Issue Type

Feature
### Summary

Just leaving these details in would make it easier to setup `add_host` tasks to mimic `ec2.py` dynamic inventory or other tasks using registered variables from the `ec2` module.
