### PR TITLE
Set default for mysql_user config_file

### DIFF
--- a/database/mysql/mysql_user.py
+++ b/database/mysql/mysql_user.py
@@ -384,7 +384,7 @@ def main():
             append_privs=dict(type="bool", default="no"),
             check_implicit_admin=dict(default=False),
             update_password=dict(default="always", choices=["always", "on_create"]),
-            config_file=dict(default=None),
+            config_file=dict(default="~/.my.cnf"),
         )
     )
     login_user = module.params["login_user"]


### PR DESCRIPTION
The default value set by the module was a value of None for the
config_file parameter, which propogates into the connect method
call overriding the stated default in the method.

Instead, the default should be set with-in the parameter
specification so the file check is not requested to check None.

This corrects issue 1215
