### PR TITLE
fetch: fix the flat parameter description

### DIFF
--- a/files/fetch.py
+++ b/files/fetch.py
@@ -45,10 +45,10 @@ options:
   flat:
     version_added: "1.2"
     description:
-      Allows you to override the default behavior of prepending hostname/path/to/file to
-      the destination.  If dest ends with '/', it will use the basename of the source
-      file, similar to the copy module.  Obviously this is only handy if the filenames
-      are unique.
+      - Allows you to override the default behavior of prepending
+        hostname/path/to/file to the destination.  If dest ends with '/', it
+        will use the basename of the source file, similar to the copy module.
+        Obviously this is only handy if the filenames are unique.
 requirements: []
 author: Michael DeHaan
 '''


### PR DESCRIPTION
ansible-doc expects the value of the description field to be a list,
otherwise the output is not correct. This patch updates the flat
description to be a list.
