### PR TITLE
Replacement for ec2_ami_search

### DIFF
--- a/cloud/amazon/ec2_ami_search.py
+++ b/cloud/amazon/ec2_ami_search.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python
 #
-# (c) 2013, Nimbis Services
-#
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify
@@ -20,181 +18,299 @@
 DOCUMENTATION = '''
 ---
 module: ec2_ami_search
-short_description: Retrieve AWS AMI information for a given operating system.
-version_added: "1.6"
+version_added: 1.9
+short_description: Searches for AMIs to obtain the AMI ID and other information
 description:
-  - Look up the most recent AMI on AWS for a given operating system.
-  - Returns C(ami), C(aki), C(ari), C(serial), C(tag)
-  - If there is no AKI or ARI associated with an image, these will be C(null).
-  - Only supports images from cloud-images.ubuntu.com
-  - 'Example output: C({"ami": "ami-69f5a900", "changed": false, "aki": "aki-88aa75e1", "tag": "release", "ari": null, "serial": "20131024"})'
-version_added: "1.6"
+  - Returns list of matching AMIs with AMI ID, along with other useful information
+  - Can search AMIs with different owners
+  - Can search by matching tag(s), by AMI name and/or other criteria
+  - Results can be sorted and sliced
+author: Tom Bamford
+notes:
+  - This module is not backwards compatible with the previous version of the ec2_search_ami module which worked only for Ubuntu AMIs listed on cloud-images.ubuntu.com.
+  - See the example below for a suggestion of how to search by distro/release.
 options:
-  distro:
-    description: Linux distribution (e.g., C(ubuntu))
-    required: true
-    choices: ["ubuntu"]
-  release:
-    description: short name of the release (e.g., C(precise))
-    required: true
-  stream:
-    description: Type of release.
-    required: false
-    default: "server"
-    choices: ["server", "desktop"]
-  store:
-    description: Back-end store for instance
-    required: false
-    default: "ebs"
-    choices: ["ebs", "ebs-io1", "ebs-ssd", "instance-store"]
-  arch:
-    description: CPU architecture
-    required: false
-    default: "amd64"
-    choices: ["i386", "amd64"]
   region:
-    description: EC2 region
+    description:
+      - The AWS region to use.
+    default: null
+    required: true
+    version_added: 1.9
+    aliases: [ 'aws_region', 'ec2_region' ]
+  owner:
+    description:
+      - Search AMIs owned by the specified owner
+      - Can specify an AWS account ID, or one of the special IDs 'self', 'amazon' or 'aws-marketplace'
+      - If not specified, all EC2 AMIs in the specified region will be searched.
+      - You can include wildcards in many of the search options. An asterisk (*) matches zero or more characters, and a question mark (?) matches exactly one character. You can escape special characters using a backslash (\) before the character. For example, a value of \*amazon\?\\ searches for the literal string *amazon?\.
     required: false
-    default: us-east-1
-    choices: ["ap-northeast-1", "ap-southeast-1", "ap-southeast-2",
-              "eu-central-1", "eu-west-1", "sa-east-1", "us-east-1",
-              "us-west-1", "us-west-2", "us-gov-west-1"]
-  virt:
-    description: virutalization type
+    default: None
+    version_added: 1.9
+  ami_id:
+    description:
+      - An AMI ID to match.
+    default: null
     required: false
-    default: paravirtual
-    choices: ["paravirtual", "hvm"]
+    version_added: 1.9
+  ami_tags:
+    description:
+      - A hash/dictionary of tags to match for the AMI.
+    default: null
+    required: false
+    version_added: 1.9
+  architecture:
+    description:
+      - An architecture type to match (e.g. x86_64).
+    default: null
+    required: false
+    version_added: 1.9
+  hypervisor:
+    description:
+      - A hypervisor type type to match (e.g. xen).
+    default: null
+    required: false
+    version_added: 1.9
+  is_public:
+    description:
+      - Whether or not the image(s) are public.
+    choices: ['yes', 'no']
+    default: null
+    required: false
+    version_added: 1.9
+  name:
+    description:
+      - An AMI name to match.
+    default: null
+    required: false
+    version_added: 1.9
+  platform:
+    description:
+      - Platform type to match.
+    default: null
+    required: false
+    version_added: 1.9
+  sort:
+    description:
+      - Optional attribute which with to sort the results.
+      - If specifying 'tag', the 'tag_name' parameter is required.
+    choices: ['name, 'description', 'tag']
+    default: null
+    required: false
+    version_added: 1.9
+  sort_tag:
+    description:
+      - Tag name with which to sort results.
+      - Required when specifying 'sort=tag'.
+    default: null
+    required: false
+    version_added: 1.9
+  sort_order:
+    description:
+      - Order in which to sort results.
+      - Only used when the 'sort' parameter is specified.
+    choices: ['ascending', 'descending']
+    default: 'ascending'
+    required: false
+    version_added: 1.9
+  sort_start:
+    description:
+      - Which result to start with (when sorting).
+      - Corresponds to Python slice notation.
+    default: null
+    required: false
+    version_added: 1.9
+  sort_end:
+    description:
+      - Which result to end with (when sorting).
+      - Corresponds to Python slice notation.
+    default: null
+    required: false
+    version_added: 1.9
+  state:
+    description:
+      - AMI state to match.
+    default: 'available'
+    required: false
+    version_added: 1.9
+  virtualization_type:
+    description:
+      - Virtualization type to match (e.g. hvm).
+    default: null
+    required: false
+    version_added: 1.9
+  no_result_action:
+    description:
+      - What to do when no results are found
+      - 'success' reports success and returns an empty array
+      - 'fail' causes the module to report failure
+    choices: ['success', 'fail']
+    default: 'success'
+    required: false
+    version_added: 1.9
+requirements:
+  - boto
 
-author: Lorin Hochstein
 '''
 
 EXAMPLES = '''
-- name: Launch an Ubuntu 12.04 (Precise Pangolin) EC2 instance
-  hosts: 127.0.0.1
-  connection: local
-  tasks:
-  - name: Get the Ubuntu precise AMI
-    ec2_ami_search: distro=ubuntu release=precise region=us-west-1 store=instance-store
-    register: ubuntu_image
-  - name: Start the EC2 instance
-    ec2: image={{ ubuntu_image.ami }} instance_type=m1.small key_name=mykey
+# Note: These examples do not set authentication details, see the AWS Guide for details.
+
+# Search for the AMI tagged "project:website"
+- ec2_ami_search:
+    owner: self
+    tags:
+      project: website
+    no_result_action: fail
+  register: ami_search
+
+# Search for the latest Ubuntu 14.04 AMI
+- ec2_ami_search:
+    name: "ubuntu/images/ebs/ubuntu-trusty-14.04-amd64-server-*"
+    owner: 099720109477
+    sort: name
+    sort_order: descending
+    sort_end: 1
+  register: ami_search
+
+# Launch an EC2 instance
+- ec2:
+    image: "{{ ami_search.results[0].ami_id }}"
+    instance_type: m3.medium
+    key_name: mykey
+    wait: yes
 '''
 
