### PR TITLE
Add body_format for handling of JSON and YAML body

### DIFF
--- a/network/basics/uri.py
+++ b/network/basics/uri.py
@@ -66,7 +66,7 @@ options:
     default: null
   body_format:
     description:
-      - The serialization format of the body. Either raw, json, or yaml. When set to json or yaml, encodes the body argument and automatically sets the Content-Type header accordingly.
+      - The serialization format of the body. Either raw, or json. When set to json, encodes the body argument and automatically sets the Content-Type header accordingly.
     required: false
     default: raw
   method:
@@ -340,7 +340,7 @@ def main():
             user = dict(required=False, default=None),
             password = dict(required=False, default=None),
             body = dict(required=False, default=None),
-            body_format = dict(required=False, default='raw', choices=['raw', 'json', 'yaml']),
+            body_format = dict(required=False, default='raw', choices=['raw', 'json']),
             method = dict(required=False, default='GET', choices=['GET', 'POST', 'PUT', 'HEAD', 'DELETE', 'OPTIONS', 'PATCH']),
             return_content = dict(required=False, default='no', type='bool'),
             force_basic_auth = dict(required=False, default='no', type='bool'),
@@ -376,13 +376,10 @@ def main():
 
     dict_headers = {}
 
-    # If body_format is json or yaml, encore the body (wich can be a dict or a list) and automatically sets the Content-Type header
+    # If body_format is json, encodes the body (wich can be a dict or a list) and automatically sets the Content-Type header
     if body_format == 'json':
         body = json.dumps(body)
         dict_headers['Content-Type'] = 'application/json'
-    elif body_format == 'yaml':
-        body = yaml.dump(body)
-        dict_headers['Content-Type'] = 'application/yaml'
 
 
     # Grab all the http headers. Need this hack since passing multi-values is currently a bit ugly. (e.g. headers='{"Content-Type":"application/json"}')


### PR DESCRIPTION
body_format is a new optional argument that enables handling of JSON or
YAML serialization format for the body argument.
When set to either 'json' or 'yaml', the body argument can be a dict or list.
The body will be encoded, and the Content-Type HTTP header will be set,
accordingly to the body_format argument.

Example:

```
- name: Facette - Create memory graph
  uri:
    method: POST
    url: http://facette/api/v1/library/graphs
    status_code: 201
    body_format: json
    body:
      name: "{{ ansible_fqdn }} - Memory usage"
      attributes:
        Source": "{{ ansible_fqdn }}"
        link: "1947a490-8ac6-4bf2-47c1-ff74272f8b32"
```
