### PR TITLE
[gce] [gce_net] fix docs; only delete network if fwname is not provided

### DIFF
--- a/cloud/google/gce_net.py
+++ b/cloud/google/gce_net.py
@@ -75,7 +75,7 @@ options:
     aliases: []
   state:
     description:
-      - desired state of the persistent disk
+      - desired state of the network or firewall
     required: false
     default: "present"
     choices: ["active", "present", "absent", "deleted"]
@@ -264,7 +264,7 @@ def main():
             if fw:
                 gce.ex_destroy_firewall(fw)
                 changed = True
-        if name:
+        elif name:
             json_output['name'] = name
             network = None
             try:


### PR DESCRIPTION
Updated the documentation so that we're not talking about persistent disks. :smile: 

Also, when managing a fw rule we specify the attributes fwname and name indicating the name of the firewall rule and name of the network it should belong too. Currently without this fix, if you go to delete a fw rule, it will also try and delete the network once it is done deleting the fw because a fw rule will always have a name attribute.

With this fix the network will only be deleted if fwname is not present, indicating our state was about the network and not a fw rule.
