### PR TITLE
Add OS architecture and OS name to the Windows setup module

### DIFF
--- a/windows/setup.ps1
+++ b/windows/setup.ps1
@@ -25,6 +25,7 @@ $result = New-Object psobject @{
     changed = $false
 };
 
+$win32_os = Get-WmiObject Win32_OperatingSystem
 $osversion = [Environment]::OSVersion
 $memory = @()
 $memory += Get-WmiObject win32_Physicalmemory
@@ -53,10 +54,13 @@ foreach ($adapter in $ActiveNetcfg)
 
 Set-Attr $result.ansible_facts "ansible_interfaces" $formattednetcfg
 
+Set-Attr $result.ansible_facts "ansible_architecture" $win32_os.OSArchitecture 
+
 Set-Attr $result.ansible_facts "ansible_hostname" $env:COMPUTERNAME;
 Set-Attr $result.ansible_facts "ansible_fqdn" "$([System.Net.Dns]::GetHostByName((hostname)).HostName)"
 Set-Attr $result.ansible_facts "ansible_system" $osversion.Platform.ToString()
 Set-Attr $result.ansible_facts "ansible_os_family" "Windows"
+Set-Attr $result.ansible_facts "ansible_os_name" $win32_os.Name.Split('|')[0]
 Set-Attr $result.ansible_facts "ansible_distribution" $osversion.VersionString
 Set-Attr $result.ansible_facts "ansible_distribution_version" $osversion.Version.ToString()
 


### PR DESCRIPTION
The ansible setup facts module for Windows is missing important details about Windows hosts. 

Here I include two pieces that, currently, I found lacking:
- `ansible_architecture`: 32 or 64 bits.
- `ansible_os_name`: Human readable string that includes the name of the OS, Version and Edition.

I think the importance of the architecture is self explanatory. The importance of the second can be explained with the samples below. In brief, Windows 8.1 and Windows 2012R2 [have the same OS version and build number](https://en.wikipedia.org/wiki/Windows_NT#Releases); the existing information provided by the module was not enough to differentiate the type of OS.

``` json
{
    "ansible_facts": {
        "ansible_architecture": "64-bit",
        "ansible_distribution": "Microsoft Windows NT 6.3.9600.0",
        "ansible_distribution_version": "6.3.9600.0",
        "ansible_fqdn": "81-X64",
        "ansible_hostname": "81-X64",
        "ansible_interfaces": [
            {
                "default_gateway": "192.168.122.1",
                "dns_domain": null,
                "interface_index": 3,
                "interface_name": "Red Hat VirtIO Ethernet Adapter"
            }
        ],
        "ansible_ip_addresses": [
            "192.168.122.91",
            "fe80::da3:39f3:12ca:ef0b"
        ],
        "ansible_os_family": "Windows",
        "ansible_os_name": "Microsoft Windows 8.1 Enterprise",
        "ansible_powershell_version": 4,
        "ansible_system": "Win32NT",
        "ansible_totalmem": 2147483648,
        "ansible_winrm_certificate_expires": "2016-03-13 22:26:32"
    },
    "changed": false
}

{
    "ansible_facts": {
        "ansible_architecture": "64-bit",
        "ansible_distribution": "Microsoft Windows NT 6.3.9600.0",
        "ansible_distribution_version": "6.3.9600.0",
        "ansible_fqdn": "2012R2-X64",
        "ansible_hostname": "2012R2-X64",
        "ansible_interfaces": [
            {
                "default_gateway": "192.168.122.1",
                "dns_domain": null,
                "interface_index": 12,
                "interface_name": "Red Hat VirtIO Ethernet Adapter"
            }
        ],
        "ansible_ip_addresses": [
            "192.168.122.76",
            "fe80::898d:b9c7:a2fb:98c0"
        ],
        "ansible_os_family": "Windows",
        "ansible_os_name": "Microsoft Windows Server 2012 R2 Standard",
        "ansible_powershell_version": 4,
        "ansible_system": "Win32NT",
        "ansible_totalmem": 2147483648,
        "ansible_winrm_certificate_expires": "2016-03-13 20:45:10"
    },
    "changed": false
}
```
