### PR TITLE
Add test validating if modules are python24 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: false
+language: python
+addons:
+  apt:
+    sources:
+      - deadsnakes
+    packages:
+      - python2.4
+script:
+  - python2.4 -m compileall -fq -x 'cloud/' .


### PR DESCRIPTION
The PR adds a `.travis.yml` file that will install python24 and run a compileall task against all modules excluding cloud modules.

Additional excludes can be added over time.

This should help us identify python24 syntax issues earlier.

Travis will need to be enabled for this to take affect.

NOTE: There are current failures that probably need to be addressed separately.
