### PR TITLE
Handle ini file properties that contain interpolation errors

### DIFF
--- a/files/ini_file.py
+++ b/files/ini_file.py
@@ -120,6 +120,9 @@ def do_ini(module, filename, section=None, option=None, value=None, state='prese
                     if cp.get(section, option):
                         cp.remove_option(section, option)
                         changed = True
+                except ConfigParser.InterpolationError:
+                    cp.remove_option(section, option)
+                    changed = True
                 except:
                     pass
 
@@ -141,6 +144,9 @@ def do_ini(module, filename, section=None, option=None, value=None, state='prese
                 cp.set(section, option, value)
                 changed = True
             except ConfigParser.NoOptionError:
+                cp.set(section, option, value)
+                changed = True
+            except ConfigParser.InterpolationError:
                 cp.set(section, option, value)
                 changed = True
 


### PR DESCRIPTION
If the initial values present in an ini file contain interpolation errors, the ini_file module errors out and cannot modify or remove them.

The error can be reproduced with a simple playbook:

```

---
- hosts: all
  tasks:
  - name: create test ini file
    lineinfile: dest=/tmp/bad.ini create=true line='[test]'
  - name: create faulty ini file data
    lineinfile: dest=/tmp/bad.ini create=true line='{{ item }} = %(badvalue)'
    with_items:
    - option1
    - option2
  - name: delete a bad option
    ini_file: dest=/tmp/bad.ini section=test option=option1 state=absent
  - name: modify a bad option
    ini_file: dest=/tmp/bad.ini section=test option=option2 value=newval
```
