### PR TITLE
Decompress mysql dumps on the fly using python subprocess …

### DIFF
--- a/database/mysql/mysql_db.py
+++ b/database/mysql/mysql_db.py
@@ -167,10 +167,8 @@ def db_import(module, host, user, password, db_name, target, all_databases, port
     if not all_databases:
     	cmd += " -D %s" % pipes.quote(db_name)
     if os.path.splitext(target)[-1] == '.gz':
-        zcat_path = module.get_bin_path('zcat')
-        if not zcat_path:
-            module.fail_json(msg="zcat command not found")
-        p1 = subprocess.Popen([zcat_path, target], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        comp_prog_path = module.get_bin_path('gzip', required=True)
+        p1 = subprocess.Popen([comp_prog_path, '-dc', target], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         p2 = subprocess.Popen(cmd.split(' '), stdin=p1.stdout, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (stdout2, stderr2) = p2.communicate()
         p1.stdout.close()
@@ -181,10 +179,8 @@ def db_import(module, host, user, password, db_name, target, all_databases, port
         else:
             return p2.returncode, stdout2, stderr2
     elif os.path.splitext(target)[-1] == '.bz2':
-        bzcat_path = module.get_bin_path('bzcat')
-        if not bzcat_path:
-            module.fail_json(msg="bzcat command not found")
-        p1 = subprocess.Popen([bzcat_path, target], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        comp_prog_path = module.get_bin_path('bzip2', required=True)
+        p1 = subprocess.Popen([comp_prog_path, '-dc', target], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         p2 = subprocess.Popen(cmd.split(' '), stdin=p1.stdout, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (stdout2, stderr2) = p2.communicate()
         p1.stdout.close()
@@ -195,10 +191,8 @@ def db_import(module, host, user, password, db_name, target, all_databases, port
         else:
             return p2.returncode, stdout2, stderr2
     elif os.path.splitext(target)[-1] == '.xz':
-        xzcat_path = module.get_bin_path('xzcat')
-        if not xzcat_path:
-            module.fail_json(msg="xzcat command not found")
-        p1 = subprocess.Popen([xzcat_path, target], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        comp_prog_path = module.get_bin_path('xz', required=True)
+        p1 = subprocess.Popen([comp_prog_path, '-dc', target], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         p2 = subprocess.Popen(cmd.split(' '), stdin=p1.stdout, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (stdout2, stderr2) = p2.communicate()
         p1.stdout.close()

--- a/database/mysql/mysql_db.py
+++ b/database/mysql/mysql_db.py
@@ -166,32 +166,16 @@ def db_import(module, host, user, password, db_name, target, all_databases, port
         cmd += " --host=%s --port=%i" % (pipes.quote(host), port)
     if not all_databases:
     	cmd += " -D %s" % pipes.quote(db_name)
+
+    comp_prog_path = None
     if os.path.splitext(target)[-1] == '.gz':
         comp_prog_path = module.get_bin_path('gzip', required=True)
-        p1 = subprocess.Popen([comp_prog_path, '-dc', target], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        p2 = subprocess.Popen(cmd.split(' '), stdin=p1.stdout, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        (stdout2, stderr2) = p2.communicate()
-        p1.stdout.close()
-        p1.wait()
-        if p1.returncode != 0:
-            stderr1 = p1.stderr.read()
-            return p1.returncode, '', stderr1
-        else:
-            return p2.returncode, stdout2, stderr2
     elif os.path.splitext(target)[-1] == '.bz2':
         comp_prog_path = module.get_bin_path('bzip2', required=True)
-        p1 = subprocess.Popen([comp_prog_path, '-dc', target], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        p2 = subprocess.Popen(cmd.split(' '), stdin=p1.stdout, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        (stdout2, stderr2) = p2.communicate()
-        p1.stdout.close()
-        p1.wait()
-        if p1.returncode != 0:
-            stderr1 = p1.stderr.read()
-            return p1.returncode, '', stderr1
-        else:
-            return p2.returncode, stdout2, stderr2
     elif os.path.splitext(target)[-1] == '.xz':
         comp_prog_path = module.get_bin_path('xz', required=True)
+
+    if comp_prog_path:
         p1 = subprocess.Popen([comp_prog_path, '-dc', target], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         p2 = subprocess.Popen(cmd.split(' '), stdin=p1.stdout, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (stdout2, stderr2) = p2.communicate()
@@ -205,7 +189,7 @@ def db_import(module, host, user, password, db_name, target, all_databases, port
     else:
         cmd += " < %s" % pipes.quote(target)
         rc, stdout, stderr = module.run_command(cmd, use_unsafe_shell=True)
-    return rc, stdout, stderr
+        return rc, stdout, stderr
 
 def db_create(cursor, db, encoding, collation):
     query_params = dict(enc=encoding, collate=collation)


### PR DESCRIPTION
…during an import to simplify operation

The mysql_db module is able to import compressed MySQL dump files. The way it currently works is a bit complicated: it first decompresses the dump file, then runs the import, and finally the dump is being recompressed. A lot of things can go wrong during these operations: we may not have the right permissions on the disk, or we may not have enough disk space to decompress the file entirely. The recompressed file may not be exactly identical to the original file and the user probably does not expect changes in what is the input file. These operation also fail on symbolic links (the user may want a symlink such as "latest_backup" to point to a regular file). Also recompressing the dump is wasting resources and it can take a long time on large files.

This change uses a simple pipeline of two programs to decompress the file on the fly using zcat/bzcat/xzcat and import it. Hence a single command has to run rather than three commands. It does not make any change at all to the original dump file. It is also faster as there is no need to recompress the file and there is less disk operations involved. And the operation will work even if there are permissions or space restrictions on the disk where the dump is stored.

The pipelines have been implemented using python subprocess so we can verify the exit status of both programs and make sure none of them failed. I have tested this change with the three types of supported compression modes.
