### PR TITLE
normalize ports for non-icmp protocols

### DIFF
--- a/cloud/amazon/ec2_group.py
+++ b/cloud/amazon/ec2_group.py
@@ -295,6 +295,12 @@ def main():
                     rule['from_port'] = None
                     rule['to_port'] = None
 
+                if str(rule['proto']) not in ('icmp'):
+                    if rule.get('from_port') in (None, '-1', -1):
+                        rule['from_port'] = None
+                    if rule.get('to_port') in (None, '-1', -1):
+                        rule['to_port'] = None
+
                 # If rule already exists, don't later delete it
                 ruleId = make_rule_key('in', rule, group_id, ip)
                 if ruleId in groupRules:
@@ -334,6 +340,12 @@ def main():
                     rule['proto'] = -1
                     rule['from_port'] = None
                     rule['to_port'] = None
+
+                if str(rule['proto']) not in ('icmp'):
+                    if rule.get('from_port') in (None, '-1', -1):
+                        rule['from_port'] = None
+                    if rule.get('to_port') in (None, '-1', -1):
+                        rule['to_port'] = None
 
                 # If rule already exists, don't later delete it
                 ruleId = make_rule_key('out', rule, group_id, ip)


### PR DESCRIPTION
for rules with custom protocols, when make_rule_key() is run from
inside addRulesToLookup(), the ports in the key are set to None.  when
make_rule_key() is run later to compare the ec2_group module arguments,
the ports in the key are set to "-1" or whatever the user entered.  this
commit sets the ports to None so both usages of make_rule_key() will
match up with each other.

Prior to this commit, the following playbook resulted in an error when run the 2nd time:

```

---
- hosts: localhost
  connection: local
  tasks:
    - name: manage groups
      ec2_group:
        name:        proto-failure-test
        description: proto-failure-test
        vpc_id:      <removed>
        region:      us-east-1
        state:       present
        rules:
          - proto:     50
            from_port: -1
            to_port:   -1
            cidr_ip:   0.0.0.0/0
```

```
TASK: [manage groups] ********************************************************* 
failed: [localhost] => {"failed": true, "parsed": false}
Traceback (most recent call last):
  File "/Users/mspiegle/.ansible/tmp/ansible-tmp-1428091988.01-144802679361344/ec2_group", line 2201, in <module>
    main()
  File "/Users/mspiegle/.ansible/tmp/ansible-tmp-1428091988.01-144802679361344/ec2_group", line 309, in main
    group.authorize(rule['proto'], rule['from_port'], rule['to_port'], ip, grantGroup)
  File "/Library/Python/2.7/site-packages/boto/ec2/securitygroup.py", line 204, in authorize
    dry_run=dry_run)
  File "/Library/Python/2.7/site-packages/boto/ec2/connection.py", line 3193, in authorize_security_group
    params, verb='POST')
  File "/Library/Python/2.7/site-packages/boto/connection.py", line 1207, in get_status
    raise self.ResponseError(response.status, response.reason, body)
boto.exception.EC2ResponseError: EC2ResponseError: 400 Bad Request
<?xml version="1.0" encoding="UTF-8"?>
<Response><Errors><Error><Code>InvalidPermission.Duplicate</Code><Message>the specified rule "peer: 0.0.0.0/0, protocol: 50, ALLOW" already exists</Message></Error></Errors><RequestID>a72d2dd9-e5bf-4db9-91f7-63abc4261301</RequestID></Response>
```
