### PR TITLE
Make behavior consistent when using 'creates' option with modules

### DIFF
--- a/network/basics/uri.py
+++ b/network/basics/uri.py
@@ -381,7 +381,7 @@ def main():
         # of uri executions.
         creates = os.path.expanduser(creates)
         if os.path.exists(creates):
-            module.exit_json(stdout="skipped, since %s exists" % creates, skipped=True, changed=False, stderr=False, rc=0)
+            module.exit_json(stdout="skipped, since %s exists" % creates, changed=False, stderr=False, rc=0)
 
     if removes is not None:
         # do not run the command if the line contains removes=filename
@@ -389,7 +389,7 @@ def main():
         # of uri executions.
         v = os.path.expanduser(removes)
         if not os.path.exists(removes):
-            module.exit_json(stdout="skipped, since %s does not exist" % removes, skipped=True, changed=False, stderr=False, rc=0)
+            module.exit_json(stdout="skipped, since %s does not exist" % removes, changed=False, stderr=False, rc=0)
 
 
     # httplib2 only sends authentication after the server asks for it with a 401.


### PR DESCRIPTION
There are three distinct behaviors in use with modules that have "creates" or "removes" arguments:

command module, shell module:
- changed=False

unarchive module, uri module:
- changed=False and skipped=True

script module:
- skipped=True

This pull request makes these behaviors consistent with the command and shell modules, reserving 'skipped' status for actions which are truly not evaluated. 
