### PR TITLE
Ensure default egress rule when vpc_id is not defined, but group has a vpc_id

### DIFF
--- a/cloud/amazon/ec2_group.py
+++ b/cloud/amazon/ec2_group.py
@@ -425,7 +425,7 @@ def main():
                                     src_group_id=grantGroup,
                                     cidr_ip=thisip)
                         changed = True
-        elif vpc_id and not module.check_mode:
+        elif (vpc_id or group.vpc_id) and not module.check_mode:
             # when using a vpc, but no egress rules are specified,
             # we add in a default allow all out rule, which was the
             # default behavior before egress rules were added


### PR DESCRIPTION
New EC2 users (and probably others with a default VPC) do not need to specify vpc_id for other actions, this should be the case for ec2_group as well.

Also, fixes docs output for module.
