### PR TITLE
Do not insert extra newline if line already contains it

### DIFF
--- a/files/lineinfile.py
+++ b/files/lineinfile.py
@@ -242,8 +242,11 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
             # Don't do backref expansion if not asked.
             new_line = line
 
-        if lines[index[0]] != new_line + os.linesep:
-            lines[index[0]] = new_line + os.linesep
+        if not new_line.endswith(os.linesep):
+            new_line += os.linesep
+
+        if lines[index[0]] != new_line:
+            lines[index[0]] = new_line
             msg = 'line replaced'
             changed = True
     elif backrefs:


### PR DESCRIPTION
When using YAML multi-line strings, e.g.:
- lineinfile:
  dest: /tmp/foo
  line: >
    foo
    bar

the line already ends with a newline.  If an extra newline is appended unconditionally it will lead to inserting an extra newline on each run.
