### PR TITLE
Fix ec2_eip ip reuse functionality

### DIFF
--- a/cloud/amazon/ec2_eip.py
+++ b/cloud/amazon/ec2_eip.py
@@ -189,7 +189,8 @@ def allocate_address(ec2, domain, module, reuse_existing_ip_allowed):
         domain_filter = { 'domain' : 'standard' }
       all_addresses = ec2.get_all_addresses(filters=domain_filter)
 
-      unassociated_addresses = filter(lambda a: a.instance_id == "", all_addresses)
+      unassociated_addresses = filter(lambda a: a.instance_id is None or  a.instance_id == "", 
+              all_addresses)
       if unassociated_addresses:
         address = unassociated_addresses[0];
       else:


### PR DESCRIPTION
This is an issue that seems to have been sprung up before in the reverse
way:

> https://github.com/ansible/ansible/pull/8518

I believe that this issue is enviroment dependent, but haven't verified
the root cause. Given that in the wild we should see users seeing
various combinations of all the dependencies that control the issue,
both situations should be handled.

Enviroment where the issue occurs:
- osx 10.10.3
- python 2.7.9 x86_64 (from MacPorts)
- ansible 1.9.1
- boto 2.38.0
