### PR TITLE
Update vsphere_guest.py

### DIFF
--- a/cloud/vmware/vsphere_guest.py
+++ b/cloud/vmware/vsphere_guest.py
@@ -71,7 +71,7 @@ options:
   from_template:
     version_added: "1.9"
     description:
-      - Specifies if the VM should be deployed from a template (annot be run with state). Only accepts 'cluster' and 'resource_pool' params. No guest customization changes to hardware such as CPU, RAM, NICs or Disks can be applied this way.
+      - Specifies if the VM should be deployed from a template (cannot be run with state). Only accepts 'cluster' and 'resource_pool' params. No guest customization changes to hardware such as CPU, RAM, NICs or Disks can be applied this way.
     default: no
     choices: ['yes', 'no']
   template_src:

--- a/cloud/vmware/vsphere_guest.py
+++ b/cloud/vmware/vsphere_guest.py
@@ -71,7 +71,7 @@ options:
   from_template:
     version_added: "1.9"
     description:
-      - Specifies if the VM should be deployed from a template (cannot be run with state). No guest customization changes to hardware such as CPU, RAM, NICs or Disks can be applied when launching from template.
+      - Specifies if the VM should be deployed from a template (mutually exclusive with state parameter). No guest customization changes to hardware such as CPU, RAM, NICs or Disks can be applied when launching from template.
     default: no
     choices: ['yes', 'no']
   template_src:

--- a/cloud/vmware/vsphere_guest.py
+++ b/cloud/vmware/vsphere_guest.py
@@ -71,7 +71,7 @@ options:
   from_template:
     version_added: "1.9"
     description:
-      - Specifies if the VM should be deployed from a template (cannot be ran with state)
+      - Specifies if the VM should be deployed from a template (annot be run with state). Only accepts 'cluster' and 'resource_pool' params. No guest customization changes to hardware such as CPU, RAM, NICs or Disks can be applied this way.
     default: no
     choices: ['yes', 'no']
   template_src:

--- a/cloud/vmware/vsphere_guest.py
+++ b/cloud/vmware/vsphere_guest.py
@@ -71,7 +71,7 @@ options:
   from_template:
     version_added: "1.9"
     description:
-      - Specifies if the VM should be deployed from a template (mutually exclusive with state parameter). No guest customization changes to hardware such as CPU, RAM, NICs or Disks can be applied when launching from template.
+      - Specifies if the VM should be deployed from a template (mutually exclusive with 'state' parameter). No guest customization changes to hardware such as CPU, RAM, NICs or Disks can be applied when launching from template.
     default: no
     choices: ['yes', 'no']
   template_src:

--- a/cloud/vmware/vsphere_guest.py
+++ b/cloud/vmware/vsphere_guest.py
@@ -195,7 +195,7 @@ EXAMPLES = '''
       hostname: esx001.mydomain.local
 
 # Deploy a guest from a template
-# No reconfiguration of the destination guest is done at this stage, a reconfigure would be needed to adjust memory/cpu etc..
+# No reconfiguration of the destination guest is done at this stage, a reconfigure is needed to adjust RAM/CPU.
 - vsphere_guest:
     vcenter_hostname: vcenter.mydomain.local
     username: myuser

--- a/cloud/vmware/vsphere_guest.py
+++ b/cloud/vmware/vsphere_guest.py
@@ -195,7 +195,6 @@ EXAMPLES = '''
       hostname: esx001.mydomain.local
 
 # Deploy a guest from a template
-# No reconfiguration of the destination guest is done at this stage, a reconfigure is needed to adjust RAM/CPU.
 - vsphere_guest:
     vcenter_hostname: vcenter.mydomain.local
     username: myuser

--- a/cloud/vmware/vsphere_guest.py
+++ b/cloud/vmware/vsphere_guest.py
@@ -65,7 +65,7 @@ options:
     default: null
   state:
     description:
-      - Indicate desired state of the vm.
+      - Indicate desired state of the vm. 'reconfigured' only applies changes to 'memory_mb' and 'num_cpus' in vm_hardware parameter, and only when hot-plugging is enabled for the guest.
     default: present
     choices: ['present', 'powered_off', 'absent', 'powered_on', 'restarted', 'reconfigured']
   from_template:

--- a/cloud/vmware/vsphere_guest.py
+++ b/cloud/vmware/vsphere_guest.py
@@ -71,7 +71,7 @@ options:
   from_template:
     version_added: "1.9"
     description:
-      - Specifies if the VM should be deployed from a template (cannot be run with state). Only accepts 'cluster' and 'resource_pool' params. No guest customization changes to hardware such as CPU, RAM, NICs or Disks can be applied this way.
+      - Specifies if the VM should be deployed from a template (cannot be run with state). No guest customization changes to hardware such as CPU, RAM, NICs or Disks can be applied when launching from template.
     default: no
     choices: ['yes', 'no']
   template_src:


### PR DESCRIPTION
Clarify [documentation](http://docs.ansible.com/vsphere_guest_module.html) to explain that although disk, hardware state, network config etc can be passed at the same time as `reconfigure` and `from_template` parameters to the `vsphere_guest` module, they are silently ignored.

`vsphere_guest` module [currently only has the facilities to modify CPU and RAM](https://github.com/ansible/ansible-modules-core/blob/devel/cloud/vmware/vsphere_guest.py) for a `reconfigure` task on a live machine, and no code paths to change anything at all (via guest customization etc) when a template is used as the source (`from_template` param).

The 6 issues referenced below demonstrate:
- the impact of the ambiguous documentation on multiple users
- the lack of warning/failure messages during module use with unsupported simultaneous params
- the need for the module to be updated to provide these expected facilities
