### PR TITLE
rax: Prevent an empty error message

### DIFF
--- a/cloud/rackspace/rax.py
+++ b/cloud/rackspace/rax.py
@@ -314,7 +314,11 @@ def create(module, names=[], flavor=None, image=None, meta={}, key_name=None,
                                              block_device_mapping_v2=bdmv2,
                                              **extra_create_args))
     except Exception, e:
-        module.fail_json(msg='%s' % e.message)
+        if e.message:
+            msg = str(e.message)
+        else:
+            msg = repr(e)
+        module.fail_json(msg=msg)
     else:
         changed = True
 


### PR DESCRIPTION
Along with https://github.com/ansible/ansible/pull/10421 this PR tries to avoid a situation where we catch an exception that does not contain a message.
