### PR TITLE
cron module: Add disabled option for commented jobs

### DIFF
--- a/system/cron.py
+++ b/system/cron.py
@@ -4,6 +4,7 @@
 # (c) 2012, Dane Summers <dsummers@pinedesk.biz>
 # (c) 2013, Mike Grozak  <mike.grozak@gmail.com>
 # (c) 2013, Patrick Callahan <pmc@patrickcallahan.com>
+# (c) 2015, Evan Kaufman <evan@digitalflophouse.com>
 #
 # This file is part of Ansible
 #
@@ -116,10 +117,16 @@ options:
     required: false
     default: null
     choices: [ "reboot", "yearly", "annually", "monthly", "weekly", "daily", "hourly" ]
+  disabled:
+    description:
+      - If the job should be disabled (commented out) in the crontab. Only has effect if state=present
+    version_added: "1.9"
+    required: false
+    default: false
 requirements:
   - cron
 author: "Dane Summers (@dsummersl)"
-updates: [ 'Mike Grozak', 'Patrick Callahan' ]
+updates: [ 'Mike Grozak', 'Patrick Callahan', 'Evan Kaufman' ]
 """
 
 EXAMPLES = '''
@@ -290,17 +297,22 @@ class CronTab(object):
 
         return []
 
-    def get_cron_job(self,minute,hour,day,month,weekday,job,special):
+    def get_cron_job(self,minute,hour,day,month,weekday,job,special,disabled):
+        if disabled:
+            disable_prefix = '#'
+        else:
+            disable_prefix = ''
+
         if special:
             if self.cron_file:
-                return "@%s %s %s" % (special, self.user, job)
+                return "%s@%s %s %s" % (disable_prefix, special, self.user, job)
             else:
-                return "@%s %s" % (special, job)
+                return "%s@%s %s" % (disable_prefix, special, job)
         else:
             if self.cron_file:
-                return "%s %s %s %s %s %s %s" % (minute,hour,day,month,weekday,self.user,job)
+                return "%s%s %s %s %s %s %s %s" % (disable_prefix,minute,hour,day,month,weekday,self.user,job)
             else:
-                return "%s %s %s %s %s %s" % (minute,hour,day,month,weekday,job)
+                return "%s%s %s %s %s %s %s" % (disable_prefix,minute,hour,day,month,weekday,job)
 
         return None
 
@@ -413,7 +425,8 @@ def main():
             special_time=dict(required=False,
                               default=None,
                               choices=["reboot", "yearly", "annually", "monthly", "weekly", "daily", "hourly"],
-                              type='str')
+                              type='str'),
+            disabled=dict(default=False, type='bool')
         ),
         supports_check_mode = False,
     )
@@ -431,6 +444,7 @@ def main():
     weekday      = module.params['weekday']
     reboot       = module.params['reboot']
     special_time = module.params['special_time']
+    disabled     = module.params['disabled']
     do_install   = state == 'present'
 
     changed      = False
@@ -481,7 +495,7 @@ def main():
         changed = crontab.remove_job_file()
         module.exit_json(changed=changed,cron_file=cron_file,state=state)
 
-    job = crontab.get_cron_job(minute, hour, day, month, weekday, job, special_time)
+    job = crontab.get_cron_job(minute, hour, day, month, weekday, job, special_time, disabled)
     old_job = crontab.find_job(name)
 
     if do_install:


### PR DESCRIPTION
My use case for this is a farm of webservers, one of which has several maintenance jobs run via cron. It would be useful to have the same jobs on _all_ sibling servers within the farm, but commented out so they do not run without manual intervention.

This way, if my designated job server goes down, I can ssh into another webserver and uncomment said jobs to keep things running smooth until said job server is restored.

As an example, this task conditionally enables the job for only the _first_ host in a `webservers` group:

``` yml
- cron: >
  minute=0
  hour=0
  weekday=0
  name="Do the thing"
  job="/bin/thething > /dev/null"
  state=present
  disabled={{ groups['webservers'] | first != inventory_hostname }}
```

On the designated job server, it would generate this crontab:

``` shell
#Ansible: Do the thing
0 0 * * 0 /bin/thething > /dev/null
```

All other servers would have _this_ crontab:

``` shell
#Ansible: Do the thing
#0 0 * * 0 /bin/thething > /dev/null
```
