### PR TITLE
Fixed the difference between client version and server version of docker

### DIFF
--- a/cloud/docker/docker_image.py
+++ b/cloud/docker/docker_image.py
@@ -59,6 +59,12 @@ options:
     required: false
     default: unix://var/run/docker.sock
     aliases: []
+  docker_api_version:
+    description:
+      - Remote API version to use. This defaults to the current default as
+        specified by docker-py.
+    default: docker-py default remote API version
+    version_added: "1.9"
   state:
     description:
       - Set the state of the image
@@ -140,7 +146,8 @@ class DockerImageManager:
         self.tag = self.module.params.get('tag')
         self.nocache = self.module.params.get('nocache')
         docker_url = urlparse(module.params.get('docker_url'))
-        self.client = docker.Client(base_url=docker_url.geturl(), timeout=module.params.get('timeout'))
+        docker_api_version = self.module.params.get('docker_api_version')
+        self.client = docker.Client(base_url=docker_url.geturl(), version=docker_api_version , timeout=module.params.get('timeout'))
         self.changed = False
         self.log = []
         self.error_msg = None
@@ -213,13 +220,14 @@ class DockerImageManager:
 def main():
     module = AnsibleModule(
         argument_spec = dict(
-            path            = dict(required=False, default=None),
-            name            = dict(required=True),
-            tag             = dict(required=False, default="latest"),
-            nocache         = dict(default=False, type='bool'),
-            state           = dict(default='present', choices=['absent', 'present', 'build']),
-            docker_url      = dict(default='unix://var/run/docker.sock'),
-            timeout         = dict(default=600, type='int'),
+            path               = dict(required=False, default=None),
+            name               = dict(required=True),
+            tag                = dict(required=False, default="latest"),
+            nocache            = dict(default=False, type='bool'),
+            state              = dict(default='present', choices=['absent', 'present', 'build']),
+            docker_url         = dict(default='unix://var/run/docker.sock'),
+            docker_api_version = dict(default="auto"),
+            timeout            = dict(default=600, type='int'),
         )
     )
     if not HAS_DOCKER_CLIENT:


### PR DESCRIPTION
I had this error "Docker API error: client and server don't have same version (client : 1.18, server: 1.17)" on the docker_image module.

I added the version on the module to handle the difference.
