### PR TITLE
django_manage: Use shebang in manage.py instead of hardcoded "python"

### DIFF
--- a/web_infrastructure/django_manage.py
+++ b/web_infrastructure/django_manage.py
@@ -234,7 +234,7 @@ def main():
 
     _ensure_virtualenv(module)
 
-    cmd = "python manage.py %s" % (command, )
+    cmd = "./manage.py %s" % (command, )
 
     if command in noinput_commands:
         cmd = '%s --noinput' % cmd


### PR DESCRIPTION
Changed django_manage to call manage.py using `./manage.py` instead of `python manage.py` which brings some pros and cons.

**Pros**:
- manage.py can call any system-wide python like python 3 which can't be called if it's not inside the virtualenv
- manage.py can still call virtualenv python after virtualenv has been started by setting the shebang to `#!/bin/env python` (which is the default of django's `startproject`)

**Cons**:
- manage.py must be executable by the user otherwise the script will fail (it is executable by default if project was create with django's `startproject`)
- it's something new and some people may need to change thing
