### PR TITLE
Update ec2.py

### DIFF
--- a/cloud/amazon/ec2.py
+++ b/cloud/amazon/ec2.py
@@ -158,6 +158,7 @@ options:
       - when provisioning within vpc, assign a public IP address. Boto library must be 2.13.0+
     required: false
     default: null
+    choices: [ "yes", "no" ]
     aliases: []
   private_ip:
     version_added: "1.2"


### PR DESCRIPTION
Make assign_public_ip choices explicit. People incorrectly try and assign a specific IP thinking it accepts an IP address as a value.
