### PR TITLE
Prevent s3 module getting the memory-error from uploading or downloading a large file

### DIFF
--- a/cloud/amazon/s3.py
+++ b/cloud/amazon/s3.py
@@ -296,6 +296,15 @@ def is_walrus(s3_url):
     else:
         return False
 
+def get_md5_digest(local_file):
+    md5 = hashlib.md5()
+    with open(local_file, 'rb') as f:
+        while True:
+            data = f.read(1024 ** 2)
+            if not data: break
+            md5.update(data)
+    return md5.hexdigest()
+
 
 def main():
     argument_spec = ec2_argument_spec()
@@ -410,7 +419,7 @@ def main():
         # Compare the remote MD5 sum of the object with the local dest md5sum, if it already exists.
         if pathrtn is True:
             md5_remote = keysum(module, s3, bucket, obj)
-            md5_local = hashlib.md5(open(dest, 'rb').read()).hexdigest()
+            md5_local = get_md5_digest(dest)
             if md5_local == md5_remote:
                 sum_matches = True
                 if overwrite == 'always':
@@ -454,7 +463,8 @@ def main():
         # Lets check key state. Does it exist and if it does, compute the etag md5sum.
         if bucketrtn is True and keyrtn is True:
                 md5_remote = keysum(module, s3, bucket, obj)
-                md5_local = hashlib.md5(open(src, 'rb').read()).hexdigest()
+                md5_local = get_md5_digest(src)
+
                 if md5_local == md5_remote:
                     sum_matches = True
                     if overwrite == 'always':

--- a/cloud/amazon/s3.py
+++ b/cloud/amazon/s3.py
@@ -299,9 +299,7 @@ def is_walrus(s3_url):
 def get_md5_digest(local_file):
     md5 = hashlib.md5()
     with open(local_file, 'rb') as f:
-        while True:
-            data = f.read(1024 ** 2)
-            if not data: break
+        for data in f.read(1024 ** 2):
             md5.update(data)
     return md5.hexdigest()
 


### PR DESCRIPTION
Issue Type: 

Bugfix Pull Request

Ansible Version:

```
$ ansible --version
ansible 1.5.4
```

Environment:

A ubuntu in the vagrant box with default memory size setting:

```
$ uname -a
Linux vagrant-ubuntu-trusty-64 3.13.0-39-generic #66-Ubuntu SMP Tue Oct 28 13:30:27 UTC 2014 x86_64 x86_64 x86_64 GNU/Linux
```

```
$ free -m
             total       used       free     shared    buffers     cached
Mem:           490        456         33          0         64        197
-/+ buffers/cache:        195        294
Swap:            0          0          0
```

Summary:

Please summarize your request in this space. You will earn bonus points for being succinct, but please add enough detail so we can understand the request. Thanks!

Steps To Reproduce:

Using s3 module to upload a big file, and s3 module will read `all` data. It will fail when no more memory to load data.

Expected Results:

upload s3 object successfully

Actual Results:

```
invalid output was: Traceback (most recent call last):
  File "/home/vagrant/.ansible/tmp/ansible-tmp-1433401665.0-221028846303211/s3", line 1686, in <module>
    main()
  File "/home/vagrant/.ansible/tmp/ansible-tmp-1433401665.0-221028846303211/s3", line 363, in main
    md5_local = hashlib.md5(open(src, 'rb').read()).hexdigest()
MemoryError
```
