### PR TITLE
git: set remote branch before switching versions when using depth arg

### DIFF
--- a/source_control/git.py
+++ b/source_control/git.py
@@ -573,12 +573,26 @@ def submodule_update(git_path, module, dest, track_submodules):
         module.fail_json(msg="Failed to init/update submodules: %s" % out + err)
     return (rc, out, err)
 
+def set_remote_branch(git_path, module, dest, remote, version, depth):
+    cmd = "%s remote set-branches %s %s" % (git_path, remote, version)
+    (rc, out, err) = module.run_command(cmd, cwd=dest)
+    if rc != 0:
+        module.fail_json(msg="Failed to set remote branch: %s" % version)
+    cmd = "%s fetch --depth=%s %s %s" % (git_path, depth, remote, version)
+    (rc, out, err) = module.run_command(cmd, cwd=dest)
+    if rc != 0:
+        module.fail_json(msg="Failed to fetch branch from remote: %s" % version)
 
 def switch_version(git_path, module, dest, remote, version):
     cmd = ''
     if version != 'HEAD':
         if is_remote_branch(git_path, module, dest, remote, version):
             if not is_local_branch(git_path, module, dest, version):
+                depth = module.params['depth']
+                if depth:
+                    # git clone --depth implies --single-branch, which makes
+                    # the checkout fail if the version changes
+                    set_remote_branch(git_path, module, dest, remote, version, depth)
                 cmd = "%s checkout --track -b %s %s/%s" % (git_path, version, remote, version)
             else:
                 (rc, out, err) = module.run_command("%s checkout --force %s" % (git_path, version), cwd=dest)


### PR DESCRIPTION
Below is an example playbook demonstrating the failure.

```
- name: switching branches fails when using depth arg
  hosts: localhost
  connection: local
  tasks:
    - git: >
        depth=1
        dest=test-clone
        repo=git@github.com:ansible/ansible-modules-core.git
        version=devel
        accept_hostkey=yes
    - git: >
        depth=1
        dest=test-clone
        repo=git@github.com:ansible/ansible-modules-core.git
        version=stable-1.9
        accept_hostkey=yes
```

This is because when creating a shallow, the --no-single-branch option is implied. Here's the relevant excerpt from `man git-clone`.

```
       --[no-]single-branch
           Clone only the history leading to the tip of a single branch, either specified by the --branch option or the primary branch remote's HEAD points at. When
           creating a shallow clone with the --depth option, this is the default, unless --no-single-branch is given to fetch the histories near the tips of all
           branches. Further fetches into the resulting repository will only update the remote-tracking branch for the branch this option was used for the initial
           cloning. If the HEAD at the remote did not point at any branch when --single-branch clone was made, no remote-tracking branch is created.
```

This is my first time working with ansible modules, so if I'm doing something wrong or there is a better way to accomplish this, please let me know. Thanks!
