### PR TITLE
gc_storage: Don't use a dict comprehension

### DIFF
--- a/cloud/google/gc_storage.py
+++ b/cloud/google/gc_storage.py
@@ -242,8 +242,10 @@ def transform_headers(headers):
     :rtype: dict
 
     """
-    
-    return {key: str(value) for key, value in headers.items()}
+
+    for key, value in headers.items():
+        headers[key] = str(value)
+    return headers
 
 def upload_gsfile(module, gs, bucket, obj, src, expiry):
     try:


### PR DESCRIPTION
`gc_storage.py` is currently failing py26 tests: https://travis-ci.org/ansible/ansible/jobs/57049057

```
======================================================================
FAIL: test_ast_parse (TestModules.TestModules)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/ansible/ansible/test/units/TestModules.py", line 32, in test_ast_parse
    assert len(ERRORS) == 0, "get_docstring errors: %s" % ERRORS
AssertionError: get_docstring errors: [('/home/travis/build/ansible/ansible/lib/ansible/modules/core/cloud/google/gc_storage.py', SyntaxError('invalid syntax', ('<unknown>', 246, 31, '    return {key: str(value) for key, value in headers.items()}\n'))), ('/home/travis/build/ansible/ansible/lib/ansible/modules/core/cloud/google/gc_storage.py', SyntaxError('invalid syntax', ('<unknown>', 246, 31, '    return {key: str(value) for key, value in headers.items()}\n'))), ('/home/travis/build/ansible/ansible/lib/ansible/modules/core/cloud/google/gc_storage.py', SyntaxError('invalid syntax', ('<unknown>', 246, 31, '    return {key: str(value) for key, value in headers.items()}\n'))), ('/home/travis/build/ansible/ansible/lib/ansible/modules/core/cloud/google/gc_storage.py', SyntaxError('invalid syntax', ('<unknown>', 246, 31, '    return {key: str(value) for key, value in headers.items()}\n')))]
>>  assert len([('/home/travis/build/ansible/ansible/lib/ansible/modules/core/cloud/google/gc_storage.py', SyntaxError('invalid syntax', ('<unknown>', 246, 31, '    return {key: str(value) for key, value in headers.items()}\n'))), ('/home/travis/build/ansible/ansible/lib/ansible/modules/core/cloud/google/gc_storage.py', SyntaxError('invalid syntax', ('<unknown>', 246, 31, '    return {key: str(value) for key, value in headers.items()}\n'))), ('/home/travis/build/ansible/ansible/lib/ansible/modules/core/cloud/google/gc_storage.py', SyntaxError('invalid syntax', ('<unknown>', 246, 31, '    return {key: str(value) for key, value in headers.items()}\n'))), ('/home/travis/build/ansible/ansible/lib/ansible/modules/core/cloud/google/gc_storage.py', SyntaxError('invalid syntax', ('<unknown>', 246, 31, '    return {key: str(value) for key, value in headers.items()}\n')))]) == 0, "get_docstring errors: %s" % [('/home/travis/build/ansible/ansible/lib/ansible/modules/core/cloud/google/gc_storage.py', SyntaxError('invalid syntax', ('<unknown>', 246, 31, '    return {key: str(value) for key, value in headers.items()}\n'))), ('/home/travis/build/ansible/ansible/lib/ansible/modules/core/cloud/google/gc_storage.py', SyntaxError('invalid syntax', ('<unknown>', 246, 31, '    return {key: str(value) for key, value in headers.items()}\n'))), ('/home/travis/build/ansible/ansible/lib/ansible/modules/core/cloud/google/gc_storage.py', SyntaxError('invalid syntax', ('<unknown>', 246, 31, '    return {key: str(value) for key, value in headers.items()}\n'))), ('/home/travis/build/ansible/ansible/lib/ansible/modules/core/cloud/google/gc_storage.py', SyntaxError('invalid syntax', ('<unknown>', 246, 31, '    return {key: str(value) for key, value in headers.items()}\n')))]
```

This PR removes the dict comprehension added at https://github.com/ansible/ansible-modules-core/commit/04c192730031b3acdab939b3050f06660c44230d#diff-905cc7f61909719c68883ee5cabc5d7fR245 and replaces it with a regular for loop.

cc @erjohnso 
