### PR TITLE
[ec2_ami_find] fix ami_search doc copy pasta

### DIFF
--- a/cloud/amazon/ec2_ami_find.py
+++ b/cloud/amazon/ec2_ami_find.py
@@ -156,7 +156,7 @@ EXAMPLES = '''
 
 # Launch an EC2 instance
 - ec2:
-    image: "{{ ami_search.results[0].ami_id }}"
+    image: "{{ ami_find.results[0].ami_id }}"
     instance_type: m3.medium
     key_name: mykey
     wait: yes


### PR DESCRIPTION
In the docs above we do `register: ami_find`.
