### PR TITLE
Add support for extra_hosts to docker module

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -246,6 +246,9 @@ options:
         retries.
     default: 0
     version_added: "1.9"
+  extra_hosts:
+    description:
+    - Dict of custom host-to-IP mappings to be defined in the container
   insecure_registry:
     description:
       - Use insecure private registry by HTTP instead of HTTPS. Needed for
@@ -492,6 +495,7 @@ class DockerManager(object):
             'dns': ((0, 3, 0), '1.10'),
             'volumes_from': ((0, 3, 0), '1.10'),
             'restart_policy': ((0, 5, 0), '1.14'),
+            'extra_hosts': ((0, 7, 0), '1.3.1'),
             'pid': ((1, 0, 0), '1.17'),
             # Clientside only
             'insecure_registry': ((0, 5, 0), '0.0')
@@ -1233,7 +1237,7 @@ class DockerManager(object):
 
         optionals = {}
         for optional_param in ('dns', 'volumes_from', 'restart_policy',
-                'restart_policy_retry', 'pid'):
+                'restart_policy_retry', 'pid', 'extra_hosts'):
             optionals[optional_param] = self.module.params.get(optional_param)
 
         if optionals['dns'] is not None:
@@ -1253,6 +1257,10 @@ class DockerManager(object):
         if optionals['pid'] is not None:
             self.ensure_capability('pid')
             params['pid_mode'] = optionals['pid']
+
+        if optionals['extra_hosts'] is not None:
+            self.ensure_capability('extra_hosts')
+            params['extra_hosts'] = optionals['extra_hosts']
 
         for i in containers:
             self.client.start(i['Id'], **params)
@@ -1438,6 +1446,7 @@ def main():
             state           = dict(default='started', choices=['present', 'started', 'reloaded', 'restarted', 'stopped', 'killed', 'absent', 'running']),
             restart_policy  = dict(default=None, choices=['always', 'on-failure', 'no']),
             restart_policy_retry = dict(default=0, type='int'),
+            extra_hosts     = dict(type='dict'),
             debug           = dict(default=False, type='bool'),
             privileged      = dict(default=False, type='bool'),
             stdin_open      = dict(default=False, type='bool'),


### PR DESCRIPTION
extra_hosts parameter (maps to --add-host in 'docker run' syntax) is used
to add host-to-ip mappings to the container.

Example usage:
    - name: start myfoo
      docker:
        name: myfoo
        image: busybox
        state: reloaded
        extra_hosts:
          dockerhost: 127.0.0.1
          foobarhost: 127.0.0.2

After running the playbook you can use docker inspect to verify that the new hosts are defined in the HostConfig section

Support for --add-host was added to docker in 1.31:
http://jasani.org/2014/11/19/docker-now-supports-adding-host-mappings/

extra_hosts was added to docker-py in 0.7.0:
https://github.com/docker/docker-py/commit/29c67c3a0503d2ad8ee1643d3db58962f3e9cfe1
