### PR TITLE
Execute yum once for all supplied packages

### DIFF
--- a/packaging/os/yum.py
+++ b/packaging/os/yum.py
@@ -663,7 +663,7 @@ def remove(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
 
     if pkgs:
         # run an actual yum transaction
-        cmd = yum_basecmd + ["remove"] + pkg
+        cmd = yum_basecmd + ["remove"] + pkgs
 
         if module.check_mode:
             module.exit_json(changed=True)

--- a/packaging/os/yum.py
+++ b/packaging/os/yum.py
@@ -541,9 +541,9 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
             # short circuit all the bs - and search for it as a pkg in is_installed
             # if you find it then we're done
             if not set(['*','?']).intersection(set(spec)):
-                pkgs = is_installed(module, repoq, spec, conf_file, en_repos=en_repos, dis_repos=dis_repos, is_pkg=True)
-                if pkgs:
-                    res['results'].append('%s providing %s is already installed' % (pkgs[0], spec))
+                installed_pkgs = is_installed(module, repoq, spec, conf_file, en_repos=en_repos, dis_repos=dis_repos, is_pkg=True)
+                if installed_pkgs:
+                    res['results'].append('%s providing %s is already installed' % (installed_pkgs[0], spec))
                     continue
             
             # look up what pkgs provide this

--- a/packaging/os/yum.py
+++ b/packaging/os/yum.py
@@ -600,6 +600,8 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
                 module.fail_json(msg="Failure deleting temp directory %s, %s" % (tempdir, e))
             module.exit_json(changed=True)
 
+        changed = True
+
         rc, out, err = module.run_command(cmd)
 
         if (rc == 1):
@@ -627,7 +629,7 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
         # look for each pkg via obsoletes
 
         # Record change
-        res['changed'] = True
+        res['changed'] = changed
 
     # Remove rpms downloaded for EL5 via url
     try:


### PR DESCRIPTION
Rather than executing yum once per package, execute yum once for all supplied packages. This is necessary when performing a yum upgrade involving multiple dependent packages installed from RPM, for example when upgrading from PostgreSQL 9.0.11 to 9.0.21 on a Red Hat server.
