### PR TITLE
Add custom headers to get_url module

### DIFF
--- a/network/basics/get_url.py
+++ b/network/basics/get_url.py
@@ -94,6 +94,7 @@ options:
     description:
       - A set of headers provided alongside request.
     required: false
+    version_added: '2.0'
   timeout:
     description:
       - Timeout for URL request


### PR DESCRIPTION
This is just a simple patch to expose headers for get_url module. This option is especially useful in cases like downloading oracle java where one has to accept a license before being able to download which is easily achievable by passing a cookie in a request.

While now such downloads could be achieved using command module like so:

```
- command: curl --location --header "Cookie:oraclelicense=accept-securebackup-cookie" --output /opt/java.tar.gz http://download.oracle.com/otn-pub/java/jdk/8u40-b25/server-jre-8u40-linux-x64.tar.gz
  args:
    creates: /opt/java.tar.gz
```

But this approach implies that you have curl installed on your system which is not always true and so to make the playbook work with most systems you either have to install curl or write a special case for systems with curl and wget separately.

This patch would allow to do this simply using get_url like so:

```
- get_url:
    url: http://download.oracle.com/otn-pub/java/jdk/8u40-b25/server-jre-8u40-linux-x64.tar.gz
    dest: /opt/java.tar.gz
    headers:
      Cookie: "oraclelicense=accept-securebackup-cookie"
```
