### PR TITLE
mysql_user: Only revoke actually granted permissions, not 'ALL'.

### DIFF
--- a/database/mysql/mysql_user.py
+++ b/database/mysql/mysql_user.py
@@ -350,7 +350,7 @@ def privileges_revoke(cursor, user,host,db_table,priv,grant_option):
         query.append("FROM %s@%s")
         query = ' '.join(query)
         cursor.execute(query, (user, host))
-    priv_string = ",".join(filter(lambda x: x not in [ 'GRANT', 'REQUIRESSL' ], priv))
+    priv_string = ",".join([p for p in priv if p not in ('GRANT', 'REQUIRESSL')])
     query = ["REVOKE %s ON %s" % (priv_string, mysql_quote_identifier(db_table, 'table'))]
     query.append("FROM %s@%s")
     query = ' '.join(query)
@@ -360,7 +360,7 @@ def privileges_grant(cursor, user,host,db_table,priv):
     # Escape '%' since mysql db.execute uses a format string and the
     # specification of db and table often use a % (SQL wildcard)
     db_table = db_table.replace('%', '%%')
-    priv_string = ",".join(filter(lambda x: x not in [ 'GRANT', 'REQUIRESSL' ], priv))
+    priv_string = ",".join([p for p in priv if p not in ('GRANT', 'REQUIRESSL')])
     query = ["GRANT %s ON %s" % (priv_string, mysql_quote_identifier(db_table, 'table'))]
     query.append("TO %s@%s")
     if 'GRANT' in priv:

--- a/database/mysql/mysql_user.py
+++ b/database/mysql/mysql_user.py
@@ -245,7 +245,7 @@ def user_mod(cursor, user, host, password, new_priv, append_privs):
                 grant_option = True
             if db_table not in new_priv:
                 if user != "root" and "PROXY" not in priv and not append_privs:
-                    privileges_revoke(cursor, user,host,db_table,grant_option)
+                    privileges_revoke(cursor, user,host,db_table,priv,grant_option)
                     changed = True
 
         # If the user doesn't currently have any privileges on a db.table, then
@@ -262,7 +262,7 @@ def user_mod(cursor, user, host, password, new_priv, append_privs):
             priv_diff = set(new_priv[db_table]) ^ set(curr_priv[db_table])
             if (len(priv_diff) > 0):
                 if not append_privs:
-                    privileges_revoke(cursor, user,host,db_table,grant_option)
+                    privileges_revoke(cursor, user,host,db_table,curr_priv[db_table],grant_option)
                 privileges_grant(cursor, user,host,db_table,new_priv[db_table])
                 changed = True
 
@@ -342,7 +342,7 @@ def privileges_unpack(priv):
 
     return output
 
-def privileges_revoke(cursor, user,host,db_table,grant_option):
+def privileges_revoke(cursor, user,host,db_table,priv,grant_option):
     # Escape '%' since mysql db.execute() uses a format string
     db_table = db_table.replace('%', '%%')
     if grant_option:
@@ -350,7 +350,8 @@ def privileges_revoke(cursor, user,host,db_table,grant_option):
         query.append("FROM %s@%s")
         query = ' '.join(query)
         cursor.execute(query, (user, host))
-    query = ["REVOKE ALL PRIVILEGES ON %s" % mysql_quote_identifier(db_table, 'table')]
+    priv_string = ",".join(filter(lambda x: x not in [ 'GRANT', 'REQUIRESSL' ], priv))
+    query = ["REVOKE %s ON %s" % (priv_string, mysql_quote_identifier(db_table, 'table'))]
     query.append("FROM %s@%s")
     query = ' '.join(query)
     cursor.execute(query, (user, host))


### PR DESCRIPTION
When applied to an existing user to reduce the user's privileges on a database, the 'privileges_revoke' function gets invoked, which attempts to perform a 'REVOKE ALL'. However, if the 'login_user' does not have 'ALL' privileges on the database or on *.*, this results in failure and thus the inability to reduce granted permissions via the module.

This is not just a hypothetical: with Amazon Web Services RDS there is no (accessible) user with 'ALL' permissions on *.*, so any attempt to reduce a user's permissions on *.* with the module results in failure. 

This change makes it such that only the actually granted privileges are revoked, thus achieving the same end result but allowing the module to function in environments with more limited privileges like Amazon RDS.
