### PR TITLE
Allow custom methods in uri module

### DIFF
--- a/network/basics/uri.py
+++ b/network/basics/uri.py
@@ -73,7 +73,6 @@ options:
     description:
       - The HTTP method of the request or response.
     required: false
-    choices: [ "GET", "POST", "PUT", "HEAD", "DELETE", "OPTIONS", "PATCH" ]
     default: "GET"
   return_content:
     description:
@@ -341,7 +340,7 @@ def main():
             password = dict(required=False, default=None),
             body = dict(required=False, default=None),
             body_format = dict(required=False, default='raw', choices=['raw', 'json']),
-            method = dict(required=False, default='GET', choices=['GET', 'POST', 'PUT', 'HEAD', 'DELETE', 'OPTIONS', 'PATCH']),
+            method = dict(required=False, default='GET'),
             return_content = dict(required=False, default='no', type='bool'),
             force_basic_auth = dict(required=False, default='no', type='bool'),
             follow_redirects = dict(required=False, default='safe', choices=['all', 'safe', 'none', 'yes', 'no']),

--- a/network/basics/uri.py
+++ b/network/basics/uri.py
@@ -73,6 +73,7 @@ options:
     description:
       - The HTTP method of the request or response.
     required: false
+    choices: [ "GET", "POST", "PUT", "HEAD", "DELETE", "OPTIONS", "PATCH", "TRACE", "CONNECT", "REFRESH" ]
     default: "GET"
   return_content:
     description:
@@ -340,7 +341,7 @@ def main():
             password = dict(required=False, default=None),
             body = dict(required=False, default=None),
             body_format = dict(required=False, default='raw', choices=['raw', 'json']),
-            method = dict(required=False, default='GET'),
+            method = dict(required=False, default='GET', choices=['GET', 'POST', 'PUT', 'HEAD', 'DELETE', 'OPTIONS', 'PATCH', 'TRACE', 'CONNECT', 'REFRESH']),
             return_content = dict(required=False, default='no', type='bool'),
             force_basic_auth = dict(required=False, default='no', type='bool'),
             follow_redirects = dict(required=False, default='safe', choices=['all', 'safe', 'none', 'yes', 'no']),


### PR DESCRIPTION
I want to use Ansible in a task to refresh Varnish caches. To do so, I have to send a _REFRESH_ request. Unfortunately it is currently not possible, because the _uri_ module restricts the methods to `[GET,POST,PUT,HEAD,DELETE,OPTIONS,PATCH]`.
I would like to propose to remove this restriction and allow any string to be use as a method. I looked into the [RFC2616](https://datatracker.ietf.org/doc/rfc2616/) if there is a list of restricted methods to allow, but it tells only that 

> The methods GET and HEAD MUST be supported by all general-purpose servers. 

So I think there is no reason to restrict the methods to this list. (Otherwise we should rename the _uri_ module to something like _rest_api_)
