### PR TITLE
added missing docs on connection_timeout for wait_for

### DIFF
--- a/utilities/logic/wait_for.py
+++ b/utilities/logic/wait_for.py
@@ -63,6 +63,11 @@ options:
       - maximum number of seconds to wait for
     required: false
     default: 300
+  connect_timeout:
+    description:
+      - maximum number of seconds to wait for a connection to happen before closing and retrying
+    required: false
+    default: 5
   delay:
     description:
       - number of seconds to wait before starting to poll


### PR DESCRIPTION
this is different from the global timeout and regulates how many times you'll try to connect and for how long withing the global timeout (when using a port).
