### PR TITLE
Add support for 'update' parameter to hg module

### DIFF
--- a/source_control/hg.py
+++ b/source_control/hg.py
@@ -65,6 +65,13 @@ options:
         required: false
         default: "no"
         choices: [ "yes", "no" ]
+    update:
+        required: false
+        default: "yes"
+        choices: [ "yes", "no" ]
+        version_added: "2.0"
+        description:
+            - If C(no), do not retrieve new revisions from the origin repository
     executable:
         required: false
         default: null
@@ -210,6 +217,7 @@ def main():
             revision = dict(default=None, aliases=['version']),
             force = dict(default='no', type='bool'),
             purge = dict(default='no', type='bool'),
+            update = dict(default='yes', type='bool'),
             executable = dict(default=None),
         ),
     )
@@ -218,6 +226,7 @@ def main():
     revision = module.params['revision']
     force = module.params['force']
     purge = module.params['purge']
+    update = module.params['update']
     hg_path = module.params['executable'] or module.get_bin_path('hg', True)
     hgrc = os.path.join(dest, '.hg/hgrc')
 
@@ -234,6 +243,9 @@ def main():
         (rc, out, err) = hg.clone()
         if rc != 0:
             module.fail_json(msg=err)
+    elif not update:
+        # Just return having found a repo already in the dest path
+        before = hg.get_revision()
     elif hg.at_revision:
         # no update needed, don't pull
         before = hg.get_revision()


### PR DESCRIPTION
This adds support for an 'update' parameter similar to git's. Set it to false to prevent ansible from trying to update an existing checkout.
