### PR TITLE
Added postgresql-license type. Fixes issue 444

### DIFF
--- a/cloud/amazon/rds.py
+++ b/cloud/amazon/rds.py
@@ -102,7 +102,7 @@ options:
     required: false
     default: null
     aliases: []
-    choices:  [ 'license-included', 'bring-your-own-license', 'general-public-license' ]
+    choices:  [ 'license-included', 'bring-your-own-license', 'general-public-license', 'postgresql-license' ]
   multi_zone:
     description:
       - Specifies if this is a Multi-availability-zone deployment. Can not be used in conjunction with zone parameter. Used only when command=create or command=modify.
@@ -963,7 +963,7 @@ def main():
             db_name           = dict(required=False),
             engine_version    = dict(required=False),
             parameter_group   = dict(required=False),
-            license_model     = dict(choices=['license-included', 'bring-your-own-license', 'general-public-license'], required=False),
+            license_model     = dict(choices=['license-included', 'bring-your-own-license', 'general-public-license', 'postgresql-license'], required=False),
             multi_zone        = dict(type='bool', default=False),
             iops              = dict(required=False), 
             security_groups   = dict(required=False),


### PR DESCRIPTION
Although boto doco is out of date, it is possible to pass a database license type of "postgresql-license".

Without this fix, you can not create a Postgresql rds instance type.

Fixes https://github.com/ansible/ansible-modules-core/issues/444
