### PR TITLE
Specify that travis should use python2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 sudo: false
 language: python
+python:
+  - "2.7"
 addons:
   apt:
     sources:
       - deadsnakes
     packages:
       - python2.4
+      - python2.6
 script:
   - python2.4 -m compileall -fq -x 'cloud/|/accelerate.py' .
   - python2.4 -m compileall -fq cloud/amazon/_ec2_ami_search.py cloud/amazon/ec2_facts.py
-  - python -m compileall -fq .
+  - python2.6 -m compileall -fq .
+  - python2.7 -m compileall -fq .


### PR DESCRIPTION
This PR specifies that travis should use python26 in addition to the default 2.7.

This matches up more closely to the travis/tox config in the `v2_final` branch in the core repo.
