### PR TITLE
Setting the actual passno and dump defaults, and warning user of consequ...

### DIFF
--- a/system/mount.py
+++ b/system/mount.py
@@ -51,14 +51,14 @@ options:
     default: null
   dump:
     description:
-      - dump (see fstab(8))
+      - "dump (see fstab(8)), Note that if nulled, C(state=present) will cease to work and duplicate entries will be made with subsequent runs."
     required: false
-    default: null
+    default: 0
   passno:
     description:
-      - passno (see fstab(8))
+      - "passno (see fstab(8)), Note that if nulled, C(state=present) will cease to work and duplicate entries will be made with subsequent runs."
     required: false
-    default: null
+    default: 0
   state:
     description:
       - If C(mounted) or C(unmounted), the device will be actively mounted or unmounted


### PR DESCRIPTION
...ences in nulling

Using ansible 1.8.4, I found that these two options actually work slightly different than advertised. 
Here's a config I use that proved this. I did multiple runs and duplicate entries are continuously made:(

```
- name: insert proper mount options for storage disks
  mount:
    name: "{{ dirprefix }}/{{ item }}"
    opts: "{{ mountoptions }}"
    fstype: "{{ filesystem }}"
    src: /dev/{{ item }}
    state: present
    ## These two don't act properly when cleared out...specifically, state=present doesn't work when they are empty.
    passno: ""
    dump: ""
  with_items:
    - sdb
    - sdc
    - sdd
    - sde
    - sdf
    - sdg
    - sdh
```

If someone wants to discuss this further, I am #inanimate on freenode.
