### PR TITLE
Make the security_groups argument a list

### DIFF
--- a/cloud/openstack/os_server.py
+++ b/cloud/openstack/os_server.py
@@ -75,7 +75,7 @@ options:
      default: None
    security_groups:
      description:
-        - The name of the security group to which the instance should be added
+        - A list of security groups to which the instance should be added
      required: false
      default: None
    nics:
@@ -291,7 +291,7 @@ def _create_server(module, cloud):
         flavor=flavor_dict['id'],
         nics=nics,
         meta=module.params['meta'],
-        security_groups=module.params['security_groups'].split(','),
+        security_groups=module.params['security_groups'],
         userdata=module.params['userdata'],
         config_drive=module.params['config_drive'],
     )
@@ -384,7 +384,7 @@ def main():
         flavor_ram                      = dict(default=None, type='int'),
         flavor_include                  = dict(default=None),
         key_name                        = dict(default=None),
-        security_groups                 = dict(default='default'),
+        security_groups                 = dict(default='default', type='list'),
         nics                            = dict(default=[]),
         meta                            = dict(default=None),
         userdata                        = dict(default=None),


### PR DESCRIPTION
In order to pass several security_groups, you have to put them
in a line separated by commas.
This change makes this argument a YAML list to make it consistent
with YAML syntax for lists.
