### PR TITLE
Update postgresql users only when necessary

### DIFF
--- a/database/postgresql/postgresql_user.py
+++ b/database/postgresql/postgresql_user.py
@@ -174,8 +174,8 @@ else:
 _flags = ('SUPERUSER', 'CREATEROLE', 'CREATEUSER', 'CREATEDB', 'INHERIT', 'LOGIN', 'REPLICATION')
 VALID_FLAGS = frozenset(itertools.chain(_flags, ('NO%s' % f for f in _flags)))
 
-VALID_PRIVS = dict(table=frozenset(('SELECT', 'INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'REFERENCES', 'TRIGGER', 'ALL', 'USAGE')),
-        database=frozenset(('CREATE', 'CONNECT', 'TEMPORARY', 'TEMP', 'ALL', 'USAGE')),
+VALID_PRIVS = dict(table=frozenset(('SELECT', 'INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'REFERENCES', 'TRIGGER', 'ALL')),
+        database=frozenset(('CREATE', 'CONNECT', 'TEMPORARY', 'TEMP', 'ALL')),
         )
 
 # map to cope with idiosyncracies of SUPERUSER and LOGIN
@@ -326,7 +326,7 @@ def user_delete(cursor, user):
 
 def has_table_privilege(cursor, user, table, priv):
     if priv == 'ALL':
-        priv = [ p for p in VALID_PRIVS['table'] if p != 'ALL' ].join(',')
+        priv = ','.join([ p for p in VALID_PRIVS['table'] if p != 'ALL' ])
     query = 'SELECT has_table_privilege(%s, %s, %s)'
     cursor.execute(query, (user, table, priv))
     return cursor.fetchone()[0]
@@ -381,7 +381,7 @@ def get_database_privileges(cursor, user, db):
 
 def has_database_privilege(cursor, user, db, priv):
     if priv == 'ALL':
-        priv = [ p for p in VALID_PRIVS['database'] if p != 'ALL' ].join(',')
+        priv = ','.join([ p for p in VALID_PRIVS['database'] if p != 'ALL' ])
     query = 'SELECT has_database_privilege(%s, %s, %s)'
     cursor.execute(query, (user, db, priv))
     return cursor.fetchone()[0]


### PR DESCRIPTION
For read-only databases, users should not change when no changes
are required.

Don't issue ALTER ROLE when role attribute flags, users password
or expiry time is not changing.

In certain cases (hashed passwords in the DB, but the password
argument is not hashed) passlib.hash is required to avoid
running ALTER ROLE.
