### PR TITLE
fixed bug where scaling policy return a random policy.

### DIFF
--- a/cloud/amazon/ec2_scaling_policy.py
+++ b/cloud/amazon/ec2_scaling_policy.py
@@ -88,7 +88,7 @@ def create_scaling_policy(connection, module):
 
         try:
             connection.create_scaling_policy(sp)
-            policy = connection.get_all_policies(policy_names=[sp_name])[0]
+            policy = connection.get_all_policies(as_group=asg_name,policy_names=[sp_name])[0]
             module.exit_json(changed=True, name=policy.name, arn=policy.policy_arn, as_name=policy.as_name, scaling_adjustment=policy.scaling_adjustment, cooldown=policy.cooldown, adjustment_type=policy.adjustment_type, min_adjustment_step=policy.min_adjustment_step)
         except BotoServerError, e:
             module.fail_json(msg=str(e))
@@ -115,7 +115,7 @@ def create_scaling_policy(connection, module):
         try:
             if changed:
                 connection.create_scaling_policy(policy)
-                policy = connection.get_all_policies(policy_names=[sp_name])[0]
+                policy = connection.get_all_policies(as_group=asg_name,policy_names=[sp_name])[0]
             module.exit_json(changed=changed, name=policy.name, arn=policy.policy_arn, as_name=policy.as_name, scaling_adjustment=policy.scaling_adjustment, cooldown=policy.cooldown, adjustment_type=policy.adjustment_type, min_adjustment_step=policy.min_adjustment_step)
         except BotoServerError, e:
             module.fail_json(msg=str(e))


### PR DESCRIPTION
Fixed bug where scaling policy return a random policy if many autoscale group have policies with same name.

Sorry if I didn't follow the guidelines. Appears to be very obvious bug obvious as a problem.
