### PR TITLE
Fix typo in authorized key module documentation.

### DIFF
--- a/system/authorized_key.py
+++ b/system/authorized_key.py
@@ -76,7 +76,7 @@ options:
         authorized_keys file. Multiple keys can be specified in a single
         key= string value by separating them by newlines.
     required: false
-    choices: [ yes", "no" ]
+    choices: [ "yes", "no" ]
     default: "no"
     version_added: "1.9"
 description:


### PR DESCRIPTION
Added opening double quote
