### PR TITLE
redhat_subscription: fix activationkeys argument

### DIFF
--- a/packaging/os/redhat_subscription.py
+++ b/packaging/os/redhat_subscription.py
@@ -207,7 +207,7 @@ class Rhsm(RegistrationBase):
 
         # Generate command arguments
         if activationkey:
-            args.append('--activationkey "%s"' % activationkey)
+            args.extend(['--activationkey', activationkey])
         else:
             if autosubscribe:
                 args.append('--autosubscribe')


### PR DESCRIPTION
Prior to this commit, Ansible would pass `--activationkeys <value>` as a literal string, which the remote server would interpret as a single argument to `subscription-manager`.

This led to the following failure message when using an activation key:

```
  subscription-manager: error: no such option: --activationkey "mykey"
```

This pull request updates the arguments so that the remote server will properly interpret them as two separate values.
