### PR TITLE
Fix KeyError in public zones in route53

### DIFF
--- a/cloud/amazon/route53.py
+++ b/cloud/amazon/route53.py
@@ -261,7 +261,7 @@ def main():
     for r53zone in results['ListHostedZonesResponse']['HostedZones']:
         # only save this zone id if the private status of the zone matches
         # the private_zone_in boolean specified in the params
-        if module.boolean(r53zone['Config']['PrivateZone']) == private_zone_in:
+        if module.boolean(r53zone['Config'].get('PrivateZone', False)) == private_zone_in:
             zone_id = r53zone['Id'].replace('/hostedzone/', '')
             zones[r53zone['Name']] = zone_id
 


### PR DESCRIPTION
The code assumed a 'PrivateZone' key in the config dict, which doesn't exist for public zones.
