### PR TITLE
Skip dead docker containers

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -1116,8 +1116,11 @@ class DockerManager(object):
             running_image = i['Image']
             running_command = i['Command'].strip()
 
+            matches = False
+
             if name:
-                matches = name in i.get('Names', [])
+                if i.get('Names') is not None:
+                    matches = name in i.get('Names', [])
             else:
                 image_matches = running_image in repo_tags
 


### PR DESCRIPTION
Dead containers in 1.6.0 have no names.

``` python
{u'Status': u'Dead', u'Created': 1419240335, u'Image': u'bobrik/marathon-tcp-haproxy:1.1.2', u'Labels': None, u'Ports': [], u'Command': u'discovery_start', u'Names': None, u'Id': u'51335f2b862b3270e2abb9b7cdd21d4d97477452079a3ce79181f4ed5fbd2447'}
```
