### PR TITLE
Allow to add build flags for gem installation

### DIFF
--- a/packaging/language/gem.py
+++ b/packaging/language/gem.py
@@ -73,6 +73,11 @@ options:
     required: false
     default: "no"
     version_added: "1.6"
+  build_flags:
+    description:
+      - Allow adding build flags for gem compilation
+    required: false
+    version_added: "2.0"
 author: Johan Wiren
 '''
 
@@ -185,6 +190,8 @@ def install(module):
     cmd.append('--no-rdoc')
     cmd.append('--no-ri')
     cmd.append(module.params['gem_source'])
+    if module.params['build_flags']:
+        cmd.extend([ '--', module.params['build_flags'] ])
     module.run_command(cmd, check_rc=True)
 
 def main():
@@ -198,8 +205,9 @@ def main():
             repository           = dict(required=False, aliases=['source'], type='str'),
             state                = dict(required=False, default='present', choices=['present','absent','latest'], type='str'),
             user_install         = dict(required=False, default=True, type='bool'),
-            pre_release           = dict(required=False, default=False, type='bool'),
+            pre_release          = dict(required=False, default=False, type='bool'),
             version              = dict(required=False, type='str'),
+            build_flags          = dict(required=False, type='str'),
         ),
         supports_check_mode = True,
         mutually_exclusive = [ ['gem_source','repository'], ['gem_source','version'] ],


### PR DESCRIPTION
This allows to add gem module specific build flags. This will make it possible to install some gems without problems, if they need build flags to compile native code. 
#### A specific example

Nokogiri is a widely used xml library for ruby. It ships with a packaged libxml2, which is not compatible to some systems (for me it was on Fedora). To make the compilation work it needs the build flags `--use-system-libraries`
**Without this change it is not possible to install gems using nokogiri (or any other gem needing specific build flags)**

With this change:

```
gem: name=nokogiri state=latest user_install=no build_flags='--use-system-libraries'
```

and it works.
