### PR TITLE
Fix a typo in create_instances

### DIFF
--- a/cloud/amazon/ec2.py
+++ b/cloud/amazon/ec2.py
@@ -939,7 +939,7 @@ def create_instances(module, ec2, vpc, override_count=None):
                 if private_ip:
                     module.fail_json(
                         msg='private_ip only available with on-demand (non-spot) instances')
-                if boto_supports_param_in_spot_request(ec2, placement_group):
+                if boto_supports_param_in_spot_request(ec2, 'placement_group'):
                     params['placement_group'] = placement_group
                 elif placement_group :
                         module.fail_json(


### PR DESCRIPTION
Fix a typo in create_instances: use 'placement_group' instead of placement_group
when calling boto_siupports_param_in_spot_request().
