### PR TITLE
[docker] Wait for process exit on detached=no.

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -174,7 +174,8 @@ options:
     default: null
   detach:
     description:
-      - Enable detached mode to leave the container running in background.
+      - Enable detached mode to leave the container running in background. If
+        disabled, fail unless the process exits cleanly.
     default: true
   state:
     description:
@@ -1257,6 +1258,13 @@ class DockerManager(object):
         for i in containers:
             self.client.start(i['Id'], **params)
             self.increment_counter('started')
+
+            if not self.module.params.get('detach'):
+                status = self.client.wait(i['Id'])
+                if status != 0:
+                    output = self.client.logs(i['Id'], stdout=True, stderr=True,
+                                              stream=False, timestamps=False)
+                    self.module.fail_json(status=status, msg=output)
 
     def stop_containers(self, containers):
         for i in containers:


### PR DESCRIPTION
This reimplements the PR proposed by @lorin in #588 on top of the refactored Docker module.

I also took the liberty of making this the default behavior any time you specify `detached=no`. If the exit status of the container's process is unimportant, you can use `ignore_errors: yes` to continue regardless.
