### PR TITLE
make migrate command idempotent with django built-in migrations

### DIFF
--- a/web_infrastructure/django_manage.py
+++ b/web_infrastructure/django_manage.py
@@ -89,7 +89,7 @@ notes:
    - I(virtualenv) (U(http://www.virtualenv.org)) must be installed on the remote host if the virtualenv parameter is specified.
    - This module will create a virtualenv if the virtualenv parameter is specified and a virtualenv does not already exist at the given location.
    - This module assumes English error messages for the 'createcachetable' command to detect table existence, unfortunately.
-   - To be able to use the migrate command, you must have south installed and added as an app in your settings
+   - To be able to use the migrate command with django versions < 1.7, you must have south installed and added as an app in your settings
    - To be able to use the collectstatic command, you must have enabled staticfiles in your settings
 requirements: [ "virtualenv", "django" ]
 author: Scott Anderson
@@ -159,7 +159,7 @@ def syncdb_filter_output(line):
     return ("Creating table " in line) or ("Installed" in line and "Installed 0 object" not in line)
 
 def migrate_filter_output(line):
-    return ("Migrating forwards " in line) or ("Installed" in line and "Installed 0 object" not in line)
+    return ("Migrating forwards " in line) or ("Installed" in line and "Installed 0 object" not in line) or ("Applying" in line)
 
 def main():
     command_allowed_param_map = dict(


### PR DESCRIPTION
Django since version 1.7 has built-in migrations, so no need to have south installed with recent django versions. The 'migrate' command works with built-in migrations without any change, but the output is different than the output produced by south, which breaks idempotence. This commit fixes this.
