### PR TITLE
Make the vsphere_guest module really reconfigure the network interfaces

### DIFF
--- a/cloud/vmware/vsphere_guest.py
+++ b/cloud/vmware/vsphere_guest.py
@@ -350,7 +350,7 @@ def add_cdrom(module, s, config_target, config, devices, default_devs, type="cli
         devices.append(cd_spec)
 
 
-def add_nic(module, s, nfmor, config, devices, nic_type="vmxnet3", network_name="VM Network", network_type="standard", mac_address=""):
+def add_nic(module, s, nfmor, config, devices, nic_type="vmxnet3", network_name="VM Network", network_type="standard", mac_address=None):
     # add a NIC
     # Different network card types are: "VirtualE1000",
     # "VirtualE1000e","VirtualPCNet32", "VirtualVmxnet", "VirtualNmxnet2",
@@ -399,7 +399,7 @@ def add_nic(module, s, nfmor, config, devices, nic_type="vmxnet3", network_name=
         module.fail_json(
             msg="Error adding nic backing to vm spec. No network type of:"
             " %s" % (network_type))
-    if mac_address != "":
+    if mac_address:
         nic_ctlr.set_element_addressType("manual")
         nic_ctlr.set_element_macAddress(mac_address)
     else:
@@ -661,6 +661,7 @@ def reconfigure_vm(vsphere_client, vm, module, esxi, resource_pool, cluster_name
                 device_config_specs.append(device_config_spec)
         # add new interfaces
         for nic in sorted(vm_nic.iterkeys()):
+            mac_address = None
             try:
                 nictype = vm_nic[nic]['type']
             except KeyError:
@@ -1193,7 +1194,8 @@ def main():
         'nic1': {
             'type': basestring,
             'network': basestring,
-            'network_type': basestring
+            'network_type': basestring,
+            'mac_address': basestring
         }
     }
 

--- a/cloud/vmware/vsphere_guest.py
+++ b/cloud/vmware/vsphere_guest.py
@@ -350,7 +350,7 @@ def add_cdrom(module, s, config_target, config, devices, default_devs, type="cli
         devices.append(cd_spec)
 
 
-def add_nic(module, s, nfmor, config, devices, nic_type="vmxnet3", network_name="VM Network", network_type="standard"):
+def add_nic(module, s, nfmor, config, devices, nic_type="vmxnet3", network_name="VM Network", network_type="standard", mac_address=""):
     # add a NIC
     # Different network card types are: "VirtualE1000",
     # "VirtualE1000e","VirtualPCNet32", "VirtualVmxnet", "VirtualNmxnet2",
@@ -399,8 +399,11 @@ def add_nic(module, s, nfmor, config, devices, nic_type="vmxnet3", network_name=
         module.fail_json(
             msg="Error adding nic backing to vm spec. No network type of:"
             " %s" % (network_type))
-
-    nic_ctlr.set_element_addressType("generated")
+    if mac_address != "":
+        nic_ctlr.set_element_addressType("manual")
+        nic_ctlr.set_element_macAddress(mac_address)
+    else:
+        nic_ctlr.set_element_addressType("generated")
     nic_ctlr.set_element_backing(nic_backing)
     nic_ctlr.set_element_key(4)
     nic_spec.set_element_device(nic_ctlr)
@@ -562,6 +565,7 @@ def reconfigure_vm(vsphere_client, vm, module, esxi, resource_pool, cluster_name
     spec = None
     changed = False
     changes = {}
+    device_config_specs = []
     request = VI.ReconfigVM_TaskRequestMsg()
     shutdown = False
 
@@ -630,6 +634,63 @@ def reconfigure_vm(vsphere_client, vm, module, esxi, resource_pool, cluster_name
 
             changes['cpu'] = vm_hardware['num_cpus']
 
+    # ====(Config Devices )====#
+    device_config_specs = []
+    # ====(Config Network )====#
+    if vm_nic:
+        spec = spec_singleton(spec, request, vm)
+        datacenter = esxi['datacenter']
+        # Datacenter managed object reference
+        dclist = [k for k,
+                 v in vsphere_client.get_datacenters().items() if v == datacenter]
+        if dclist:
+            dcmor=dclist[0]
+        else:
+            vsphere_client.disconnect()
+            module.fail_json(msg="Cannot find datacenter named: %s" % datacenter)
+
+        dcprops = VIProperty(vsphere_client, dcmor)
+        # networkFolder managed object reference
+        nfmor = dcprops.networkFolder._obj
+        # remove all interfaces
+        for device in vm.properties.config.hardware.device:
+            if device._type in ["VirtualEthernetCard", "VirtualE1000", "VirtualE1000e", "VirtualPCNet32", "VirtualVmxnet", "VirtualVmxnet2", "VirtualVmxnet3"]:
+                device_config_spec = spec.new_deviceChange()
+                device_config_spec.set_element_operation('remove')
+                device_config_spec.set_element_device(device._obj)
+                device_config_specs.append(device_config_spec)
+        # add new interfaces
+        for nic in sorted(vm_nic.iterkeys()):
+            try:
+                nictype = vm_nic[nic]['type']
+            except KeyError:
+                vsphere_client.disconnect()
+                module.fail_json(
+                    msg="Error on %s definition. type needs to be "
+                    " specified." % nic)
+            try:
+                network = vm_nic[nic]['network']
+            except KeyError:
+                vsphere_client.disconnect()
+                module.fail_json(
+                    msg="Error on %s definition. network needs to be "
+                    " specified." % nic)
+            try:
+                network_type = vm_nic[nic]['network_type']
+            except KeyError:
+                vsphere_client.disconnect()
+                module.fail_json(
+                    msg="Error on %s definition. network_type needs to be "
+                    " specified." % nic)
+            try:
+                mac_address = vm_nic[nic]['mac_address']
+            except KeyError:
+                pass
+            add_nic(module, vsphere_client, nfmor, spec, device_config_specs, nictype, network, network_type, mac_address)
+
+        # set device modification flag
+        changes['device_change'] = 'yes'
+
     if len(changes):
 
         if shutdown and vm.is_powered_on():
@@ -641,6 +702,9 @@ def reconfigure_vm(vsphere_client, vm, module, esxi, resource_pool, cluster_name
                 module.fail_json(
                     msg='Failed to shutdown vm %s: %s' % (guest, e)
                 )
+
+        if changes['device_change'] == 'yes':
+            spec.set_element_deviceChange(device_config_specs)
 
         request.set_element_spec(spec)
         ret = vsphere_client._proxy.ReconfigVM_Task(request)._returnval
@@ -877,9 +941,13 @@ def create_vm(vsphere_client, module, esxi, resource_pool, cluster_name, guest, 
                 module.fail_json(
                     msg="Error on %s definition. network_type needs to be "
                     " specified." % nic)
+            try:
+                mac_address = vm_nic[nic]['mac_address']
+            except KeyError:
+                pass
             # Add the nic to the VM spec.
             add_nic(module, vsphere_client, nfmor, config, devices,
-                    nictype, network, network_type)
+                    nictype, network, network_type, mac_address)
 
     config.set_element_deviceChange(devices)
     create_vm_request.set_element_config(config)

--- a/cloud/vmware/vsphere_guest.py
+++ b/cloud/vmware/vsphere_guest.py
@@ -1194,8 +1194,7 @@ def main():
         'nic1': {
             'type': basestring,
             'network': basestring,
-            'network_type': basestring,
-            'mac_address': basestring
+            'network_type': basestring
         }
     }
 


### PR DESCRIPTION
Code was missing for reconfiguring devices in state=reconfigured handling code. This commit adds initial support for reconfiguring devices and adds complete code for handling the network devices.

Signed-off-by: Vyronas Tsingaras vtsingaras@it.auth.gr
