### PR TITLE
Supports creation of vpc instances with boto profile

### DIFF
--- a/cloud/amazon/ec2.py
+++ b/cloud/amazon/ec2.py
@@ -1205,14 +1205,13 @@ def main():
 
     ec2 = ec2_connect(module)
 
-    ec2_url, aws_access_key, aws_secret_key, region = get_ec2_creds(module)
+    region, ec2_url, boto_params = get_aws_connection_info(module)
 
     if region:
         try:
             vpc = boto.vpc.connect_to_region(
                 region,
-                aws_access_key_id=aws_access_key,
-                aws_secret_access_key=aws_secret_key
+                **boto_params
             )
         except boto.exception.NoAuthHandlerFound, e:
             module.fail_json(msg = str(e))


### PR DESCRIPTION
The current ec2 module has a bug whereby it doesn't support creating ec2 instances in a VPC when using a boto profile. If you try to create an instance in a VPC using a boto profile, the default credentials end up being used.  In my setup this results in an 'InvalidSubnetID.NotFound' error message being returned.  

This pull request resolves the bug by adding support for boto profiles.
