### PR TITLE
Escape spaces, backslashes and ampersands in fstab

### DIFF
--- a/system/mount.py
+++ b/system/mount.py
@@ -102,6 +102,10 @@ def write_fstab(lines, dest):
     fs_w.flush()
     fs_w.close()
 
+def _escape_fstab(v):
+    """ escape space (040), ampersand (046) and backslash (134) which are invalid in fstab fields """
+    return v.replace('\\', '\\134').replace(' ', '\\040').replace('&', '\\046')
+
 def set_mount(**kwargs):
     """ set/change a mount point location in fstab """
 
@@ -119,6 +123,7 @@ def set_mount(**kwargs):
     to_write = []
     exists = False
     changed = False
+    escaped_args = dict([(k, _escape_fstab(v)) for k, v in args.iteritems()])
     for line in open(args['fstab'], 'r').readlines():
         if not line.strip():
             to_write.append(line)
@@ -135,16 +140,16 @@ def set_mount(**kwargs):
         ld = {}
         ld['src'], ld['name'], ld['fstype'], ld['opts'], ld['dump'], ld['passno']  = line.split()
 
-        if ld['name'] != args['name']:
+        if ld['name'] != escaped_args['name']:
             to_write.append(line)
             continue
 
         # it exists - now see if what we have is different
         exists = True
         for t in ('src', 'fstype','opts', 'dump', 'passno'):
-            if ld[t] != args[t]:
+            if ld[t] != escaped_args[t]:
                 changed = True
-                ld[t] = args[t]
+                ld[t] = escaped_args[t]
 
         if changed:
             to_write.append(new_line % ld)
@@ -175,6 +180,7 @@ def unset_mount(**kwargs):
 
     to_write = []
     changed = False
+    escaped_name = _escape_fstab(args['name'])
     for line in open(args['fstab'], 'r').readlines():
         if not line.strip():
             to_write.append(line)
@@ -191,7 +197,7 @@ def unset_mount(**kwargs):
         ld = {}
         ld['src'], ld['name'], ld['fstype'], ld['opts'], ld['dump'], ld['passno']  = line.split()
 
-        if ld['name'] != args['name']:
+        if ld['name'] != escaped_name:
             to_write.append(line)
             continue
 
@@ -260,8 +266,6 @@ def main():
         args['passno'] = module.params['passno']
     if module.params['opts'] is not None:
         args['opts'] = module.params['opts']
-        if ' ' in args['opts']:
-            module.fail_json(msg="unexpected space in 'opts' parameter")
     if module.params['dump'] is not None:
         args['dump'] = module.params['dump']
     if module.params['fstab'] is not None:


### PR DESCRIPTION
Currently ansible mount core module **corrupts** `/etc/fstab` if `src` or `name` parameters contains symbols that _must_ be escaped in fstab (like space, amp and backslash chars). And fails if `opts` contain spaces (behavior added by kludge-like fix in 7efe74d1513b27e91628c3cbc97b952d089592e8)

Also, `state=absent` doesn't remove fstab entries if `name` contain one of chars that _must_ be escaped.

Fixes #530.

It's more generic than #578 which only fixes spaces escaping in name (target dir to mount).
Escaping is used in both `set_mount` (important for `src`, `name` and `opts`) and
`unset_mount` (for `name`).

It's shouldn't be used in `mount` and `umount` since `name` parameter is passed as array element
to `module.run_command`.

Also, reverts 7efe74d1513b27e91628c3cbc97b952d089592e8.
