### PR TITLE
Use of proper fstab file on FreeBSD

### DIFF
--- a/system/mount.py
+++ b/system/mount.py
@@ -206,13 +206,29 @@ def unset_mount(**kwargs):
 
 def mount(module, **kwargs):
     """ mount up a path or remount if needed """
+
+    # kwargs: name, src, fstype, opts, dump, passno, state, fstab=/etc/fstab
+    args = dict(
+        opts   = 'default',
+        dump   = '0',
+        passno = '0',
+        fstab  = '/etc/fstab'
+    )
+    args.update(kwargs)
+
     mount_bin = module.get_bin_path('mount')
 
     name = kwargs['name']
+    
+    cmd = [ mount_bin, ]
+    
     if os.path.ismount(name):
-        cmd = [ mount_bin , '-o', 'remount', name ]
-    else:
-        cmd = [ mount_bin, name ]
+        cmd += [ '-o', 'remount', ]
+
+    if get_platform().lower() == 'freebsd':
+        cmd += [ '-F', args['fstab'], ]
+
+    cmd += [ name, ]
 
     rc, out, err = module.run_command(cmd)
     if rc == 0:


### PR DESCRIPTION
Currently mount command doesn't use custom fstab file, trying to do so and set state=mounted returns error, although the file itself is properly edited.

Fixed that for FreeBSD, which uses -F option for custom fstab in mount command.

It's more complicated for Linux systems, as different releases have different options for that action, some (CentOS 6) have none at all.
