### PR TITLE
Fix modify command when using vpc_security_groups

### DIFF
--- a/cloud/amazon/rds.py
+++ b/cloud/amazon/rds.py
@@ -453,6 +453,9 @@ class RDS2Connection:
             raise RDSException(e)
 
     def modify_db_instance(self, instance_name, **params):
+        # We need a list of ids and not instances
+        vpc_security_groups = params.pop('vpc_security_groups', [])
+        vpc_security_group_ids = [g.vpc_group for g in vpc_security_groups]
         try:
             result = self.connection.modify_db_instance(instance_name, **params)['ModifyDBInstanceResponse']['ModifyDBInstanceResult']['DBInstance']
             return RDS2DBInstance(result)


### PR DESCRIPTION
##### Issue Type:

 “Bugfix Pull Request”
##### Ansible Version:

ansible 1.9.0.1
##### Environment:

N/A
##### Summary:

In the documentation it is stated that the RDS `modify` command accepts a `vpc_security_groups` argument. This does not work when the `RDS2Connection` is used because a recent enough version of
`boto` was detected.
##### Steps To Reproduce:

``` yaml
- name: Modify MySQL RDS instance
  rds:
    command: modify
    instance_name: "{{ db_instance_name }}"
    size: "{{ db_allocated_storage }}"
    instance_type: "{{ db_instance_type }}"
    db_engine: MySQL
    engine_version: 5.6.22
    password: "{{ db_password }}"
    multi_zone: "{{ db_multi_az|lower }}"
    backup_retention: 14
    backup_window: 02:00-04:00
    vpc_security_groups: "sg-1234567"
    wait: yes
```
##### Expected Results:

```
____________________________________________________________
< TASK: db_restore | Modify MySQL RDS instance >
 -------------------------------------------------------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||


ok: [localhost]
```
##### Actual Results:

```
 ______________________________________________
< TASK: db_restore | Modify MySQL RDS instance >
 ----------------------------------------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||


failed: [localhost] => {"failed": true, "parsed": false}
Traceback (most recent call last):
  File "/Users/jan/.ansible/tmp/ansible-tmp-1427882454.31-135383981396060/rds", line 2807, in <module>
    main()
  File "/Users/jan/.ansible/tmp/ansible-tmp-1427882454.31-135383981396060/rds", line 1008, in main
    invocations[module.params.get('command')](module, conn)
  File "/Users/jan/.ansible/tmp/ansible-tmp-1427882454.31-135383981396060/rds", line 769, in modify_db_instance
    result = conn.modify_db_instance(instance_name, **params)
  File "/Users/jan/.ansible/tmp/ansible-tmp-1427882454.31-135383981396060/rds", line 457, in modify_db_instance
    result = self.connection.modify_db_instance(instance_name, **params)['ModifyDBInstanceResponse']['ModifyDBInstanceResult']['DBInstance']
TypeError: modify_db_instance() got an unexpected keyword argument 'vpc_security_groups'
```
