### PR TITLE
Fix subversion module for repos with svn:externals files

### DIFF
--- a/source_control/subversion.py
+++ b/source_control/subversion.py
@@ -153,11 +153,10 @@ class Subversion(object):
 
     def has_local_mods(self):
         '''True if revisioned files have been added or modified. Unrevisioned files are ignored.'''
-        lines = self._exec(["status", self.dest])
-        # Match only revisioned files, i.e. ignore status '?'.
-        regex = re.compile(r'^[^?]')
+        lines = self._exec(["status", "--quiet", self.dest])
+        # The --quiet option will return only modified files.
         # Has local mods if more than 0 modifed revisioned files.
-        return len(filter(regex.match, lines)) > 0
+        return len(filter(len, lines)) > 0
 
     def needs_update(self):
         curr, url = self.get_revision()


### PR DESCRIPTION
When a SVN repository has some svn:externals properties, the module always report changes.

Long story :
When a SVN repository has some svn:externals properties, "svn status" will report files with the X attribute, and lines will be added at the end to list externals statuses with a text looking like
"Performing status on external item at ....".
Such lines were counted as a local modification by the regex, and the module returned a change, even though they were none.

To have a clean (and parsable) "svn status" output, it is recommended to use the --quiet option. The externals will only appear if they have been modified. With this option on, it seems even safer to consider there are local modifications when "svn status" outputs anything.
