### PR TITLE
[docker] Fix formating error when remote host doesn't have required version

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -657,9 +657,9 @@ class DockerManager(object):
                 ' docker-py: %s, docker server apiversion %s; found'
                 ' docker-py: %s, server: %s' % (
                     capability,
-                    '.'.join(self._cap_ver_req[capability][0]),
+                    '.'.join(map(str, self._cap_ver_req[capability][0])),
                     self._cap_ver_req[capability][1],
-                    '.'.join(self.docker_py_versioninfo),
+                    '.'.join(map(str, self.docker_py_versioninfo)),
                     api_version))
 
     def get_links(self, links):


### PR DESCRIPTION
Hi,

On master, there is an error when formating the error message after the check of a capability fails.

For example, with the following recipe:

```
- docker:
    state=running
    image=busybox
    restart_policy=always
```

Presence of `restart_policy` parameter will call `ensure_capability('restart_policy')`. If the remote system doesn't have required versions of `docker-py` or `docker`, we got the following trace:

```
Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-tmp-1426682489.01-149944249088994/docker", line 3101, in <module>
    main()
  File "/root/.ansible/tmp/ansible-tmp-1426682489.01-149944249088994/docker", line 1475, in main
    started(manager, containers, count, name)
  File "/root/.ansible/tmp/ansible-tmp-1426682489.01-149944249088994/docker", line 1336, in started
    manager.start_containers(created)
  File "/root/.ansible/tmp/ansible-tmp-1426682489.01-149944249088994/docker", line 1237, in start_containers
    self.ensure_capability('restart_policy')
  File "/root/.ansible/tmp/ansible-tmp-1426682489.01-149944249088994/docker", line 661, in ensure_capability
    '.'.join(self._cap_ver_req[capability][0]),
TypeError: sequence item 0: expected string, int found
```

My patch converts to strings all tuple items (that are integers) before do the `join` (which handles only strings). So on my system, it correctly displays the expected error message:

```
msg: Specifying the `restart_policy` parameter requires docker-py: 0.5.0, docker server apiversion 1.14; found docker-py: 0.5.0, server: 1.12
```
