### PR TITLE
ec2: Apply all security groups at instance-creation

### DIFF
--- a/cloud/amazon/ec2.py
+++ b/cloud/amazon/ec2.py
@@ -806,8 +806,7 @@ def create_instances(module, ec2, vpc, override_count=None):
             if type(group_id) == str:
                 group_id = [group_id]
             grp_details = ec2.get_all_security_groups(group_ids=group_id)
-            grp_item = grp_details[0]
-            group_name = [grp_item.name]
+            group_name = [grp_item.name for grp_item in grp_details]
     except boto.exception.NoAuthHandlerFound, e:
             module.fail_json(msg = str(e))
 


### PR DESCRIPTION
The code was picking out the first instance from the security groups
specified, even when multiple groups were specified. Now we use all of
them.