-import csv
+try:
+    import boto.ec2
+except ImportError:
+    print "failed=True msg='boto required for this module'"
+    sys.exit(1)
+
 import json
-import urllib2
-import urlparse
-
-SUPPORTED_DISTROS = ['ubuntu']
-
-AWS_REGIONS = ['ap-northeast-1',
-               'ap-southeast-1',
-               'ap-southeast-2',
-               'eu-central-1',
-               'eu-west-1',
-               'sa-east-1',
-               'us-east-1',
-               'us-west-1',
-               'us-west-2',
-               "us-gov-west-1"]
-
-
-def get_url(module, url):
-    """ Get url and return response """
-    try:
-        r = urllib2.urlopen(url)
-    except (urllib2.HTTPError, urllib2.URLError), e:
-        code = getattr(e, 'code', -1)
-        module.fail_json(msg="Request failed: %s" % str(e), status_code=code)
-    return r
-
-
-def ubuntu(module):
-    """ Get the ami for ubuntu """
-
-    release = module.params['release']
-    stream = module.params['stream']
-    store = module.params['store']
-    arch = module.params['arch']
-    region = module.params['region']
-    virt = module.params['virt']
-
-    url = get_ubuntu_url(release, stream)
-
-    req = get_url(module, url)
-    reader = csv.reader(req, delimiter='\t')
-    try:
-        ami, aki, ari, tag, serial = lookup_ubuntu_ami(reader, release, stream,
-            store, arch, region, virt)
-        module.exit_json(changed=False, ami=ami, aki=aki, ari=ari, tag=tag,
-            serial=serial)
-    except KeyError:
-        module.fail_json(msg="No matching AMI found")
-
-
-def lookup_ubuntu_ami(table, release, stream, store, arch, region, virt):
-    """ Look up the Ubuntu AMI that matches query given a table of AMIs
-
-        table: an iterable that returns a row of
-               (release, stream, tag, serial, region, ami, aki, ari, virt)
-        release: ubuntu release name
-        stream: 'server' or 'desktop'
-        store: 'ebs', 'ebs-io1', 'ebs-ssd' or 'instance-store'
-        arch: 'i386' or 'amd64'
-        region: EC2 region
-        virt: 'paravirtual' or 'hvm'
-
-        Returns (ami, aki, ari, tag, serial)"""
-    expected = (release, stream, store, arch, region, virt)
-
-    for row in table:
-        (actual_release, actual_stream, tag, serial,
-            actual_store, actual_arch, actual_region, ami, aki, ari,
-            actual_virt) = row
-        actual = (actual_release, actual_stream, actual_store, actual_arch,
-            actual_region, actual_virt)
-        if actual == expected:
-            # aki and ari are sometimes blank
-            if aki == '':
-                aki = None
-            if ari == '':
-                ari = None
-            return (ami, aki, ari, tag, serial)
-
-    raise KeyError()
-
-
-def get_ubuntu_url(release, stream):
-    url = "https://cloud-images.ubuntu.com/query/%s/%s/released.current.txt"
-    return url % (release, stream)
-
 
 def main():
