### PR TITLE
Fix syntax error in gem.py

### DIFF
--- a/packaging/language/gem.py
+++ b/packaging/language/gem.py
@@ -215,7 +215,7 @@ def main():
             state                = dict(required=False, default='present', choices=['present','absent','latest'], type='str'),
             user_install         = dict(required=False, default=True, type='bool'),
             pre_release          = dict(required=False, default=False, type='bool'),
-            include_doc         = dict(required=False, default=False, type-'bool'),
+            include_doc         = dict(required=False, default=False, type='bool'),
             version              = dict(required=False, type='str'),
             build_flags          = dict(required=False, type='str'),
         ),


### PR DESCRIPTION
The following PR introduced a syntax error into gem.py that is causing travis to fail: https://github.com/ansible/ansible-modules-core/pull/60

This PR corrects the syntax error by changing a `-` to a `=`.
