### PR TITLE
Added pip example installing from local tarball

### DIFF
--- a/packaging/language/pip.py
+++ b/packaging/language/pip.py
@@ -113,6 +113,9 @@ EXAMPLES = '''
 # Install (MyApp) using one of the remote protocols (bzr+,hg+,git+,svn+). You do not have to supply '-e' option in extra_args.
 - pip: name='svn+http://myrepo/svn/MyApp#egg=MyApp'
 
+# Install (MyApp) from local tarball
+- pip: name='file:///path/to/MyApp.tar.gz'
+
 # Install (Bottle) into the specified (virtualenv), inheriting none of the globally installed modules
 - pip: name=bottle virtualenv=/my_app/venv
 


### PR DESCRIPTION
The website docs currently do not indicate that it is possible to use the 'pip' module to install a local tarball.
