### PR TITLE
Fixes rds_subnet_group never reports changed

### DIFF
--- a/cloud/amazon/rds_subnet_group.py
+++ b/cloud/amazon/rds_subnet_group.py
@@ -149,10 +149,14 @@ def main():
         else:
             if not exists:
                 new_group = conn.create_db_subnet_group(group_name, desc=group_description, subnet_ids=group_subnets)
-
+                changed = True
             else:
-                changed_group = conn.modify_db_subnet_group(group_name, description=group_description, subnet_ids=group_subnets)
-
+                # Sort the subnet groups before we compare them
+                matching_groups[0].subnet_ids.sort()
+                group_subnets.sort()
+                if ( (matching_groups[0].name != group_name) or (matching_groups[0].description != group_description) or (matching_groups[0].subnet_ids != group_subnets) ):
+                    changed_group = conn.modify_db_subnet_group(group_name, description=group_description, subnet_ids=group_subnets)
+                    changed = True
     except BotoServerError, e:
         module.fail_json(msg = e.error_message)
 


### PR DESCRIPTION
Added changed=True flag when new subnet groups created.  Added conditional so that modify_db_subnet_group is only called when necessary and changed=True flag will be set.

Fixes #958