-    arg_spec = dict(
-        distro=dict(required=True, choices=SUPPORTED_DISTROS),
-        release=dict(required=True),
-        stream=dict(required=False, default='server',
-            choices=['desktop', 'server']),
-        store=dict(required=False, default='ebs',
-            choices=['ebs', 'ebs-io1', 'ebs-ssd', 'instance-store']),
-        arch=dict(required=False, default='amd64',
-            choices=['i386', 'amd64']),
-        region=dict(required=False, default='us-east-1', choices=AWS_REGIONS),
-        virt=dict(required=False, default='paravirtual',
-            choices=['paravirtual', 'hvm'])
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(dict(
+            region = dict(required=True,
+                aliases = ['aws_region', 'ec2_region']),
+            owner = dict(required=False, default=None),
+            ami_id = dict(required=False),
+            ami_tags = dict(required=False, type='dict',
+                aliases = ['search_tags', 'image_tags']),
+            architecture = dict(required=False),
+            hypervisor = dict(required=False),
+            is_public = dict(required=False),
+            name = dict(required=False),
+            platform = dict(required=False),
+            sort = dict(required=False, default=None,
+                choices=['name', 'description', 'tag']),
+            sort_tag = dict(required=False),
+            sort_order = dict(required=False, default='ascending',
+                choices=['ascending', 'descending']),
+            sort_start = dict(required=False),
+            sort_end = dict(required=False),
+            state = dict(required=False, default='available'),
+            virtualization_type = dict(required=False),
+            no_result_action = dict(required=False, default='success',
+                choices = ['success', 'fail']),
+        )
     )
-    module = AnsibleModule(argument_spec=arg_spec)
-    distro = module.params['distro']
 
-    if distro == 'ubuntu':
-        ubuntu(module)
-    else:
-        module.fail_json(msg="Unsupported distro: %s" % distro)
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+    )
 
