### PR TITLE
Rackspace: Fix attribute name for Auto Scale servers

### DIFF
--- a/cloud/rackspace/rax_scaling_group.py
+++ b/cloud/rackspace/rax_scaling_group.py
@@ -262,8 +262,8 @@ def rax_asg(module, cooldown=300, disk_config=None, files={}, flavor=None,
             # Launch Configuration Updates
             lc = sg.get_launch_config()
             lc_args = {}
-            if server_name != lc.get('name'):
-                lc_args['name'] = server_name
+            if server_name != lc.get('server_name'):
+                lc_args['server_name'] = server_name
 
             if image != lc.get('image'):
                 lc_args['image'] = image

--- a/cloud/rackspace/rax_scaling_group.py
+++ b/cloud/rackspace/rax_scaling_group.py
@@ -262,7 +262,7 @@ def rax_asg(module, cooldown=300, disk_config=None, files={}, flavor=None,
             # Launch Configuration Updates
             lc = sg.get_launch_config()
             lc_args = {}
-            if server_name != lc.get('server_name'):
+            if server_name != lc.get('name'):
                 lc_args['server_name'] = server_name
 
             if image != lc.get('image'):


### PR DESCRIPTION
If you look at [update_launch_config](https://github.com/rackspace/pyrax/blob/master/pyrax/autoscale.py#L107) in Pyrax, it expects `server_name` not `name`. This is currently throwing an error.
