### PR TITLE
add comment: ports need to be exposed.

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -62,7 +62,8 @@ options:
       - List containing private to public port mapping specification. Use docker
       - 'CLI-style syntax: C(8000), C(9000:8000), or C(0.0.0.0:9000:8000)'
       - where  8000 is a container port, 9000 is a host port, and 0.0.0.0 is
-      - a host interface.
+      - a host interface. The container ports need to be exposed either in the 
+      - Dockerfile or via the next option.
     default: null
     version_added: "1.5"
   expose:


### PR DESCRIPTION
port mapping with this module only works for ports that are exposed either in the Dockerfile or via an additional arguments. This is different from the command line docker client, that is willing to also map ports that are not exposed.

This comments makes the behaviour more obvious.