+    ami_id = module.params.get('ami_id')
+    ami_tags = module.params.get('ami_tags')
+    architecture = module.params.get('architecture')
+    hypervisor = module.params.get('hypervisor')
+    is_public = module.params.get('is_public')
+    name = module.params.get('name')
+    owner = module.params.get('owner')
+    platform = module.params.get('platform')
+    sort = module.params.get('sort')
+    sort_tag = module.params.get('sort_tag')
+    sort_order = module.params.get('sort_order')
+    sort_start = module.params.get('sort_start')
+    sort_end = module.params.get('sort_end')
+    state = module.params.get('state')
+    virtualization_type = module.params.get('virtualization_type')
+    no_result_action = module.params.get('no_result_action')
 
+    filter = {'state': state}
 
-# this is magic, see lib/ansible/module_common.py
-#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+    if ami_id:
+        filter['image_id'] = ami_id
+    if ami_tags:
+        for tag in ami_tags:
+            filter['tag:'+tag] = ami_tags[tag]
+    if architecture:
+        filter['architecture'] = architecture
+    if hypervisor:
+        filter['hypervisor'] = hypervisor
+    if is_public:
+        filter['is_public'] = is_public
+    if name:
+        filter['name'] = name
+    if platform:
+        filter['platform'] = platform
+    if virtualization_type:
+        filter['virtualization_type'] = virtualization_type
+
+    ec2 = ec2_connect(module)
+
+    images_result = ec2.get_all_images(owners=owner, filters=filter)
+
+    if no_result_action == 'fail' and len(images_result) == 0:
+        module.fail_json(msg="No AMIs matched the attributes: %s" % json.dumps(filter))
+
+    results = []
+    for image in images_result:
+        data = {
+            'ami_id': image.id,
+            'architecture': image.architecture,
+            'description': image.description,
+            'is_public': image.is_public,
+            'name': image.name,
+            'owner_id': image.owner_id,
+            'platform': image.platform,
+            'root_device_name': image.root_device_name,
+            'root_device_type': image.root_device_type,
+            'state': image.state,
+            'tags': image.tags,
+            'virtualization_type': image.virtualization_type,
+        }
+
+        if image.kernel_id:
+            data['kernel_id'] = image.kernel_id
+        if image.ramdisk_id:
+            data['ramdisk_id'] = image.ramdisk_id
+
+        results.append(data)
+
+    if sort == 'tag':
+        if not sort_tag:
+            module.fail_json(msg="'sort_tag' option must be given with 'sort=tag'")
+        results.sort(key=lambda e: e['tags'][sort_tag], reverse=(sort_order=='descending'))
+    elif sort:
+        results.sort(key=lambda e: e[sort], reverse=(sort_order=='descending'))
+
+    try:
+        if sort and sort_start and sort_end:
+            results = results[int(sort_start):int(sort_end)]
+        elif sort and sort_start:
+            results = results[int(sort_start):]
+        elif sort and sort_end:
+            results = results[:int(sort_end)]
+    except TypeError:
+        module.fail_json(msg="Please supply numeric values for sort_start and/or sort_end")
+
+    module.exit_json(results=results)
+
+# import module snippets
+from ansible.module_utils.basic import *
+from ansible.module_utils.ec2 import *
 
 if __name__ == '__main__':
     main()
+


### PR DESCRIPTION
This is a replacement for the current ec2_ami_search module. It makes use of the boto get_all_images method to search for AMIs matching a number of criteria. Results can be sorted and sliced.

Note that the options are not compatible with the current version of this module, although the current version of this module doesn't really have anything to do with EC2 at all, it just fetches and parses a text file from an Ubuntu project server. However one can achieve a near drop-in replacement with the new syntax (example given). 

Potential uses for this module might be
- Search for the latest and greatest AMI of your favourite distro or publisher
- Search your own AMIs and launch instances with them
- Search your own AMIs and perform actions on them, such as deleting older AMIs
