### PR TITLE
[docker] pulling missing docker image before doing anything

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -1460,10 +1460,14 @@ def main():
         if count > 1 and name:
             module.fail_json(msg="Count and name must not be used together")
 
-        # Explicitly pull new container images, if requested.
-        # Do this before noticing running and deployed containers so that the image names will differ
-        # if a newer image has been pulled.
-        if pull == "always":
+        # Explicitly pull new container images, if requested. Do this before
+        # noticing running and deployed containers so that the image names
+        # will differ if a newer image has been pulled.
+        # Missing images should be pulled first to avoid downtime when old
+        # container is stopped, but image for new one is now downloaded yet.
+        # It also prevents removal of running container before realizing
+        # that requested image cannot be retrieved.
+        if pull == "always" or (state == 'reloaded' and manager.get_inspect_image() is None):
             manager.pull_image()
 
         containers = ContainerSet(manager)


### PR DESCRIPTION
This actually fixes #670.

Fixed scenarios:
- First
  1. Run container from 10gb image
  2. Run newer version that requires download of 10 more gb
  3. Boom, running container is nuked and nothing works before newer image is downloaded
- Second
  1. Run some super-duper important container
  2. Change image to something that does not exist, deploy
  3. Boom, running container is nuked and error is presented to a user

In both scenarios error would happen before nuking current container.
