### PR TITLE
[service] Fix bug with upstart detection

### DIFF
--- a/system/service.py
+++ b/system/service.py
@@ -472,7 +472,7 @@ class LinuxService(Service):
             self.module.fail_json(msg="no service or tool found for: %s" % self.name)
 
         # If no service control tool selected yet, try to see if 'service' is available
-        if not self.svc_cmd and location.get('service', False):
+        if self.svc_cmd is None and location.get('service', False):
             self.svc_cmd = location['service']
 
         # couldn't find anything yet


### PR DESCRIPTION
Upstart scripts are being incorrectly identified as SysV init scripts due to a logic error in the `service` module.

Because upstart uses multiple commands (`/sbin/start`, `/sbin/stop`, etc.) for managing service state, the codepath for upstart sets `self.svc_cmd` to an empty string on line 451.

Empty strings are considered a non-truthy value in Python, so conditionals which are checking the state of `self.svc_cmd` should explicitly compare it to `None` to avoid overlooking the fact that the service may be controlled by an upstart script.
