### PR TITLE
Error handling in supervisorctl module.

### DIFF
--- a/web_infrastructure/supervisorctl.py
+++ b/web_infrastructure/supervisorctl.py
@@ -183,14 +183,14 @@ def main():
         if module.check_mode:
             module.exit_json(changed=True)
         for process_name in to_take_action_on:
-            rc, out, err = run_supervisorctl(action, process_name)
+            rc, out, err = run_supervisorctl(action, process_name, check_rc=True)
             if '%s: %s' % (process_name, expected_result) not in out:
                 module.fail_json(msg=out)
 
         module.exit_json(changed=True, name=name, state=state, affected=to_take_action_on)
 
     if state == 'restarted':
-        rc, out, err = run_supervisorctl('update')
+        rc, out, err = run_supervisorctl('update', check_rc=True)
         processes = get_matched_processes()
         take_action_on_processes(processes, lambda s: True, 'restart', 'started')
 


### PR DESCRIPTION
If execution of supervisorctl was not successful (exit code > 0), module silently suppress this error and returns changed = false, which results to OK task state instead of error.
This is very confusing. For example, when using `supervisorctl` needs authentication, and credentials are not specified in module or are incorrect, services are not restarted/started/stopped without properly raising an error.

Task example. Supervisor needs authentication, but we do not specify credentials:

```
    - name: restart SERVICE.NAME via supervisord
      supervisorctl: name=SERVICE.NAME state=restarted

TASK: [test | rrestart SERVICE.NAME via supervisord] *** 
ok: [development.testdomain]
```

This is NOT OK, because service was not restarted nor error was raised.

Supervisorctl exits with value other then 0, if incorrect credentials are specified. This Merge Request handles such situation correctly and raises error if supervisorctl return code is other than 0. 
