### PR TITLE
Add missing import of apt.debfile

### DIFF
--- a/packaging/os/apt.py
+++ b/packaging/os/apt.py
@@ -523,6 +523,7 @@ def main():
             module.run_command('apt-get update && apt-get install python-apt -y -q', use_unsafe_shell=True, check_rc=True)
             global apt, apt_pkg
             import apt
+            import apt.debfile
             import apt_pkg
         except ImportError:
             module.fail_json(msg="Could not import python modules: apt, apt_pkg. Please install python-apt package.")


### PR DESCRIPTION
In cases when the python-apt package is not installed, ansible will
attempt to install it. After this attempt, it tries to import the
needed apt modules, but forgets to import the apt.debfile module.

The result is that playbooks that use the deb argument on a machine
that does not initially have the python-apt package available will
fail with the following error

AttributeError: 'module' object has no attribute 'debfile'

This patch adds the appropriate import to the apt module to ensure
that necessary libraries are available in cases when the deb argument
is being used on a system that does not initially have the python-apt
package installed
