### PR TITLE
When no use_tls is not specified and no tls parameters are given we need to not attempt tls.

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -589,12 +589,8 @@ class DockerManager(object):
         #   or tls_ca_cert (which requests verifying the server with
         #   a specific ca certificate)
         use_tls = module.params.get('use_tls')
-        if use_tls == 'no':
-            tls_config = None
-        else:
-            # If this stays True, we'll do encryption.  If something overrides
-            # it, then we'll have a TLSConfig obj instead
-            tls_config = True
+        tls_config = None
+        if use_tls != 'no':
             params = {}
 
             # Setup client auth


### PR DESCRIPTION
From the error in #940 it looks like we need to set tls_config=None in more cases.  This is a fix for one common case in the tls features introduced with #926
