### PR TITLE
Fix 'Group does not exist' when adding groups

### DIFF
--- a/system/user.py
+++ b/system/user.py
@@ -505,7 +505,7 @@ class User(object):
         if self.groups is None:
             return None
         info = self.user_info()
-        groups = set(filter(None, self.groups.split(',')))
+        groups = set([x.strip() for x in self.groups.split(',') if x])
         for g in set(groups):
             if not self.group_exists(g):
                 self.module.fail_json(msg="Group %s does not exist" % (g))


### PR DESCRIPTION
Creating a user with 'groups=sudo, adm' resulted in an error because the group ' adm' (with space) doesn't exist. Strip group names to fix this.
