### PR TITLE
ec2_vol: fix race condition when deleting a volume

### DIFF
--- a/cloud/amazon/ec2_vol.py
+++ b/cloud/amazon/ec2_vol.py
@@ -239,15 +239,14 @@ def get_volumes(module, ec2):
     return vols
 
 def delete_volume(module, ec2):
-    vol = get_volume(module, ec2)
-    if not vol:
-        module.exit_json(changed=False)
-    else:
-       if vol.attachment_state() is not None: 
-           adata = vol.attach_data
-           module.fail_json(msg="Volume %s is attached to an instance %s." % (vol.id, adata.instance_id))
-       ec2.delete_volume(vol.id)
-       module.exit_json(changed=True)
+    volume_id = module.params['id']
+    try:
+        ec2.delete_volume(volume_id)
+        module.exit_json(changed=True)
+    except boto.exception.EC2ResponseError as ec2_error:
+        if ec2_error.code == 'InvalidVolume.NotFound':
+            module.exit_json(changed=False)
+        module.fail_json(msg=ec2_error.message)
 
 def boto_supports_volume_encryption():
     """


### PR DESCRIPTION
The module fails when deleting a volume that existed at `get_volume` time and disappeared before calling `ec2.delete_volume`. Instead of query-check-delete just try to delete and handle the errors correctly.
