### PR TITLE
Add alias support to Route53 module.

### DIFF
--- a/cloud/amazon/ec2_elb_lb.py
+++ b/cloud/amazon/ec2_elb_lb.py
@@ -328,7 +328,9 @@ class ElbManager(object):
                 'security_group_ids': check_elb.security_groups,
                 'status': self.status,
                 'subnets': self.subnets,
-                'scheme': check_elb.scheme
+                'scheme': check_elb.scheme,
+                'hosted_zone_name': check_elb.canonical_hosted_zone_name,
+                'hosted_zone_id': check_elb.canonical_hosted_zone_name_id
             }
 
             if check_elb.health_check:


### PR DESCRIPTION
This is the rebase that the pull request https://github.com/ansible/ansible-modules-core/pull/167 needs.

Code is largely the same, I was in need of this feature and that pull request had clearly stagnated itself. After setting it up in my fork and testing it decided I'd submit it as it seemed a rebase was all that was holding things up.

A summary of why this exists:

A pull request was made to the `ansible` repo before `ansible-modules-core` was split out, intending to add alias support to the route53 module allowing for `A records` to point to an ELB, it makes ELB return a hosted zone id as well (which is required when making an alias). Someone made a pull request directly copying that code to `ansible-modules-core` conversation died out on Nov 24th of 2014 leaving the pull request in need of a rebase and stuck open.

Obviously credit is due to original creator.

I will maintain this as is needed until it gets merged in.
