### PR TITLE
Add py27 compileall to test all modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ addons:
 script:
   - python2.4 -m compileall -fq -x 'cloud/|/accelerate.py' .
   - python2.4 -m compileall -fq cloud/amazon/_ec2_ami_search.py cloud/amazon/ec2_facts.py
+  - python -m compileall -fq .


### PR DESCRIPTION
This PR adds a python27 compileall "test" that amongst checking for python27 compatibility will also allow for finding syntax errors in modules excluded by the py24 compileall.
