### PR TITLE
Added choice validation for EC2 state arg

### DIFF
--- a/cloud/amazon/ec2.py
+++ b/cloud/amazon/ec2.py
@@ -1199,7 +1199,7 @@ def main():
             instance_profile_name = dict(),
             instance_ids = dict(type='list', aliases=['instance_id']),
             source_dest_check = dict(type='bool', default=True),
-            state = dict(default='present'),
+            state = dict(default='present', choices=['present', 'absent', 'running', 'stopped']),
             exact_count = dict(type='int', default=None),
             count_tag = dict(),
             volumes = dict(type='list'),


### PR DESCRIPTION
Fixes traceback on invalid state arg (conditional falls through to exit_json without changed being set):

module.exit_json(changed=changed, instance_ids=new_instance_ids, instances=instance_dict_array, tagged_instances=tagged_instances) :
UnboundLocalError: local variable 'changed' referenced before assignment)
