### PR TITLE
Improvements to win_feature

### DIFF
--- a/windows/win_feature.ps1
+++ b/windows/win_feature.ps1
@@ -23,7 +23,7 @@ Import-Module Servermanager;
 
 $params = Parse-Args $args;
 
-$result = New-Object PSObject -Property @{
+$result = New-Object psobject @{
     changed = $false
 }
 
@@ -70,33 +70,37 @@ Else
     $includemanagementtools = $false
 }
 
+$name = $name.split(",")
+
+
 If ($state -eq "present") {
     try {
-        If (Get-Command "Install-WindowsFeature" -ErrorAction SilentlyContinue) {
-            $featureresult = Install-WindowsFeature -Name $name -Restart:$restart -IncludeAllSubFeature:$includesubfeatures -IncludeManagementTools:$includemanagementtools -ErrorAction SilentlyContinue
-        }
-        ElseIf (Get-Command "Add-WindowsFeature" -ErrorAction SilentlyContinue) {
-            $featureresult = Add-WindowsFeature -Name $name -Restart:$restart -IncludeAllSubFeature:$includesubfeatures -ErrorAction SilentlyContinue
-        }
-        Else {
-            Fail-Json $result "Not supported on this version of Windows"
-        }
+
+        $featureresult = Add-WindowsFeature -Name $name -Restart:$restart -IncludeAllSubFeature:$includesubfeatures -IncludeManagementTools:$includemanagementtools
+
+
+
+
+
+
+
     }
     catch {
         Fail-Json $result $_.Exception.Message
     }
 }
-ElseIf ($state -eq "absent") {
+Elseif ($state -eq "absent") {
     try {
-        If (Get-Command "Uninstall-WindowsFeature" -ErrorAction SilentlyContinue) {
-            $featureresult = Uninstall-WindowsFeature -Name $name -Restart:$restart -ErrorAction SilentlyContinue
-        }
-        ElseIf (Get-Command "Remove-WindowsFeature" -ErrorAction SilentlyContinue) {
-            $featureresult = Remove-WindowsFeature -Name $name -Restart:$restart -ErrorAction SilentlyContinue
-        }
-        Else {
-            Fail-Json $result "Not supported on this version of Windows"
-        }
+
+
+
+
+
+
+
+
+
+        $featureresult = Remove-WindowsFeature -Name $name -Restart:$restart
     }
     catch {
         Fail-Json $result $_.Exception.Message
@@ -107,40 +111,49 @@ ElseIf ($state -eq "absent") {
 # each role/feature that is installed/removed
 $installed_features = @()
 #$featureresult.featureresult is filled if anything was changed
-If ($featureresult.FeatureResult)
+if ($featureresult.FeatureResult)
 {
     ForEach ($item in $featureresult.FeatureResult) {
-        $message = @()
-        ForEach ($msg in $item.Message) {
-            $message += New-Object PSObject -Property @{
-                message_type = $msg.MessageType.ToString()
-                error_code = $msg.ErrorCode
-                text = $msg.Text
-            }
-        }
-        $installed_features += New-Object PSObject -Property @{
-            id = $item.Id
+
+
+
+
+
+
+
+
+        $installed_features += New-Object psobject @{
+            id = $item.id.ToString()
             display_name = $item.DisplayName
-            message = $message
-            restart_needed = $item.RestartNeeded.ToString() | ConvertTo-Bool
+
+            message = $item.Message
+            restart_needed = $item.RestartNeeded.ToString()
             skip_reason = $item.SkipReason.ToString()
-            success = $item.Success.ToString() | ConvertTo-Bool
+            success = $item.Success.ToString()
         }
     }
+    Set-Attr $result "feature_result" $installed_features
+    
+
     $result.changed = $true
 }
+Else
+{
+    Set-Attr $result "feature_result" $null
+}
 
-Set-Attr $result "feature_result" $installed_features
-Set-Attr $result "success" ($featureresult.Success.ToString() | ConvertTo-Bool)
-Set-Attr $result "exitcode" $featureresult.ExitCode.ToString()
-Set-Attr $result "restart_needed" ($featureresult.RestartNeeded.ToString() | ConvertTo-Bool)
+Set-Attr $result "feature_success" $featureresult.Success.ToString()
 
-If ($result.success) {
-    Exit-Json $result
-}
-ElseIf ($state -eq "present") {
-    Fail-Json $result "Failed to add feature"
-}
-Else {
-    Fail-Json $result "Failed to remove feature"
-}
+Set-Attr $result "feature_exitcode" $featureresult.ExitCode.ToString()
+Set-Attr $result "feature_restart_needed" $featureresult.RestartNeeded.ToString()
+
+
+
+
+
+
+
+
+
+
+Exit-Json $result;


### PR DESCRIPTION
This improvement enables a comma-separated list of roles/features to install (doesn't work correctly in the current version, although the docs indicate that it should). This will make it way faster than using with_items in situations where lots of features need to be added.

This command will actually work now (multiple features at once): 
ansible -i hosts -m win_feature -a 'name="Web-Server,Web-Common-Http"' all
