### PR TITLE
use is-enabled to check systemd service status.

### DIFF
--- a/system/service.py
+++ b/system/service.py
@@ -478,6 +478,12 @@ class LinuxService(Service):
         if location.get('initctl', False):
             self.svc_initctl = location['initctl']
 
+    def get_systemd_service_enabled(self):
+        (rc, out, err) = self.execute_command("%s is-enabled %s" % (self.enable_cmd, self.__systemd_unit,))
+        if rc == 0:
+            return True
+        return False
+
     def get_systemd_status_dict(self):
         (rc, out, err) = self.execute_command("%s show %s" % (self.enable_cmd, self.__systemd_unit,))
         if rc != 0:
@@ -692,12 +698,11 @@ class LinuxService(Service):
                 action = 'disable'
 
             # Check if we're already in the correct state
-            d = self.get_systemd_status_dict()
-            if "UnitFileState" in d:
-                if self.enable and d["UnitFileState"] == "enabled":
-                    self.changed = False
-                elif not self.enable and d["UnitFileState"] == "disabled":
-                    self.changed = False
+            service_enabled = self.get_systemd_service_enabled()
+            if self.enable and service_enabled:
+                self.changed = False
+            elif not self.enable and not service_enabled:
+                self.changed = False
             elif not self.enable:
                 self.changed = False
 


### PR DESCRIPTION
The service module fails to correctly report a SysV service's enabled state on a system that uses systemd. The issue is that this breaks idempotence of the service module. 

For example:
I have SysV service sensu-client enabled on a Centos 7 host (ripper.lan)

```
sensu-client    0:off   1:off   2:on    3:on    4:on    5:on    6:off
```

Setting the already enabled service to be enabled reports a change:

```
$ ansible ripper.lan -m service -a 'name=sensu-client enabled=yes' -s
ripper.lan | success >> {
    "changed": true,
    "enabled": true,
    "name": "sensu-client"
}
```

The reason is that it checks the enabled state by looking at the value of 'UnitFileState' returned from 'systemctl show &lt;service&gt;' which isn't returned for SysV services.

This PR makes use of 'systemctl is-enabled &lt;service&gt;' which works for both systemd and SysV configured services.

Only tested on Centos 7 implementation of systemd.
