### PR TITLE
Fixed typo in cloud docker module.

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -1136,7 +1136,7 @@ class DockerManager(object):
                     name_list = []
                 matches = name in name_list
             else:
-                details = self.client.inspect_container(i['Id'])
+                details = self.client.inspect_container(container['Id'])
                 details = _docker_id_quirk(details)
 
                 running_image = normalize_image(details['Config']['Image'])


### PR DESCRIPTION
Remove undefined `i` variable with `container` in the definition of `get_deployed_containers` in class `DockerManager`.
