### PR TITLE
documentation: remove include of files options only relevant to unix from win_file.py

### DIFF
--- a/windows/win_file.py
+++ b/windows/win_file.py
@@ -24,7 +24,6 @@ DOCUMENTATION = '''
 module: win_file
 version_added: "1.8"
 short_description: Creates, touches or removes files or directories.
-extends_documentation_fragment: files
 description:
      - Creates (empty) files, updates file modification stamps of existing files,
        and can create or remove directories.


### PR DESCRIPTION
spotted that I'd accidentally left in group etc options which aren't relevant to windows.
