### PR TITLE
Fix ``get_deployed_containers`` when no name specified

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -1136,7 +1136,7 @@ class DockerManager(object):
                     name_list = []
                 matches = name in name_list
             else:
-                details = self.client.inspect_container(i['Id'])
+                details = self.client.inspect_container(container['Id'])
                 details = _docker_id_quirk(details)
 
                 running_image = normalize_image(details['Config']['Image'])


### PR DESCRIPTION
Previous fix missed one remaining instance of `i`.
