### PR TITLE
gc_storage allow setting headers

### DIFF
--- a/cloud/google/gc_storage.py
+++ b/cloud/google/gc_storage.py
@@ -58,6 +58,7 @@ options:
     required: false
     default: private 
   headers:
+    version_added: 2.0
     description:
       - Headers to attach to object.
     required: false


### PR DESCRIPTION
It would be super useful to allow specifying "headers" when uploading a file to google cloud storage.

For example, when uploading a gzipped file to gc_storage I would like to set "Content-Encoding" to "gzip", or specify "Cache-Control".

my task has the following:

``` yml
- name: uploading built files to cloud
  gc_storage: >
    bucket=my-awesome-bucket
    src='{{ item }}'
    object='{{ item | basename }}'
    mode=put
    permission=public-read
    headers='{"Content-Encoding": "gzip", "Cache-Control": "max-age=31536000"}'
  with_fileglob:
    - '{{ repository_path }}/ask-peers/build/production/*'
```

and this is the outcome:

![image](https://cloud.githubusercontent.com/assets/5485798/6859241/9ea30a2c-d40e-11e4-8415-ec40f48cb418.png)
