### PR TITLE
Add state to easy_install

### DIFF
--- a/packaging/language/easy_install.py
+++ b/packaging/language/easy_install.py
@@ -70,6 +70,12 @@ options:
     version_added: "1.3"
     required: false
     default: null
+  state:
+    description:
+      - The desired state of the gem. C(latest) ensures that the latest version is installed.
+    required: false
+    choices: [present, latest]
+    default: present
 notes:
     - Please note that the M(easy_install) module can only install Python
       libraries. Thus this module is not able to remove libraries. It is
@@ -83,7 +89,7 @@ author: Matt Wright
 
 EXAMPLES = '''
 # Examples from Ansible Playbooks
-- easy_install: name=pip
+- easy_install: name=pip state=latest
 
 # Install Bottle into the specified virtualenv.
 - easy_install: name=bottle virtualenv=/webapps/myapp/venv

--- a/packaging/language/easy_install.py
+++ b/packaging/language/easy_install.py
@@ -143,7 +143,8 @@ def main():
     site_packages = module.params['virtualenv_site_packages']
     virtualenv_command = module.params['virtualenv_command']
     executable_arguments = []
-    module.params['state'] is 'latest' and executable_arguments.append('--upgrade')
+    if module.params['state'] == 'latest':
+        executable_arguments.append('--upgrade')
 
     rc = 0
     err = ''

--- a/packaging/language/easy_install.py
+++ b/packaging/language/easy_install.py
@@ -71,6 +71,7 @@ options:
     required: false
     default: null
   state:
+    version_added: "2.0"
     description:
       - The desired state of the library. C(latest) ensures that the latest version is installed.
     required: false

--- a/packaging/language/easy_install.py
+++ b/packaging/language/easy_install.py
@@ -72,7 +72,7 @@ options:
     default: null
   state:
     description:
-      - The desired state of the gem. C(latest) ensures that the latest version is installed.
+      - The desired state of the library. C(latest) ensures that the latest version is installed.
     required: false
     choices: [present, latest]
     default: present

--- a/packaging/language/easy_install.py
+++ b/packaging/language/easy_install.py
@@ -90,7 +90,7 @@ EXAMPLES = '''
 '''
 
 def _is_package_installed(module, name, easy_install, executable_arguments):
-    executable_arguments.append('--dry-run')
+    executable_arguments = executable_arguments + ['--dry-run']
     cmd = '%s %s %s' % (easy_install, ' '.join(executable_arguments), name)
     rc, status_stdout, status_stderr = module.run_command(cmd)
     return not ('Reading' in status_stdout or 'Downloading' in status_stdout)


### PR DESCRIPTION
State may be either `present` or `latest`. If it is latest, the `--upgrade` option is passed to the easy_install executable when it is run.
