### PR TITLE
[Docker] Add signal parameter when killing container

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -176,6 +176,12 @@ options:
     description:
       - Enable detached mode to leave the container running in background.
     default: true
+  signal:
+    description:
+      - With the state "killed", you can alter the signal sent to the
+        container.
+    required: false
+    default: KILL
   state:
     description:
       - Assert the container's desired state. "present" only asserts that the
@@ -1272,7 +1278,7 @@ class DockerManager(object):
 
     def kill_containers(self, containers):
         for i in containers:
-            self.client.kill(i['Id'])
+            self.client.kill(i['Id'], self.module.params.get('signal'))
             self.increment_counter('killed')
 
     def restart_containers(self, containers):
@@ -1436,6 +1442,7 @@ def main():
             dns             = dict(),
             detach          = dict(default=True, type='bool'),
             state           = dict(default='started', choices=['present', 'started', 'reloaded', 'restarted', 'stopped', 'killed', 'absent', 'running']),
+            signal          = dict(default=None),
             restart_policy  = dict(default=None, choices=['always', 'on-failure', 'no']),
             restart_policy_retry = dict(default=0, type='int'),
             debug           = dict(default=False, type='bool'),


### PR DESCRIPTION
A signal parameter can be given to the kill function ([already present in the 0.3.0](https://github.com/docker/docker-py/blob/0.3.0/docker/client.py#L538)). This pull-request add an optional `signal` parameter in order to define the signal sent to the container, instead of the default KILL.

With a already running container `debian`, you can send a SIGTERM with the following playbook:

``` yaml
- docker:
    image=debian
    state=killed
    signal=TERM
```

The `signal` parameter can't be a choice because signal differs from an OS to another. If an invalid signal is given, the following error is displayed when the playbook is run:

```
msg: Docker API Error: Invalid signal: TOTO
```
