### PR TITLE
Fix typo that prevents use_tls 'encrypt' option from working properly.

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -609,7 +609,7 @@ class DockerManager(object):
                 else:
                     params['verify'] = True
                     params['assert_hostname'] = tls_hostname
-            elif use_tls == 'encrpyt':
+            elif use_tls == 'encrypt':
                 params['verify'] = False
 
             if params:


### PR DESCRIPTION
Fix typo that prevents use_tls 'encrypt' option from working properly.
