### PR TITLE
Don't use 'tenancy' in ec2 spot requests

### DIFF
--- a/cloud/amazon/ec2.py
+++ b/cloud/amazon/ec2.py
@@ -834,7 +834,8 @@ def create_instances(module, ec2, override_count=None):
             if ebs_optimized:
               params['ebs_optimized'] = ebs_optimized
               
-            if tenancy:
+            # 'tenancy' always has a default value, but it is not a valid parameter for spot instance resquest
+            if not spot_price:
               params['tenancy'] = tenancy
 
             if boto_supports_profile_name_arg(ec2):


### PR DESCRIPTION
The problem was introduced in commit f5789e8. 'tenancy' is a parameter of ec2.run_instances, but not in ec2.request_spot_instances. So it was breaking the support for spot requests.

This pull request is based on #597, which is fixing a different problem with ec2 spot requests.
