### PR TITLE
Port `force` functionality from `get_url` module

### DIFF
--- a/windows/win_get_url.ps1
+++ b/windows/win_get_url.ps1
@@ -26,6 +26,15 @@ $result = New-Object psobject @{
     changed = $false
 }
 
+If ($params.force)
+{
+    $force = $params.force | ConvertTo-Bool
+}
+Else
+{
+    $force = $false
+}
+
 If ($params.url) {
     $url = $params.url
 }
@@ -40,17 +49,22 @@ Else {
     Fail-Json $result "missing required argument: dest"
 }
 
-$client = New-Object System.Net.WebClient
+$destIsDir = Test-Path $dest -pathType container
+$destIsFile = Test-Path $dest -pathType leaf
 
-Try {
-    $client.DownloadFile($url, $dest)
-    $result.changed = $true
-}
-Catch {
-    Fail-Json $result "Error downloading $url to $dest"
-}
+If ($destIsDir -or -not $destIsFile -or $force) {
+    $client = New-Object System.Net.WebClient
+    
+    Try {
+        $client.DownloadFile($url, $dest)
+        $result.changed = $true
+    }
+    Catch {
+        Fail-Json $result "Error downloading $url to $dest"
+    }
 
-Set-Attr $result.win_get_url "url" $url
-Set-Attr $result.win_get_url "dest" $dest
+    Set-Attr $result.win_get_url "url" $url
+    Set-Attr $result.win_get_url "dest" $dest
+}
 
 Exit-Json $result;

--- a/windows/win_get_url.py
+++ b/windows/win_get_url.py
@@ -41,6 +41,17 @@ options:
     required: false
     default: yes
     aliases: []
+  force:
+    description:
+      - If C(yes) and C(dest) is not a directory, will download the file every
+        time and replace the file if the contents change. If C(no), the file
+        will only be downloaded if the destination does not exist. Generally
+        should be C(yes) only for small local files. Prior to 2.0, this module
+        behaved as if C(yes) was the default.
+    version_added: "2.0"
+    required: false
+    choices: [ "yes", "no" ]
+    default: "no"
 author: "Paul Durivage (@angstwad)"
 '''
 


### PR DESCRIPTION
Make the Windows `win_get_url` module behave more like `get_url`, with respect of overwriting files.
