### PR TITLE
generic fix for Exceptions that happen when trying to set permissions

### DIFF
--- a/files/unarchive.py
+++ b/files/unarchive.py
@@ -303,7 +303,10 @@ def main():
     # do we need to change perms?
     for filename in handler.files_in_archive:
         file_args['path'] = os.path.join(dest, filename)
-        res_args['changed'] = module.set_fs_attributes_if_different(file_args, res_args['changed'])
+        try:
+            res_args['changed'] = module.set_fs_attributes_if_different(file_args, res_args['changed'])
+        except (IOError, OSError), e:
+            module.fail_json(msg="Unexpected error when accessing exploded file: %s" % str(e))
 
     if module.params['list_files']:
         res_args['files'] = handler.files_in_archive


### PR DESCRIPTION
 on extracted files which are not accessible or don't exist (OS X resource forks in some cases)

fixes ansible/ansible#10934 which is really a corner case
