### PR TITLE
Fix issue #793: mysql_db: for state={absent,present} connections to database mysql fail for users other than root

### DIFF
--- a/database/mysql/mysql_db.py
+++ b/database/mysql/mysql_db.py
@@ -312,7 +312,7 @@ def main():
             module.fail_json(msg="with state=%s target is required" % (state))
         connect_to_db = db
     else:
-        connect_to_db = 'mysql'
+        connect_to_db = ''
     try:
         if socket:
             try:


### PR DESCRIPTION
When dropping or creating the database specified via the name parameter, the module falls back to connecting to database mysql.  Connections to this database and read access on the tables in it are usually reserved only for the root user, and privileges on it aren't ordinarily granted to non-root users.  When the remote user or sudo user or login_user is not root, the task fails due to the failed database connection.  MySQLdb.connect() allows the connection to proceed when its db argument is either not passed or passed with the empty string as its value.  The simplest fix seems to be to let the database fall back to the empty string via the connect_to_db variable in main().
