### PR TITLE
cloudformation: accept local templates in yaml format

### DIFF
--- a/cloud/amazon/cloudformation.py
+++ b/cloud/amazon/cloudformation.py
@@ -81,6 +81,12 @@ options:
       - Location of file containing the template body. The URL must point to a template (max size 307,200 bytes) located in an S3 bucket in the same region as the stack. This parameter is mutually exclusive with 'template'. Either one of them is required if "state" parameter is "present"
     required: false
     version_added: "2.0"
+  template_format:
+    description: For local templates, allows specification of json or yaml format
+    default: json
+    choices: [ json, yaml ]
+    required: false
+    version_added: "2.0"
 
 author: James S. Martin
 extends_documentation_fragment: aws
@@ -127,6 +133,7 @@ EXAMPLES = '''
 
 import json
 import time
+import yaml
 
 try:
     import boto
@@ -224,6 +231,7 @@ def main():
             stack_policy=dict(default=None, required=False),
             disable_rollback=dict(default=False, type='bool'),
             template_url=dict(default=None, required=False),
+            template_format=dict(default='json', choices=['json', 'yaml'], required=False),
             tags=dict(default=None)
         )
     )
@@ -249,6 +257,12 @@ def main():
         template_body = open(module.params['template'], 'r').read()
     else:
         template_body = None
+
+    if module.params['template_format'] == 'yaml':
+        if template_body is None:
+            module.fail_json(msg='yaml format only supported for local templates')
+        else:
+            template_body = json.dumps(yaml.load(template_body), indent=2)
 
     if module.params['stack_policy'] is not None:
         stack_policy_body = open(module.params['stack_policy'], 'r').read()


### PR DESCRIPTION
Since the YAML data format is a subset of JSON, it is trivial to convert
the former to the latter. This means that we can use YAML templates to
build cloudformation stacks, as long as we translate them before passing
them to the AWS API. This could potentially be quite popular in
the Ansible world, since we already use so much YAML for our playbooks.
