### PR TITLE
Allow vpc_subnet_id to remain unspecified (see bc0c169)

### DIFF
--- a/cloud/amazon/ec2.py
+++ b/cloud/amazon/ec2.py
@@ -785,6 +785,8 @@ def create_instances(module, ec2, vpc, override_count=None):
 
     if vpc_subnet_id:
         vpc_id = vpc.get_all_subnets(subnet_ids=[vpc_subnet_id])[0].vpc_id
+    else:
+        vpc_id = None
 
     try:
         # Here we try to lookup the group id from the security group name - if group is set.


### PR DESCRIPTION
@cwarner-mdsol alerted me to this problem in a previous commit of mine. `vpc_subnet_id` must be allowed to be unset, in which case `vpc_id` still needs to be set, at least to `None`.

@cwarner-mdsol, can you test that this fixes your issue?
