### PR TITLE
Fix support for comma seperated feature names in the name parameter of...

### DIFF
--- a/windows/win_feature.ps1
+++ b/windows/win_feature.ps1
@@ -28,7 +28,7 @@ $result = New-Object PSObject -Property @{
 }
 
 If ($params.name) {
-    $name = $params.name
+    $name = $params.name -split ',' | % { $_.Trim() }
 }
 Else {
     Fail-Json $result "mising required argument: name"


### PR DESCRIPTION
According to the documentation it should be possible to install multiple windows features at once by comma separating them using the win_feature module:

http://docs.ansible.com/win_feature_module.htm
$ ansible -i hosts -m win_feature -a "name=Web-Server,Web-Common-Http" all

At the moment this does not work because the comma separated list of features is passed to the underlyng Add-WindowsFeature cmdlet as a single string. This is a bug. The Add-WindowsFeature and Install-WindowsFeature cmdlets require the list to be passed as a string[]

This patch splits the string and removes whitespace. If the input is not a comma seperated list; powershell coerces the result to a string so the previous behaviour is preserved. It has been tested on Windows 2008 R2 and Windows 2012 R2.
