### PR TITLE
Fixed Documentation issue concerning file mode 

### DIFF
--- a/files/file.py
+++ b/files/file.py
@@ -88,6 +88,7 @@ options:
 '''
 
 EXAMPLES = '''
+# change file ownership, group and mode. When specifying mode using octal numbers, first digit should always be 0.
 - file: path=/etc/foo.conf owner=foo group=foo mode=0644
 - file: src=/file/to/link/to dest=/path/to/symlink owner=foo group=foo state=link
 - file: src=/tmp/{{ item.path }} dest={{ item.dest }} state=link


### PR DESCRIPTION
File mode when specified using numerical value should always proceed with a trailing 0. Like 0644
