### PR TITLE
Add support for template_url in the cloudformation module.

### DIFF
--- a/cloud/amazon/cloudformation.py
+++ b/cloud/amazon/cloudformation.py
@@ -301,7 +301,7 @@ def main():
         try:
             cfn.update_stack(stack_name, parameters=template_parameters_tup,
                              template_body=template_body,
-                             template_url=module.params['template_url'],
+                             template_url=template_url,
                              stack_policy_body=stack_policy_body,
                              disable_rollback=disable_rollback,
                              capabilities=['CAPABILITY_IAM'])


### PR DESCRIPTION
Large templates can't be uploaded through the 'normal' template_body, and have to be uploaded manually to S3 before processing them in Cloudformation. This pull request adds support for S3 urls next to the local templates.
