### PR TITLE
Adds overwrite option to rax_dns_record

### DIFF
--- a/cloud/rackspace/rax_dns_record.py
+++ b/cloud/rackspace/rax_dns_record.py
@@ -49,7 +49,7 @@ options:
       - Add new records if data doesn't match, instead of updating existing
         record with matching name. If there are already multiple records with
         matching name and overwrite=true, this module will fail.
-    default: false
+    default: true
   priority:
     description:
       - Required for MX and SRV records, but forbidden for other record types.
@@ -190,7 +190,7 @@ def rax_dns_record_ptr(module, data=None, comment=None, loadbalancer=None,
 
 
 def rax_dns_record(module, comment=None, data=None, domain=None, name=None,
-                   overwrite=False, priority=None, record_type='A',
+                   overwrite=True, priority=None, record_type='A',
                    state='present', ttl=7200):
     """Function for manipulating record types other than PTR"""
 

--- a/cloud/rackspace/rax_dns_record.py
+++ b/cloud/rackspace/rax_dns_record.py
@@ -44,6 +44,12 @@ options:
     description:
       - FQDN record name to create
     required: True
+  overwrite:
+    description:
+      - Add new records if data doesn't match, instead of updating existing
+        record with matching name. If there are already multiple records with
+        matching name and overwrite=true, this module will fail.
+    default: false
   priority:
     description:
       - Required for MX and SRV records, but forbidden for other record types.
@@ -184,7 +190,8 @@ def rax_dns_record_ptr(module, data=None, comment=None, loadbalancer=None,
 
 
 def rax_dns_record(module, comment=None, data=None, domain=None, name=None,
-                   priority=None, record_type='A', state='present', ttl=7200):
+                   overwrite=False, priority=None, record_type='A',
+                   state='present', ttl=7200):
     """Function for manipulating record types other than PTR"""
 
     changed = False
@@ -206,9 +213,12 @@ def rax_dns_record(module, comment=None, data=None, domain=None, name=None,
             module.fail_json(msg='%s' % e.message)
 
         try:
-            record = domain.find_record(record_type, name=name)
+            if overwrite:
+                record = domain.find_record(record_type, name=name)
+            else:
+                record = domain.find_record(record_type, name=name, data=data)
         except pyrax.exceptions.DomainRecordNotUnique, e:
-            module.fail_json(msg='%s' % e.message)
+            module.fail_json(msg='overwrite=true and there are multiple matching records')
         except pyrax.exceptions.DomainRecordNotFound, e:
             try:
                 record_data = {
@@ -278,6 +288,7 @@ def main():
             domain=dict(),
             loadbalancer=dict(),
             name=dict(required=True),
+            overwrite=dict(type='bool', default=True),
             priority=dict(type='int'),
             server=dict(),
             state=dict(default='present', choices=['present', 'absent']),
@@ -306,6 +317,7 @@ def main():
     domain = module.params.get('domain')
     loadbalancer = module.params.get('loadbalancer')
     name = module.params.get('name')
+    overwrite = module.params.get('overwrite')
     priority = module.params.get('priority')
     server = module.params.get('server')
     state = module.params.get('state')
@@ -323,8 +335,8 @@ def main():
                            state=state, ttl=ttl)
     else:
         rax_dns_record(module, comment=comment, data=data, domain=domain,
-                       name=name, priority=priority, record_type=record_type,
-                       state=state, ttl=ttl)
+                       name=name, overwrite=overwrite, priority=priority,
+                       record_type=record_type, state=state, ttl=ttl)
 
 
 # import module snippets


### PR DESCRIPTION
This is required for creating multiple records with the same name. If you want to stay backward compatible, change the default value of overwrite to True.
