### PR TITLE
Adding s3metadata parameter to s3 GET operations

### DIFF
--- a/cloud/amazon/s3.py
+++ b/cloud/amazon/s3.py
@@ -233,7 +233,7 @@ def download_s3file(module, s3, bucket, obj, dest):
         bucket = s3.lookup(bucket)
         key = bucket.lookup(obj)
         key.get_contents_to_filename(dest)
-        module.exit_json(msg="GET operation complete", changed=True)
+        module.exit_json(msg="GET operation complete", s3metadata=key.metadata, changed=True)
     except s3.provider.storage_copy_error, e:
         module.fail_json(msg= str(e))
 
@@ -242,7 +242,7 @@ def download_s3str(module, s3, bucket, obj):
         bucket = s3.lookup(bucket)
         key = bucket.lookup(obj)
         contents = key.get_contents_as_string()
-        module.exit_json(msg="GET operation complete", contents=contents, changed=True)
+        module.exit_json(msg="GET operation complete", contents=contents, s3metadata=key.metadata, changed=True)
     except s3.provider.storage_copy_error, e:
         module.fail_json(msg= str(e))
 
@@ -251,7 +251,7 @@ def get_download_url(module, s3, bucket, obj, expiry, changed=True):
         bucket = s3.lookup(bucket)
         key = bucket.lookup(obj)
         url = key.generate_url(expiry)
-        module.exit_json(msg="Download url:", url=url, expiry=expiry, changed=changed)
+        module.exit_json(msg="Download url:", url=url, expiry=expiry, s3metadata=key.metadata, changed=changed)
     except s3.provider.storage_response_error, e:
         module.fail_json(msg= str(e))
 


### PR DESCRIPTION
This is a simple addition to the s3 module. It allows users to access s3 metadata on GET operations by registering the result of the s3 module via the s3metadata variable. 

Example:

```
# Simple GET operation                                                                                                                                                               
- s3: bucket=mybucket object=/my/desired/key.txt dest=/usr/local/myfile.txt mode=get
  register: s3response

- file: content="{{ s3response.metdata | to_nice_yaml }}" dest=/path/to/metadata/file.yml
```
