### PR TITLE
[user] Allow '*' as empty password.

### DIFF
--- a/system/user.py
+++ b/system/user.py
@@ -904,7 +904,7 @@ class OpenBSDUser(User):
             cmd.append('-L')
             cmd.append(self.login_class)
 
-        if self.password is not None:
+        if self.password is not None and self.password != '*':
             cmd.append('-p')
             cmd.append(self.password)
 
@@ -998,7 +998,8 @@ class OpenBSDUser(User):
                 cmd.append('-L')
                 cmd.append(self.login_class)
 
-        if self.update_password == 'always' and self.password is not None and info[1] != self.password:
+        if self.update_password == 'always' and self.password is not None \
+           and self.password != '*' and info[1] != self.password:
             cmd.append('-p')
             cmd.append(self.password)
 


### PR DESCRIPTION
If `password` is defined as `*` `useradd` or `usermod` returns an error:

```
msg: usermod: Invalid password: `*'
```

This works very well on Linux host to not define any password for a
user (mainly useful if your setup is only based on SSH keys for
auth). On OpenBSD this does not work, so we have to ignore the encrypted
password parameter if it defined as `*`.
