### PR TITLE
Strip spaces around MySQL privileges before comparing to valid privileges

### DIFF
--- a/database/mysql/mysql_user.py
+++ b/database/mysql/mysql_user.py
@@ -291,7 +291,7 @@ def privileges_unpack(priv):
                     pieces[0][idx] = "`" + pieces[0][idx] + "`"
             pieces[0] = '.'.join(pieces[0])
 
-        output[pieces[0]] = pieces[1].upper().split(',')
+        output[pieces[0]] = map(lambda s: s.strip(), pieces[1].upper().split(','))
         new_privs = frozenset(output[pieces[0]])
         if not new_privs.issubset(VALID_PRIVS):
             raise InvalidPrivsError('Invalid privileges specified: %s' % new_privs.difference(VALID_PRIVS))


### PR DESCRIPTION
When comparing MySQL privileges to the list of valid privileges we do not strip whitespace from around the privileges.  So, `"*.*:RELOAD, LOCK TABLES, REPLICATION CLIENT"` will lead to the error `msg: invalid privileges string: Invalid privileges specified: frozenset([' LOCK TABLES', ' REPLICATION CLIENT'])`.  As you can see from the error, the "LOCK TABLES" and "REPLICATION CLIENT" have spaces in front of them.  I added a bit of code to strip the whitespaces from the permissions in privileges_unpack().

``` python
>>> test = "*.*:RELOAD, LOCK TABLES, REPLICATION CLIENT"
>>> map(lambda s: s.strip(), test.split(","))
['*.*:RELOAD', 'LOCK TABLES', 'REPLICATION CLIENT']
```
