### PR TITLE
ec2: Use get_aws_connection_info to get AWS creds.

### DIFF
--- a/cloud/amazon/ec2.py
+++ b/cloud/amazon/ec2.py
@@ -1207,15 +1207,11 @@ def main():
 
     ec2 = ec2_connect(module)
 
-    ec2_url, aws_access_key, aws_secret_key, region = get_ec2_creds(module)
+    region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module)
 
     if region:
         try:
-            vpc = boto.vpc.connect_to_region(
-                region,
-                aws_access_key_id=aws_access_key,
-                aws_secret_access_key=aws_secret_key
-            )
+            vpc = boto.vpc.connect_to_region(region, **aws_connect_kwargs)
         except boto.exception.NoAuthHandlerFound, e:
             module.fail_json(msg = str(e))
     else:


### PR DESCRIPTION
Previously used get_ec2_creds did not consider security_token,
which caused MFA requests to fail 
