### PR TITLE
APT: Add multiple packages inline + support Async

### DIFF
--- a/packaging/os/apt.py
+++ b/packaging/os/apt.py
@@ -601,8 +601,12 @@ def main():
             install_deb(module, p['deb'], cache,
                         install_recommends=install_recommends,
                         force=force_yes, dpkg_options=p['dpkg_options'])
+        try:
+            packages = p['package'][0].split(' ')
+        except:
+            module.fail_json(
+                msg="invalid package specs: {0}".format(p['package']))
 
-        packages = p['package']
         latest = p['state'] == 'latest'
         for package in packages:
             if package.count('=') > 1:


### PR DESCRIPTION
Hi, 

If you want to use Async module in apt at the moment it's difficult. 

Async task are not compatible with loops, so my behaviour is to use multiple packages inline. I used this approach for pip as example. 

So, my idea is to use the following: 

``` task.yml
- name: Install deps
  apt:
    name: "git make ngrep"
    update_cache: yes
  async: 10000
  poll: 0
  register: apt_sleeper
```

So with this patch, the system will accept multiple packages, as apt-get install do. 

I've just check, and debian names can't be with space. So no exception it's expected. 

Thanks
Regards. 
