### PR TITLE
Revert "Don't use 'tenancy' in ec2 spot requests"

### DIFF
--- a/cloud/amazon/ec2.py
+++ b/cloud/amazon/ec2.py
@@ -834,8 +834,7 @@ def create_instances(module, ec2, override_count=None):
             if ebs_optimized:
               params['ebs_optimized'] = ebs_optimized
               
-            # 'tenancy' always has a default value, but it is not a valid parameter for spot instance resquest
-            if not spot_price:
+            if tenancy:
               params['tenancy'] = tenancy
 
             if boto_supports_profile_name_arg(ec2):


### PR DESCRIPTION
Reverts ansible/ansible-modules-core#753
