### PR TITLE
Issue #1161 DigitalOcean API 2 ssh_key_ids problem

### DIFF
--- a/cloud/digital_ocean/digital_ocean.py
+++ b/cloud/digital_ocean/digital_ocean.py
@@ -59,7 +59,7 @@ options:
      - This is the slug of the region you would like your server to be created in.
   ssh_key_ids:
     description:
-     - Optional, array of of ssh_key_ids that you would like to be added to the server.
+     - Optional, array of of SSH key (numeric) ID that you would like to be added to the server.
   virtio:
     description:
      - "Bool, turn on virtio driver in droplet for improved network and storage I/O."
@@ -154,7 +154,7 @@ EXAMPLES = '''
 
 - digital_ocean: >
       state=present
-      ssh_key_ids=[id1,id2]
+      ssh_key_ids=123,456
       name=mydroplet
       api_token=XXX
       size_id=2gb
@@ -398,7 +398,7 @@ def main():
             size_id = dict(),
             image_id = dict(),
             region_id = dict(),
-            ssh_key_ids = dict(default=''),
+            ssh_key_ids = dict(type='list'),
             virtio = dict(type='bool', default='yes'),
             private_networking = dict(type='bool', default='no'),
             backups_enabled = dict(type='bool', default='no'),


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

```
ansible 2.0.0 (devel f4172fb9da) last updated 2015/04/18 19:42:59 (GMT +200)
  lib/ansible/modules/core: (detached HEAD a19fa6ba48) last updated 2015/04/18 19:43:07 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD df7fcc90d9) last updated 2015/04/18 19:43:15 (GMT +200)
  v2/ansible/modules/core: (detached HEAD 34784b7a61) last updated 2015/04/18 19:43:24 (GMT +200)
  v2/ansible/modules/extras: (detached HEAD df7fcc90d9) last updated 2015/04/18 19:43:35 (GMT +200)
  configured module search path = None
```
##### Environment:

Irrevelant (Slackware GNU/Linux).
##### Summary:

Fix issue #1161.
- fix documentation: show a valid syntax
- make ssh_key_ids a list and not a string
