### PR TITLE
Use auto scaling group managed ELBs if present.

### DIFF
--- a/cloud/amazon/ec2_elb.py
+++ b/cloud/amazon/ec2_elb.py
@@ -105,6 +105,7 @@ import os
 try:
     import boto
     import boto.ec2
+    import boto.ec2.autoscale
     import boto.ec2.elb
     from boto.regioninfo import RegionInfo
 except ImportError:
@@ -255,6 +256,9 @@ class ElbManager:
                   for elb lookup instead of returning what elbs
                   are attached to self.instance_id"""
 
+        if not ec2_elbs:
+           ec2_elbs = self._get_auto_scaling_group_lbs()
+
         try:
             elb = connect_to_aws(boto.ec2.elb, self.region, 
                                  **self.aws_connect_params)
@@ -272,6 +276,32 @@ class ElbManager:
                     if self.instance_id == info.id:
                         lbs.append(lb)
         return lbs
+
+    def _get_auto_scaling_group_lbs(self):
+        """Returns a list of ELBs associated with self.instance_id
+           indirectly through its auto scaling group membership"""
+
+        try:
+           asg = connect_to_aws(boto.ec2.autoscale, self.region, **self.aws_connect_params)
+        except (boto.exception.NoAuthHandlerFound, StandardError), e:
+            self.module.fail_json(msg=str(e))
+
+        asg_instances = asg.get_all_autoscaling_instances([self.instance_id])
+        if len(asg_instances) > 1:
+           self.module.fail_json(msg="Illegal state, expected one auto scaling group instance.")
+
+        if not asg_instances:
+           asg_elbs = []
+        else:
+           asg_name = asg_instances[0].group_name
+
+           asgs = asg.get_all_groups([asg_name])
+           if len(asg_instances) != 1:
+              self.module.fail_json(msg="Illegal state, expected one auto scaling group.")
+
+           asg_elbs = asgs[0].load_balancers
+
+        return asg_elbs
 
     def _get_instance(self):
         """Returns a boto.ec2.InstanceObject for self.instance_id"""


### PR DESCRIPTION
This change fixes a problem with instances not being registered in the auto scaling group associated ELBs. It typically happens when the auto scaling instance has been previously deregistered from the ELB but was never added back.

The issue can be reproduced with the following steps:
1. Manually deregister instance from ELB
2. Run playbook (see: example below) that tries to deregister instance first. This action tries to [automatically discover the associated instance ELBs](https://github.com/ansible/ansible-modules-core/blob/0ab5682b8740f0075bd74e6345a81aea6b4be6cd/cloud/amazon/ec2_elb.py#L264).

**Note:** The issue does not occur when the "ec2_elbs" variable is configured to use a specific value. Using a specific value [bypasses the attempt to automatically discover the associated ELBs](https://github.com/ansible/ansible-modules-core/blob/0ab5682b8740f0075bd74e6345a81aea6b4be6cd/cloud/amazon/ec2_elb.py#L266).

```
  - name: gather ec2 facts
    ec2_facts:

  - name: Deregister instance from ELB(s)
    local_action: ec2_elb instance_id="{{ ansible_ec2_instance_id }}" region="{{ aws_default_region }}" state="absent"
    register: dereg
    until: dereg|success
    retries: 10
    delay: 5

   # do custom application shutdown/startup

  - name: Register instance with ELB(s)
    local_action: ec2_elb instance_id="{{ ansible_ec2_instance_id }}" ec2_elbs="{{ item }}" region="{{ aws_default_region }}" state="present"
    with_items: ec2_elbs
    register: rereg
    until: rereg|success
    retries: 10
    delay: 5
```
