### PR TITLE
bugfixes for redhat_subscription

### DIFF
--- a/packaging/os/redhat_subscription.py
+++ b/packaging/os/redhat_subscription.py
@@ -76,6 +76,12 @@ EXAMPLES = '''
 - redhat_subscription: state=present
                        activationkey=1-222333444
                        pool='^(Red Hat Enterprise Server|Red Hat Virtualization)$'
+
+# Update the consumed subscriptions from the previous example (remove the Red
+# Hat Virtualization subscription)
+- redhat_subscription: state=present
+                       activationkey=1-222333444
+                       pool='^Red Hat Enterprise Server$'
 '''
 
 import os

--- a/packaging/os/redhat_subscription.py
+++ b/packaging/os/redhat_subscription.py
@@ -340,7 +340,10 @@ class RhsmPools(object):
                 consumed(bool): if True list consumed  pools, else list available pools (default False)
         """
         args = "subscription-manager list"
-        args += " --consumed" if consumed else " --available"
+        if consumed:
+            args += " --consumed"
+        else:
+            args += " --available"
         rc, stdout, stderr = self.module.run_command(args, check_rc=True)
 
         products = []


### PR DESCRIPTION
- correctly return pool ids for newer versions of subscription-manager
- allow for managing subscriptions after initial registration.
