### PR TITLE
ec2_group: select own group if the name matches

### DIFF
--- a/cloud/amazon/ec2_group.py
+++ b/cloud/amazon/ec2_group.py
@@ -223,7 +223,12 @@ def main():
     groups = {}
     for curGroup in ec2.get_all_security_groups():
         groups[curGroup.id] = curGroup
-        groups[curGroup.name] = curGroup
+        if curGroup.name in groups:
+            # Prioritise groups from the current VPC
+            if vpc_id is None or curGroup.vpc_id == vpc_id:
+                groups[curGroup.name] = curGroup
+        else:
+            groups[curGroup.name] = curGroup
 
         if curGroup.name == name and (vpc_id is None or curGroup.vpc_id == vpc_id):
             group = curGroup

--- a/cloud/amazon/ec2_group.py
+++ b/cloud/amazon/ec2_group.py
@@ -162,12 +162,12 @@ def get_target_from_rule(module, ec2, rule, name, group, groups, vpc_id):
         group_id = rule['group_id']
     elif 'group_name' in rule:
         group_name = rule['group_name']
-        if group_name in groups:
-            group_id = groups[group_name].id
-        elif group_name == name:
+        if group_name == name:
             group_id = group.id
             groups[group_id] = group
             groups[group_name] = group
+        elif group_name in groups:
+            group_id = groups[group_name].id
         else:
             if not rule.get('group_desc', '').strip():
                 module.fail_json(msg="group %s will be automatically created by rule %s and no description was provided" % (group_name, rule))


### PR DESCRIPTION
This fixes an issue where multiple VPC have the same group name and
the one from the other VPC is selected.

Related to this issue, it would be nice if the vpc_id groups where prioritized as well but it would require more changes to the module.
