### PR TITLE
Complete rewrite of ini_file module to remove limitations.

### DIFF
--- a/files/ini_file.py
+++ b/files/ini_file.py
@@ -134,7 +134,7 @@ class IniFile(object):
 
 
     def save(self):
-        f = open(filepath)
+        f = open(filepath, 'w')
         try:
             f.writelines(self.lines)
         finally:

--- a/files/ini_file.py
+++ b/files/ini_file.py
@@ -184,7 +184,8 @@ class IniFile(object):
             if match:
                 #if we're about to leave the desired section, insert our option at the end of it
                 if cur_section == section:
-                    self.lines[last_opt_line+1:last_opt_line+1] = "%s = %s\n" % (option, value)
+                    ins_index = last_opt_line > 0 and last_opt_line + 1 or 0
+                    self.lines[ins_index:ins_index] = "%s = %s\n" % (option, value)
                     return
                 cur_section = match.group(1)
                 last_opt_line = lineno


### PR DESCRIPTION
The old ini_file module was implemented using ConfigParser, which has
some limitations. This implementation removes those limitations.
Specifically:
- comments and blank lines are now preserved
- section headers are no longer required

This implementation should be fully backwards compatible with the old
one.
Fixes https://github.com/ansible/ansible/issues/10071
