### PR TITLE
changes hostname to lowercase

### DIFF
--- a/database/mysql/mysql_user.py
+++ b/database/mysql/mysql_user.py
@@ -396,7 +396,7 @@ def main():
     login_password = module.params["login_password"]
     user = module.params["user"]
     password = module.params["password"]
-    host = module.params["host"]
+    host = module.params["host"].lower()
     state = module.params["state"]
     priv = module.params["priv"]
     check_implicit_admin = module.params['check_implicit_admin']


### PR DESCRIPTION
This changes host= to lowercase which will stop ansible from getting confused when a user adds a host= in all capitals.
