### PR TITLE
Instance deregistration should try all associated ELBs. Fixes #869

### DIFF
--- a/cloud/amazon/ec2_elb.py
+++ b/cloud/amazon/ec2_elb.py
@@ -130,9 +130,9 @@ class ElbManager:
         for lb in self.lbs:
             initial_state = self._get_instance_health(lb) 
             if initial_state is None:
-                # The instance isn't registered with this ELB so just 
-                # return unchanged
-                return
+                # Instance isn't registered with this load
+                # balancer. Ignore it and try the next one.
+                continue
 
             lb.deregister_instances([self.instance_id])
 


### PR DESCRIPTION
This fixes issue #869 where instance deregistration can short circuit prior to trying all associated ELBs.
