### PR TITLE
Allow parsing of a multiline metadata value by escaping newline caracter.

### DIFF
--- a/cloud/google/gce.py
+++ b/cloud/google/gce.py
@@ -319,7 +319,7 @@ def create_instances(module, gce, instance_names):
     # [ {'key': key1, 'value': value1}, {'key': key2, 'value': value2}, ...]
     if metadata:
         try:
-            md = literal_eval(metadata)
+            md = literal_eval(metadata.replace("\n", "\\n"))
             if not isinstance(md, dict):
                 raise ValueError('metadata must be a dict')
         except ValueError, e:


### PR DESCRIPTION
This is useful for the parsing of a google-container-manifest metadata to succeed.
