### PR TITLE
Fixes regression introduced by edf1ac1ea6ffd5d44bb2bb62ad320364baf310a3

### DIFF
--- a/cloud/amazon/ec2_vpc.py
+++ b/cloud/amazon/ec2_vpc.py
@@ -486,14 +486,15 @@ def create_vpc(module, vpc_conn):
             'id': sn.id,
         })
 
-    # Sort subnets by the order they were listed in the play
-    order = {}
-    for idx, val in enumerate(subnets):
-        order[val['cidr']] = idx
+    if subnets is not None:
+        # Sort subnets by the order they were listed in the play
+        order = {}
+        for idx, val in enumerate(subnets):
+            order[val['cidr']] = idx
 
-    # Number of subnets in the play
-    subnets_in_play = len(subnets)
-    returned_subnets.sort(key=lambda x: order.get(x['cidr'], subnets_in_play))
+        # Number of subnets in the play
+        subnets_in_play = len(subnets)
+        returned_subnets.sort(key=lambda x: order.get(x['cidr'], subnets_in_play))
 
     return (vpc_dict, created_vpc_id, returned_subnets, changed)
 


### PR DESCRIPTION
Issue Type:

Bugfix Pull Request

Ansible Version:

ansible 1.9.0.1
  configured module search path = None

Environment:

N/A

Summary:

edf1ac1ea6ffd5d44bb2bb62ad320364baf310a3 introduced a regression in behavior.  The documentation specifies that the `subnets` key may be omitted from the ec2_vpc module, but edf1ac1ea6ffd5d44bb2bb62ad320364baf310a3 tries to enumerate on `subnets` without checking if it was provided.

Steps To Reproduce:

Assuming the subnets referred to in the route tables below were created in a prior task, and that `aws_region` and `instance_id` evaluate to an AWS region and EC2 instance ID, respectively

``` yaml
- ec2_vpc:
    state: present
    region: '{{ aws_region }}'
    cidr_block: 10.0.0.1/16
    internet_gateway: true
    route_tables:
      - subnets:
          - 10.0.0.2/24
          - 10.0.0.3/24
        routes:
          - dest: 0.0.0.0/0
            gw: igw
      - subnets:
          - 10.0.0.4/24
          - 10.0.0.5/24
        routes:
          - dest: 0.0.0.0/0
            gw: '{{ instance_id }}'
```

Expected Results:

Successful task run, setting routes but not bothering with subnets.

Actual Results:

``` bash
failed: [local] => {"failed": true, "parsed": false}
Traceback (most recent call last):
  File "/home/ubuntu/.ansible/tmp/ansible-tmp-1429640371.21-187878110987904/ec2_vpc", line 2425, in <module>
    main()
  File "/home/ubuntu/.ansible/tmp/ansible-tmp-1429640371.21-187878110987904/ec2_vpc", line 624, in main
    (vpc_dict, new_vpc_id, subnets_changed, changed) = create_vpc(module, vpc_conn)
  File "/home/ubuntu/.ansible/tmp/ansible-tmp-1429640371.21-187878110987904/ec2_vpc", line 511, in create_vpc
    for idx, val in enumerate(subnets):
TypeError: 'NoneType' object is not iterable
```
