### PR TITLE
prevent using undefined variable

### DIFF
--- a/packaging/os/apt.py
+++ b/packaging/os/apt.py
@@ -366,7 +366,7 @@ def install_deb(m, debs, cache, force, install_recommends, dpkg_options):
         try:
             pkg = apt.debfile.DebPackage(deb_file)
         except SystemError, e:
-            m.fail_json(msg="Error: %s\nSystem Error: %s" % (pkg._failure_string,str(e)))
+            m.fail_json(msg="System Error: %s" % str(e))
 
         # Check if it's already installed
         if pkg.compare_to_version_in_cache() == pkg.VERSION_SAME:


### PR DESCRIPTION
If deb file had not found message will appear: `NameError: name 'pkg' is not defined`
