### PR TITLE
Decompress mysql dumps on the fly during an import to simplify operation

### DIFF
--- a/database/mysql/mysql_db.py
+++ b/database/mysql/mysql_db.py
@@ -166,56 +166,20 @@ def db_import(module, host, user, password, db_name, target, all_databases, port
     if not all_databases:
     	cmd += " -D %s" % pipes.quote(db_name)
     if os.path.splitext(target)[-1] == '.gz':
-        gzip_path = module.get_bin_path('gzip')
-        if not gzip_path:
-            module.fail_json(msg="gzip command not found")
-        #gzip -d file (uncompress)
-        rc, stdout, stderr = module.run_command('%s -d %s' % (gzip_path, target))
-        if rc != 0:
-            return rc, stdout, stderr
-        #Import sql
-        cmd += " < %s" % pipes.quote(os.path.splitext(target)[0])
-        try:
-            rc, stdout, stderr = module.run_command(cmd, use_unsafe_shell=True)
-            if rc != 0:
-                return rc, stdout, stderr
-        finally:
-            #gzip file back up
-            module.run_command('%s %s' % (gzip_path, os.path.splitext(target)[0]))
+        zcat_path = module.get_bin_path('zcat')
+        if not zcat_path:
+            module.fail_json(msg="zcat command not found")
+        rc, stdout, stderr = module.run_command('%s %s | %s' % (zcat_path, target, cmd), use_unsafe_shell=True)
     elif os.path.splitext(target)[-1] == '.bz2':
-        bzip2_path = module.get_bin_path('bzip2')
-        if not bzip2_path:
-            module.fail_json(msg="bzip2 command not found")
-        #bzip2 -d file (uncompress)
-        rc, stdout, stderr = module.run_command('%s -d %s' % (bzip2_path, target))
-        if rc != 0:
-            return rc, stdout, stderr
-        #Import sql
-        cmd += " < %s" % pipes.quote(os.path.splitext(target)[0])
-        try:
-            rc, stdout, stderr = module.run_command(cmd, use_unsafe_shell=True)
-            if rc != 0:
-                return rc, stdout, stderr
-        finally:
-            #bzip2 file back up
-            rc, stdout, stderr = module.run_command('%s %s' % (bzip2_path, os.path.splitext(target)[0]))
+        bzcat_path = module.get_bin_path('bzcat')
+        if not bzcat_path:
+            module.fail_json(msg="bzcat command not found")
+        rc, stdout, stderr = module.run_command('%s %s | %s' % (bzcat_path, target, cmd), use_unsafe_shell=True)
     elif os.path.splitext(target)[-1] == '.xz':
-        xz_path = module.get_bin_path('xz')
-        if not xz_path:
-            module.fail_json(msg="xz command not found")
-        #xz -d file (uncompress)
-        rc, stdout, stderr = module.run_command('%s -d %s' % (xz_path, target))
-        if rc != 0:
-            return rc, stdout, stderr
-        #Import sql
-        cmd += " < %s" % pipes.quote(os.path.splitext(target)[0])
-        try:
-            rc, stdout, stderr = module.run_command(cmd, use_unsafe_shell=True)
-            if rc != 0:
-                return rc, stdout, stderr
-        finally:
-            #xz file back up
-            rc, stdout, stderr = module.run_command('%s %s' % (xz_path, os.path.splitext(target)[0]))
+        xzcat_path = module.get_bin_path('xzcat')
+        if not xzcat_path:
+            module.fail_json(msg="xzcat command not found")
+        rc, stdout, stderr = module.run_command('%s %s | %s' % (xzcat_path, target, cmd), use_unsafe_shell=True)
     else:
         cmd += " < %s" % pipes.quote(target)
         rc, stdout, stderr = module.run_command(cmd, use_unsafe_shell=True)


### PR DESCRIPTION
The mysql_db module is able to import compressed MySQL dump files. The way it currently works is a bit complicated: it first decompresses the dump file, then runs the import, and finally the dump is being recompressed. A lot of things can go wrong during these operations: we may not have the right permissions on the disk, or we may not have enough disk space to decompress the file entirely. The recompressed file may not be exactly identical to the original file and the user probably does not expect changes in what is the input file. These operation also fail on symbolic links (the user may want a symlink such as "latest_backup" to point to a regular file). Also recompressing the dump is wasting resources and it can take a long time on large files.

This change uses a simple pipeline of two programs to decompress the file on the fly using zcat/bzcat/xzcat and import it. Hence a single command has to run rather than three commands. It does not make any change at all to the original dump file. It is also faster as there is no need to recompress the file and there is less disk operations involved. And the operation will work even if there are permissions or space restrictions on the disk where the dump is stored.

I have tested this change with the three types of supported compression modes. 
