### PR TITLE
Update set_fact.py

### DIFF
--- a/utilities/logic/set_fact.py
+++ b/utilities/logic/set_fact.py
@@ -40,12 +40,13 @@ version_added: "1.2"
 
 EXAMPLES = '''
 # Example setting host facts using key=value pairs
-- set_fact: one_fact="something" other_fact="{{ local_var * 2 }}"
+- set_fact: one_fact="something" other_fact="{{ local_var }}"
 
 # Example setting host facts using complex arguments
 - set_fact:
      one_fact: something
      other_fact: "{{ local_var * 2 }}"
+     another_fact: "{{ some_registered_var.results | map(attribute='ansible_facts.some_fact') | list }}"
 
 # As of 1.8, Ansible will convert boolean strings ('true', 'false', 'yes', 'no')
 # to proper boolean values when using the key=value syntax, however it is still


### PR DESCRIPTION
Context: I recently discovered that when setting a fact, key=value pairs and complex arguments differ in how the fact is stored. For example, when attempting to use complex arguments using key=values, the result can be stored as a unicode string as opposed to an object/list/etc.

I'm hoping the above example update will better demonstrate to and instruct people to use complex arguments instead of key=value pairs in certain situations.
