### PR TITLE
fix delete ec2 asg failure because "ScalingActivityInProgress"

### DIFF
--- a/cloud/amazon/ec2_asg.py
+++ b/cloud/amazon/ec2_asg.py
@@ -67,7 +67,7 @@ options:
       - Number of instances you'd like to replace at a time.  Used with replace_all_instances.
     required: false
     version_added: "1.8"
-    default: 1  
+    default: 1
   replace_instances:
     description:
       - List of instance_ids belonging to the named ASG that you would like to terminate and be replaced with instances matching the current launch configuration.
@@ -141,9 +141,9 @@ EXAMPLES = '''
 
 # Rolling ASG Updates
 
-Below is an example of how to assign a new launch config to an ASG and terminate old instances.  
+Below is an example of how to assign a new launch config to an ASG and terminate old instances.
 
-All instances in "myasg" that do not have the launch configuration named "my_new_lc" will be terminated in 
+All instances in "myasg" that do not have the launch configuration named "my_new_lc" will be terminated in
 a rolling fashion with instances using the current launch configuration, "my_new_lc".
 
 This could also be considered a rolling deploy of a pre-baked AMI.
@@ -494,7 +494,7 @@ def replace(connection, module):
     if replaceable == 0:
         changed = False
         return(changed, props)
-        
+
     # set temporary settings and wait for them to be reached
     as_group = connection.get_all_groups(names=[group_name])[0]
     as_group.max_size = max_size + batch_size
@@ -514,8 +514,8 @@ def replace(connection, module):
         wait_for_elb(connection, module, group_name)
         as_group = connection.get_all_groups(names=[group_name])[0]
     # return settings to normal
-    as_group.max_size = max_size 
-    as_group.min_size = min_size 
+    as_group.max_size = max_size
+    as_group.min_size = min_size
     as_group.desired_capacity = desired_capacity
     as_group.update()
     as_group = connection.get_all_groups(names=[group_name])[0]
@@ -546,7 +546,7 @@ def terminate_batch(connection, module, replace_instances):
     # set all instances given to unhealthy
     for instance_id in old_instances:
         connection.set_instance_health(instance_id,'Unhealthy')
-    
+
     # we wait to make sure the machines we marked as Unhealthy are
     # no longer in the list
 
@@ -609,9 +609,9 @@ def main():
             wait_for_instances=dict(type='bool', default=True)
         ),
     )
-    
+
     module = AnsibleModule(
-        argument_spec=argument_spec, 
+        argument_spec=argument_spec,
         mutually_exclusive = [['replace_all_instances', 'replace_instances']]
     )
 

--- a/cloud/amazon/ec2_asg.py
+++ b/cloud/amazon/ec2_asg.py
@@ -445,10 +445,7 @@ def delete_autoscaling_group(connection, module):
     groups = connection.get_all_groups(names=[group_name])
     if groups:
         group = groups[0]
-        group.max_size = 0
-        group.min_size = 0
-        group.desired_capacity = 0
-        group.update()
+        group.shutdown_instances()
 
         while True:
             try:

--- a/cloud/amazon/ec2_asg.py
+++ b/cloud/amazon/ec2_asg.py
@@ -458,7 +458,16 @@ def delete_autoscaling_group(connection, module):
                    instances = False
             time.sleep(10)
 
-        group.delete()
+        while True:
+            try:
+                group.delete()
+                break
+            except BotoServerError, e:
+                if e.error_code == 'ScalingActivityInProgress' or e.error_code == 'ResourceInUse':
+                    time.sleep(10)
+                else:
+                    raise e
+
         while len(connection.get_all_groups(names=[group_name])):
             time.sleep(5)
         changed=True

--- a/cloud/amazon/ec2_asg.py
+++ b/cloud/amazon/ec2_asg.py
@@ -449,14 +449,6 @@ def delete_autoscaling_group(connection, module):
         group.min_size = 0
         group.desired_capacity = 0
         group.update()
-        instances = True
-        while instances:
-            tmp_groups = connection.get_all_groups(names=[group_name])
-            if tmp_groups:
-                tmp_group = tmp_groups[0]
-                if not tmp_group.instances:
-                   instances = False
-            time.sleep(10)
 
         while True:
             try:


### PR DESCRIPTION
When deleting an ec2 asg the status `ScalingActivityInProgress` may appear and should be retried.

```
10:52:16 TASK: [app | Deploy blue/green update of CMS app AMI - Gracefully terminate previous asg] *** 
10:54:17 failed: [localhost] => {"failed": true, "parsed": false}
10:54:17 Traceback (most recent call last):
10:54:17   File "/var/lib/jenkins/.ansible/tmp/ansible-tmp-1428915136.17-78977212951736/ec2_asg", line 2437, in <module>
10:54:17     main()
10:54:17   File "/var/lib/jenkins/.ansible/tmp/ansible-tmp-1428915136.17-78977212951736/ec2_asg", line 2428, in main
10:54:17     changed = delete_autoscaling_group(connection, module)
10:54:17   File "/var/lib/jenkins/.ansible/tmp/ansible-tmp-1428915136.17-78977212951736/ec2_asg", line 2255, in delete_autoscaling_group
10:54:17     group.delete()
10:54:17   File "/var/lib/jenkins/workspace/stable-update-cmspool-staging/venv/lib/python2.6/site-packages/boto/ec2/autoscale/group.py", line 300, in delete
10:54:17     force_delete)
10:54:17   File "/var/lib/jenkins/workspace/stable-update-cmspool-staging/venv/lib/python2.6/site-packages/boto/ec2/autoscale/__init__.py", line 210, in delete_auto_scaling_group
10:54:17     return self.get_object('DeleteAutoScalingGroup', params, Request)
10:54:17   File "/var/lib/jenkins/workspace/stable-update-cmspool-staging/venv/lib/python2.6/site-packages/boto/connection.py", line 1204, in get_object
10:54:17     raise self.ResponseError(response.status, response.reason, body)
10:54:17 boto.exception.BotoServerError: BotoServerError: 400 Bad Request
10:54:17 <ErrorResponse xmlns="http://autoscaling.amazonaws.com/doc/2011-01-01/">
10:54:17   <Error>
10:54:17     <Type>Sender</Type>
10:54:17     <Code>ScalingActivityInProgress</Code>
10:54:17     <Message>You cannot delete an AutoScalingGroup while there are scaling activities in progress for that group.</Message>
10:54:17   </Error>
10:54:17   <RequestId>aaa95c15-e1ba-11e4-8dc4-e336f2de97de</RequestId>
10:54:17 </ErrorResponse>
10:54:17 
10:54:17 
10:54:17 
10:54:17 FATAL: all hosts have already failed -- aborting
```
