### PR TITLE
Add service option to avoid failure on missing service

### DIFF
--- a/system/service.py
+++ b/system/service.py
@@ -72,6 +72,14 @@ options:
         description:
         - Additional arguments provided on the command line
         aliases: [ 'args' ]
+    must_exist:
+        required: false
+        default: true
+        version_added: "1.9"
+        description:
+        - Avoid a module failure if the named service does not exist. Useful
+          for opportunistically starting/stopping/restarting a list of
+          potential services.
 '''
 
 EXAMPLES = '''
@@ -95,6 +103,9 @@ EXAMPLES = '''
 
 # Example action to restart network service for interface eth0
 - service: name=network state=restarted args=eth0
+
+# Example action to restart nova-compute if it exists
+- service: name=nova-compute state=restarted must_exist=no
 '''
 
 import platform
@@ -465,7 +476,11 @@ class LinuxService(Service):
                 self.enable_cmd = location['chkconfig']
 
         if self.enable_cmd is None:
-            self.module.fail_json(msg="no service or tool found for: %s" % self.name)
+            if self.module.params['must_exist']:
+                self.module.fail_json(msg="no service or tool found for: %s" % self.name)
+            else:
+                # exiting without change on non-existent service
+                self.module.exit_json(changed=False, exists=False)
 
         # If no service control tool selected yet, try to see if 'service' is available
         if not self.svc_cmd and location.get('service', False):
@@ -473,7 +488,11 @@ class LinuxService(Service):
 
         # couldn't find anything yet
         if self.svc_cmd is None and not self.svc_initscript:
-            self.module.fail_json(msg='cannot find \'service\' binary or init script for service,  possible typo in service name?, aborting')
+            if self.module.params['must_exist']:
+                self.module.fail_json(msg='cannot find \'service\' binary or init script for service,  possible typo in service name?, aborting')
+            else:
+                # exiting without change on non-existent service
+                self.module.exit_json(changed=False, exists=False)
 
         if location.get('initctl', False):
             self.svc_initctl = location['initctl']
@@ -1361,6 +1380,7 @@ def main():
             enabled = dict(type='bool'),
             runlevel = dict(required=False, default='default'),
             arguments = dict(aliases=['args'], default=''),
+            must_exist = dict(type='bool', default=True),
         ),
         supports_check_mode=True
     )


### PR DESCRIPTION
This adds a must_exist option to the service module, which gives callers the
ability to be tolerant to services that do not exist. This allows for
opportunistic manipulation of a list of services if they happen to exist on the
host. While failed_when could be used, it's difficult to track all the
different error strings that might come from various service tools regarding a
missing service.
