### PR TITLE
Removed check whether destination directory is writable from files/un…

### DIFF
--- a/files/unarchive.py
+++ b/files/unarchive.py
@@ -277,8 +277,6 @@ def main():
     # is dest OK to receive tar file?
     if not os.path.isdir(dest):
         module.fail_json(msg="Destination '%s' is not a directory" % dest)
-    if not os.access(dest, os.W_OK):
-        module.fail_json(msg="Destination '%s' not writable" % dest)
 
     handler = pick_handler(src, dest, module)
 


### PR DESCRIPTION
Removed check whether destination directory is writable from `files/unarchive.py`. This check will prevent extraction of an archive even if the archive does not actually write to the destination directory but only writes to any writable sub-directories of it. The underlying tar command will report errors should it try to write to read-only directories.
