### PR TITLE
Update gce.py to correctly handle propagated metadata type from a mot…

### DIFF
--- a/cloud/google/gce.py
+++ b/cloud/google/gce.py
@@ -317,7 +317,7 @@ def create_instances(module, gce, instance_names):
     # [ {'key': key1, 'value': value1}, {'key': key2, 'value': value2}, ...]
     if metadata:
         try:
-            md = literal_eval(metadata)
+            md = literal_eval(str(metadata))
             if not isinstance(md, dict):
                 raise ValueError('metadata must be a dict')
         except ValueError, e:


### PR DESCRIPTION
  My project is using Ansible to automate cloud build process. Ansible has a core module gce.py for managing GCE instances. 
  We've come across a use case that's not yet supported - when executing ansible-playbook, if a child template is included, then metadata which is defined in and propagated from the mother template is treated as string type and not parsed correctly(which instead is dictionary type), and triggers release flow failure.
   We currently put some fix by explicitly casting metadata to string type in our own branch, but would like to contribute the fix to Ansible so that everyone onboarding GCE and using Ansible for release management could benefit from it, or hear owner's opinion on fixing the issue if there's a better fix in owner's mind:)
