### PR TITLE
Explain that state=present should be used with yum and url

### DIFF
--- a/packaging/os/yum.py
+++ b/packaging/os/yum.py
@@ -49,7 +49,7 @@ description:
 options:
   name:
     description:
-      - "Package name, or package specifier with version, like C(name-1.0). When using state=latest, this can be '*' which means run: yum -y update. You can also pass a url or a local path to a rpm file.  To operate on several packages this can accept a comma separated list of packages or (as of 2.0) a list of packages."
+      - "Package name, or package specifier with version, like C(name-1.0). When using state=latest, this can be '*' which means run: yum -y update. You can also pass a url or a local path to a rpm file (using state=present).  To operate on several packages this can accept a comma separated list of packages or (as of 2.0) a list of packages."
     required: true
     default: null
     aliases: []


### PR DESCRIPTION
Document that url or file install should be used with 'state=present'.
Some get confused when using 'state=latest' and seeing it failing with no obvious reason.
