### PR TITLE
postgres_user: skip password changes so pg_authid isn't needed

### DIFF
--- a/database/postgresql/postgresql_user.py
+++ b/database/postgresql/postgresql_user.py
@@ -117,8 +117,9 @@ options:
     description:
       - if C(yes), don't inspect database for password changes. Effective when C(pg_authid) is not accessible (such as AWS RDS). Otherwise, make password changes as necessary.
     required: false
-    default: 'yes'
+    default: 'no'
     choices: [ "yes", "no" ]
+    version_added: '2.0'
 notes:
    - The default authentication assumes that you are either logging in as or
      sudo'ing to the postgres account on the host.
@@ -492,7 +493,7 @@ def main():
         module.fail_json(msg="privileges require a database to be specified")
     privs = parse_privs(module.params["priv"], db)
     port = module.params["port"]
-    no_password_changes = module.params.get("no_password_changes", False)
+    no_password_changes = module.params["no_password_changes"]
     try:
         role_attr_flags = parse_role_attrs(module.params["role_attr_flags"])
     except InvalidFlagsError, e:


### PR DESCRIPTION
Some places ([AWS RDS](https://forums.aws.amazon.com/thread.jspa?threadID=151248)) don't have, or don't allow, access to the `pg_authid` table. The only reason that is necessary is to check for a password change.

This flag is a workaround so passwords can only be set at creation time. It isn't as elegant as changing the password down the line, but it fixes the longstanding issue #297 that prevented this from being useful on AWS RDS.
