### PR TITLE
Fix RDS modify command

### DIFF
--- a/cloud/amazon/rds.py
+++ b/cloud/amazon/rds.py
@@ -759,7 +759,7 @@ def modify_db_instance(module, conn):
     valid_vars = ['apply_immediately', 'backup_retention', 'backup_window',
                   'db_name', 'engine_version', 'instance_type', 'iops', 'license_model',
                   'maint_window', 'multi_zone', 'new_instance_name',
-                  'option_group', 'parameter_group' 'password', 'size', 'upgrade']
+                  'option_group', 'parameter_group', 'password', 'size', 'upgrade']
 
     params = validate_parameters(required_vars, valid_vars, module)
     instance_name = module.params.get('instance_name')


### PR DESCRIPTION
##### Issue Type:

 “Bugfix Pull Request”
##### Ansible Version:

ansible 1.9.0.1
##### Environment:

N/A
##### Summary:

In the documentation it is stated that the RDS `modify` command accepts both a `password` and a `parameter_group`. Neither is the case.
##### Steps To Reproduce:

``` yaml
- name: Modify MySQL RDS instance
  rds:
    command: modify
    instance_name: "{{ db_instance_name }}"
    size: "{{ db_allocated_storage }}"
    instance_type: "{{ db_instance_type }}"
    db_engine: MySQL
    engine_version: 5.6.22
    password: "{{ db_password }}"
    multi_zone: "{{ db_multi_az|lower }}"
    backup_retention: 14
    backup_window: 02:00-04:00
    parameter_group: "{{ db_common['stack_outputs']['RdsDbParameterGroupName'] }}"
    vpc_security_groups: "{{ db_common['stack_outputs']['RdsSecurityGroupIngressName'] }}"
    wait: yes
```
##### Expected Results:

```
____________________________________________________________
< TASK: db_restore | Modify MySQL RDS instance >
 -------------------------------------------------------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||


ok: [localhost]
```
##### Actual Results:

```
 ______________________________________________
< TASK: db_restore | Modify MySQL RDS instance >
 ----------------------------------------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||


failed: [localhost] => {"failed": true}
msg: Parameter parameter_group is not valid for modify command.

FATAL: all hosts have already failed -- aborting
```
