### PR TITLE
authorized_keys: allow multiple key options for certain options

### DIFF
--- a/system/authorized_key.py
+++ b/system/authorized_key.py
@@ -236,7 +236,7 @@ def parseoptions(module, options):
                     (key, value) = part.split("=", 1)
                     # certain options can have multiple entries in the authorized_keys file
                     if key in OPTIONS_WITH_MULTIPLE_VALUES:
-                        if key in options_dict.keys():
+                        if key in options_dict:
                             options_dict[key].append(value)
                         else:
                             options_dict[key] = [value]


### PR DESCRIPTION
Allow the `authorized_keys` module to permit multiple entries for certain `key_options`.

Per the spec (http://man.he.net/man5/authorized_keys), certain options allow multiple values not by comma delimiting the value itself, but providing multiple options.

`permitopen="host.com:22",permitopen="anotherhost.com:23"`

Docs dictate that `permitopen` and `environment` allow for multiple entries.

This currently breaks as the implementation assumes keys are unique and sticks them in the `keydict`, thus only taking the last value of any set of values in `key_options`.
