### PR TITLE
List the name servers of a zone. Fixes #801

### DIFF
--- a/cloud/amazon/route53.py
+++ b/cloud/amazon/route53.py
@@ -248,7 +248,13 @@ def main():
                 module.exit_json(changed=False)
 
     if command_in == 'get':
-        module.exit_json(changed=False, set=record)
+        if type_in == 'NS':
+            ns = record['values']
+        else:
+            # Retrieve name servers associated to the zone.
+            ns = conn.get_zone(zone_in).get_nameservers()
+
+        module.exit_json(changed=False, set=record, nameservers=ns)
 
     if command_in == 'delete' and not found_record:
         module.exit_json(changed=False)


### PR DESCRIPTION
 Fixes #801

Also list the name servers associated to a zone, when command `get` is used.

After I made the change to the code, I found out that you can get the name servers already with current code. So this would be only an addition to make things a little bit more convenient for the users.

Just for the curios ones here is an example to get the name servers with existing code:

```
route53:
    command: get
    zone: foo.com
    record: foo.com
    type: NS
register: rec
```
