### PR TITLE
wait_for: updated docs, resolvable hostname, vagrant example

### DIFF
--- a/utilities/logic/wait_for.py
+++ b/utilities/logic/wait_for.py
@@ -54,7 +54,7 @@ version_added: "0.7"
 options:
   host:
     description:
-      - hostname or IP address to wait for
+      - A resolvable hostname or IP address to wait for
     required: false
     default: "127.0.0.1"
     aliases: []
@@ -123,8 +123,9 @@ EXAMPLES = '''
 # wait until the process is finished and pid was destroyed
 - wait_for: path=/proc/3466/status state=absent
 
-# Wait 300 seconds for port 22 to become open and contain "OpenSSH", don't start checking for 10 seconds
-- local_action: wait_for port=22 host="{{ inventory_hostname }}" search_regex=OpenSSH delay=10
+# wait 300 seconds for port 22 to become open and contain "OpenSSH", don't assume the inventory_hostname is resolvable
+# and don't start checking for 10 seconds
+- local_action: wait_for port=22 host="{{ ansible_ssh_host | default(inventory_hostname) }}" search_regex=OpenSSH delay=10
 
 '''
 


### PR DESCRIPTION
Based on discussion in IRC, where someone was failing to successfully get wait_for to work against a vagrant instance.

If a host= param is set, e.g. {{ inventory_hostname }}, the address must be resolvable, which often isn't the case for vagrant instances.  A simple doc update specifying that for the host param it should be a resolvable hostname, and also a few examples added.  

One thing I wasn't sure of, is whether to point out that using inventory_hostname won't resolve to ansible_ssh_host.

Happy to reword.  My first PR, so keeping it simple :)
