### PR TITLE
rhn_channel: using depreciated methods

### DIFF
--- a/packaging/os/rhn_channel.py
+++ b/packaging/os/rhn_channel.py
@@ -90,17 +90,17 @@ def get_systemid(client, session, sysname):
 
 # ------------------------------------------------------- #
 
-def subscribe_channels(channels, client, session, sysname, sys_id):
-    c = base_channels(client, session, sys_id)
-    c.append(channels)
-    return client.channel.software.setSystemChannels(session, sys_id, c)
+def subscribe_channels(channelname, client, session, sysname, sys_id):
+    channels = base_channels(client, session, sys_id)
+    channels.append(channelname)
+    return client.system.setChildChannels(session, sys_id, channels)
 
 # ------------------------------------------------------- #
 
-def unsubscribe_channels(channels, client, session, sysname, sys_id):
-    c = base_channels(client, session, sys_id)
-    c.remove(channels)
-    return client.channel.software.setSystemChannels(session, sys_id, c)
+def unsubscribe_channels(channelname, client, session, sysname, sys_id):
+    channels = base_channels(client, session, sys_id)
+    channels.remove(channelname)
+    return client.system.setChildChannels(session, sys_id, channels)
 
 # ------------------------------------------------------- #
 
@@ -167,3 +167,4 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 main()
+


### PR DESCRIPTION
Fixes #112 replace channel.software.setSystemChannels with system.setChildChannels. Looks like channel.software.setSystemChannels has been depreciated for some time. tested on RHN sat server 5.5
