### PR TITLE
Make pid_mode parameter do minimum docker-py/docker server version checks

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -463,6 +463,7 @@ class DockerManager(object):
             'dns': ((0, 3, 0), '1.10'),
             'volumes_from': ((0, 3, 0), '1.10'),
             'restart_policy': ((0, 5, 0), '1.14'),
+            'pid_mode': ((1, 0, 0), '1.17'),
             # Clientside only
             'insecure_registry': ((0, 5, 0), '0.0')
             }
@@ -1160,11 +1161,11 @@ class DockerManager(object):
             'privileged': self.module.params.get('privileged'),
             'links': self.links,
             'network_mode': self.module.params.get('net'),
-            'pid_mode': self.module.params.get('pid'),
         }
 
         optionals = {}
-        for optional_param in ('dns', 'volumes_from', 'restart_policy', 'restart_policy_retry'):
+        for optional_param in ('dns', 'volumes_from', 'restart_policy',
+                'restart_policy_retry', 'pid_mode'):
             optionals[optional_param] = self.module.params.get(optional_param)
 
         if optionals['dns'] is not None:
@@ -1180,6 +1181,10 @@ class DockerManager(object):
             params['restart_policy'] = { 'Name': optionals['restart_policy'] }
             if params['restart_policy']['Name'] == 'on-failure':
                 params['restart_policy']['MaximumRetryCount'] = optionals['restart_policy_retry']
+
+        if optionals['pid_mode'] is not None:
+            self.ensure_capability('pid_mode')
+            params['pid_mode'] = optionals['pid_mode']
 
         for i in containers:
             self.client.start(i['Id'], **params)

--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -200,7 +200,7 @@ options:
     version_added: "1.8"
   pid:
     description:
-      - Set the PID namespace mode for the container (currently only supports 'host'). Requires docker-py >= 1.0.0 and docker >= 1.4.1.
+      - Set the PID namespace mode for the container (currently only supports 'host'). Requires docker-py >= 1.0.0 and docker >= 1.5.0
     required: false
     default: None
     aliases: []
@@ -463,7 +463,7 @@ class DockerManager(object):
             'dns': ((0, 3, 0), '1.10'),
             'volumes_from': ((0, 3, 0), '1.10'),
             'restart_policy': ((0, 5, 0), '1.14'),
-            'pid_mode': ((1, 0, 0), '1.17'),
+            'pid': ((1, 0, 0), '1.17'),
             # Clientside only
             'insecure_registry': ((0, 5, 0), '0.0')
             }
@@ -1165,7 +1165,7 @@ class DockerManager(object):
 
         optionals = {}
         for optional_param in ('dns', 'volumes_from', 'restart_policy',
-                'restart_policy_retry', 'pid_mode'):
+                'restart_policy_retry', 'pid'):
             optionals[optional_param] = self.module.params.get(optional_param)
 
         if optionals['dns'] is not None:
@@ -1182,9 +1182,9 @@ class DockerManager(object):
             if params['restart_policy']['Name'] == 'on-failure':
                 params['restart_policy']['MaximumRetryCount'] = optionals['restart_policy_retry']
 
-        if optionals['pid_mode'] is not None:
-            self.ensure_capability('pid_mode')
-            params['pid_mode'] = optionals['pid_mode']
+        if optionals['pid'] is not None:
+            self.ensure_capability('pid')
+            params['pid_mode'] = optionals['pid']
 
         for i in containers:
             self.client.start(i['Id'], **params)


### PR DESCRIPTION
Adding pid_mode in: https://github.com/ansible/ansible-modules-core/pull/890

needed to perform checks for what version of docker-py and docker server we were running against.  If the versions are too old we need fail with a good error message.  This PR implements those checks.

This is to fix https://github.com/ansible/ansible/issues/10453
