### PR TITLE
fixed regexp for repos with svn:externals set

### DIFF
--- a/source_control/subversion.py
+++ b/source_control/subversion.py
@@ -155,7 +155,7 @@ class Subversion(object):
         '''True if revisioned files have been added or modified. Unrevisioned files are ignored.'''
         lines = self._exec(["status", "-q", self.dest])
         # Match only revisioned files, i.e. ignore status '?'.
-        regex = re.compile(r'^($|\?|Performing status)')
+        regex = re.compile(r'^($|\?|Performing status on external item)')
         # Has local mods if more than 0 modifed revisioned files.
         return len(filter(lambda e: not regex.match(e), lines)) > 0
 

--- a/source_control/subversion.py
+++ b/source_control/subversion.py
@@ -153,11 +153,11 @@ class Subversion(object):
 
     def has_local_mods(self):
         '''True if revisioned files have been added or modified. Unrevisioned files are ignored.'''
-        lines = self._exec(["status", self.dest])
+        lines = self._exec(["status", "-q", self.dest])
         # Match only revisioned files, i.e. ignore status '?'.
-        regex = re.compile(r'^[^?]')
+        regex = re.compile(r'^($|\?|Performing status)')
         # Has local mods if more than 0 modifed revisioned files.
-        return len(filter(regex.match, lines)) > 0
+        return len(filter(lambda e: not regex.match(e), lines)) > 0
 
     def needs_update(self):
         curr, url = self.get_revision()


### PR DESCRIPTION
svn status prints a message if svn:externals property is set, which is interpreted as local modifications message by ansible, which is considered to be an error.
Added -q to svn status command to suppress "X filename" strings, indicating separate external files and modified regexp to pass empty strings and overall status message for externals.
