### PR TITLE
[docker] Compare container's configured image instead of running image

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -420,6 +420,13 @@ def get_split_image_tag(image):
 
     return resource, tag
 
+def normalize_image(image):
+    """
+    Normalize a Docker image name to include the implied :latest tag.
+    """
+
+    return ":".join(get_split_image_tag(image))
+
 
 def is_running(container):
     '''Return True if an inspected container is in a state we consider "running."'''
@@ -1109,11 +1116,13 @@ class DockerManager(object):
         if inspected:
             repo_tags = self.get_image_repo_tags()
         else:
-            image, tag = get_split_image_tag(self.module.params.get('image'))
-            repo_tags = [':'.join([image, tag])]
+            repo_tags = [normalize_image(self.module.params.get('image'))]
 
         for i in self.client.containers(all=True):
-            running_image = i['Image']
+            details = self.client.inspect_container(i['Id'])
+            details = _docker_id_quirk(details)
+
+            running_image = normalize_image(details['Config']['Image'])
             running_command = i['Command'].strip()
 
             if name:
@@ -1128,9 +1137,6 @@ class DockerManager(object):
                 matches = image_matches and command_matches
 
             if matches:
-                details = self.client.inspect_container(i['Id'])
-                details = _docker_id_quirk(details)
-
                 deployed.append(details)
 
         return deployed

--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -1119,15 +1119,17 @@ class DockerManager(object):
             repo_tags = [normalize_image(self.module.params.get('image'))]
 
         for i in self.client.containers(all=True):
-            details = self.client.inspect_container(i['Id'])
-            details = _docker_id_quirk(details)
-
-            running_image = normalize_image(details['Config']['Image'])
-            running_command = i['Command'].strip()
+            details = None
 
             if name:
                 matches = name in i.get('Names', [])
             else:
+                details = self.client.inspect_container(i['Id'])
+                details = _docker_id_quirk(details)
+
+                running_image = normalize_image(details['Config']['Image'])
+                running_command = i['Command'].strip()
+
                 image_matches = running_image in repo_tags
 
                 # if a container has an entrypoint, `command` will actually equal
@@ -1137,6 +1139,10 @@ class DockerManager(object):
                 matches = image_matches and command_matches
 
             if matches:
+                if not details:
+                    details = self.client.inspect_container(i['Id'])
+                    details = _docker_id_quirk(details)
+
                 deployed.append(details)
 
         return deployed


### PR DESCRIPTION
The "Image" field returned by `client.containers(all=True)` is the same one that's used for the output of `docker ps`. It's chosen from the list of image and tag names currently known by Docker, which means that if the image and tag have been changed by a pull since the container was launched, it will be a SHA rather than a real name, and `get_deployed_containers()` will no longer recognize it as a matching container.

This performs a full inspect on each container and compares against a normalized version of "Config/Image" instead, which is the image name that was used when the container was launched. It _is_ somewhat more expensive to do this, because we need to perform an inspect call to the Docker API for each container rather than just the matching ones, but it's necessary for image matching to work properly.

Fixes #989.
