### PR TITLE
1-line fix Darwin group_mod in system/group module by adding **kwargs

### DIFF
--- a/system/group.py
+++ b/system/group.py
@@ -283,7 +283,7 @@ class DarwinGroup(Group):
         (rc, out, err) = self.execute_command(cmd)
         return (rc, out, err)
 
-    def group_mod(self):
+    def group_mod(self, **kwargs):
         info = self.group_info()
         if self.gid is not None and int(self.gid) != info[2]:
             cmd = [self.module.get_bin_path('dseditgroup', True)]

--- a/system/group.py
+++ b/system/group.py
@@ -121,7 +121,7 @@ class Group(object):
         if len(cmd) == 1:
             return (None, '', '')
         if self.module.check_mode:
-	    return (0, '', '')
+            return (0, '', '')
         cmd.append(self.name)
         return self.execute_command(cmd)
 
@@ -150,7 +150,7 @@ class SunOS(Group):
 
     This overrides the following methods from the generic class:-
         - group_add()
-    """ 
+    """
 
     platform = 'SunOS'
     distribution = None


### PR DESCRIPTION
This also contains two tiny spacing/indentation changes, contained in a second commit.
