### PR TITLE
updates win_msi to allow install/uninstall to wait

### DIFF
--- a/windows/win_msi.ps1
+++ b/windows/win_msi.ps1
@@ -25,7 +25,7 @@ $path = Get-Attr $params "path" -failifempty $true
 $state = Get-Attr $params "state" "present"
 $creates = Get-Attr $params "creates" $false
 $extra_args = Get-Attr $params "extra_args" ""
-$wait = $false
+$wait = Get-Attr $params "wait" $false | ConvertTo-Bool
 
 $result = New-Object psobject @{
     changed = $false
@@ -36,32 +36,27 @@ If (($creates -ne $false) -and ($state -ne "absent") -and (Test-Path $creates))
     Exit-Json $result;
 }
 
-If ($params.wait.ToLower() -eq "true" -Or $params.wait.ToLower() -eq "yes")
-{
-  $wait = $true
-}
-
 $logfile = [IO.Path]::GetTempFileName();
 if ($state -eq "absent")
 {
   If ($wait)
   {
-    Start-Process -FilePath msiexec.exe -ArgumentList "/x $path /qn /l $logfile $extra_args" -Verb Runas -Wait;
+    Start-Process -FilePath msiexec.exe -ArgumentList "/x `"$path`" /qn /l $logfile $extra_args" -Verb Runas -Wait;
   }
   Else
   {
-    Start-Process -FilePath msiexec.exe -ArgumentList "/x $path /qn /l $logfile $extra_args" -Verb Runas;
+    Start-Process -FilePath msiexec.exe -ArgumentList "/x `"$path`" /qn /l $logfile $extra_args" -Verb Runas;
   }
 }
 Else
 {
   If ($wait)
   {
-    Start-Process -FilePath msiexec.exe -ArgumentList "/i $path /qn /l $logfile $extra_args" -Verb Runas -Wait;
+    Start-Process -FilePath msiexec.exe -ArgumentList "/i `"$path`" /qn /l $logfile $extra_args" -Verb Runas -Wait;
   }
   Else
   {
-    Start-Process -FilePath msiexec.exe -ArgumentList "/i $path /qn /l $logfile $extra_args" -Verb Runas;
+    Start-Process -FilePath msiexec.exe -ArgumentList "/i `"$path`" /qn /l $logfile $extra_args" -Verb Runas;
   }
 }
 

--- a/windows/win_msi.ps1
+++ b/windows/win_msi.ps1
@@ -23,10 +23,16 @@ $params = Parse-Args $args;
 
 $result = New-Object psobject;
 Set-Attr $result "changed" $false;
+$wait = $false
 
 If (-not $params.path.GetType)
 {
     Fail-Json $result "missing required arguments: path"
+}
+
+If ($params.wait -eq "true" -Or $params.wait -eq "yes")
+{
+  $wait = $true
 }
 
 $extra_args = ""
@@ -44,13 +50,27 @@ If ($params.creates.GetType -and $params.state.GetType -and $params.state -ne "a
 }
 
 $logfile = [IO.Path]::GetTempFileName();
-if ($params.state.GetType -and $params.state -eq "absent")
+If ($params.state.GetType -and $params.state -eq "absent")
 {
-    msiexec.exe /x $params.path /qb /l $logfile $extra_args;
+  If ($wait)
+  {
+    Start-Process -FilePath msiexec.exe -ArgumentList "/x $params.path /qb /l $logfile $extra_args" -Verb Runas -Wait;
+  }
+  Else
+  {
+    Start-Process -FilePath msiexec.exe -ArgumentList "/x $params.path /qb /l $logfile $extra_args" -Verb Runas;
+  }
 }
 Else
 {
-    msiexec.exe /i $params.path /qb /l $logfile $extra_args;
+  If ($wait)
+  {
+    Start-Process -FilePath msiexec.exe -ArgumentList "/i $params.path /qb /l $logfile $extra_args" -Verb Runas -Wait;
+  }
+  Else
+  {
+    Start-Process -FilePath msiexec.exe -ArgumentList "/i $params.path /qb /l $logfile $extra_args" -Verb Runas;
+  }
 }
 
 Set-Attr $result "changed" $true;

--- a/windows/win_msi.py
+++ b/windows/win_msi.py
@@ -45,12 +45,25 @@ options:
         description:
             - Path to a file created by installing the MSI to prevent from
               attempting to reinstall the package on every run
+    wait:
+        version_added: ""
+        description:
+            - Specify whether to wait for install or uninstall to complete before continuing.
+        choices:
+            - true
+            - yes
+            - false
+            - no
+        default: false
 author: Matt Martz
 '''
 
 EXAMPLES = '''
 # Install an MSI file
 - win_msi: path=C:\\\\7z920-x64.msi
+
+# Install an MSI, and wait for it to complete before continuing
+- win_msi: path=C:\\\\7z920-x64.msi wait=true
 
 # Uninstall an MSI file
 - win_msi: path=C:\\\\7z920-x64.msi state=absent


### PR DESCRIPTION
- Adds additional `wait` param for specifying whether to wait on the install/uninstall to complete.
- Updates to use `Start-Process` (https://technet.microsoft.com/en-us/library/hh849848(v=wps.620).aspx) to allow `-Wait` param
  - `Start-Process` **is** available in PowerShell V2.0 and greater
  - This will allow `msiexec.exe` cmdlet process to wait if specified (which currently isn't supported as an extra arg to `msiexec.exe`)

Questions, concerns, let me know.

Phil
