### PR TITLE
[docker] fixed: global name 'e' is not defined

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -1094,7 +1094,7 @@ class DockerManager(object):
                     email=self.module.params.get('email'),
                     registry=self.module.params.get('registry')
                 )
-            except e:
+            except Exception as e:
                 self.module.fail_json(msg="failed to login to the remote registry, check your username/password.", error=repr(e))
         try:
             last = None
@@ -1110,7 +1110,7 @@ class DockerManager(object):
             else:
                 # Unrecognized status string.
                 self.module.fail_json(msg="Unrecognized status from pull.", status=status)
-        except e:
+        except Exception as e:
             self.module.fail_json(msg="Failed to pull the specified image: %s" % resource, error=repr(e))
 
     def create_containers(self, count=1):


### PR DESCRIPTION
This is how it looked like:

```
failed: [web601] => {"failed": true, "parsed": false}
Traceback (most recent call last):
  File "<stdin>", line 3031, in <module>
  File "<stdin>", line 1397, in main
  File "<stdin>", line 1112, in pull_image
NameError: global name 'e' is not defined


FATAL: all hosts have already failed -- aborting
```
