### PR TITLE
Add ClassicLink settings to EC2_launchconfig

### DIFF
--- a/cloud/amazon/ec2_lc.py
+++ b/cloud/amazon/ec2_lc.py
@@ -116,6 +116,18 @@ options:
     default: false
     aliases: []
     version_added: "1.8"
+  classic_link_vpc_id:
+    description:
+      - Id of ClassicLink enabled VPC
+    required: false
+    default: null
+    version_added: "2.0"
+  classic_link_vpc_security_groups"
+    description:
+       - A list of security group id’s with which to associate the ClassicLink VPC instances.
+    required: false
+    default: null
+    version_added: "2.0"
 extends_documentation_fragment: aws
 """
 
@@ -184,6 +196,8 @@ def create_launch_config(connection, module):
     ramdisk_id = module.params.get('ramdisk_id')
     instance_profile_name = module.params.get('instance_profile_name')
     ebs_optimized = module.params.get('ebs_optimized')
+    classic_link_vpc_id = module.params.get('classic_link_vpc_id')
+    classic_link_vpc_security_groups = module.params.get('classic_link_vpc_security_groups')
     bdm = BlockDeviceMapping()
 
     if volumes:
@@ -206,10 +220,12 @@ def create_launch_config(connection, module):
         kernel_id=kernel_id,
         spot_price=spot_price,
         instance_monitoring=instance_monitoring,
-        associate_public_ip_address = assign_public_ip,
+        associate_public_ip_address=assign_public_ip,
         ramdisk_id=ramdisk_id,
         instance_profile_name=instance_profile_name,
         ebs_optimized=ebs_optimized,
+        classic_link_vpc_security_groups=classic_link_vpc_security_groups,
+        classic_link_vpc_id=classic_link_vpc_id,
     )
 
     launch_configs = connection.get_all_launch_configurations(names=[name])
@@ -257,7 +273,9 @@ def main():
             ebs_optimized=dict(default=False, type='bool'),
             associate_public_ip_address=dict(type='bool'),
             instance_monitoring=dict(default=False, type='bool'),
-            assign_public_ip=dict(type='bool')
+            assign_public_ip=dict(type='bool'),
+            classic_link_vpc_security_groups=dict(type='list'),
+            classic_link_vpc_id=dict(type='str')
         )
     )
 

--- a/cloud/amazon/ec2_lc.py
+++ b/cloud/amazon/ec2_lc.py
@@ -122,7 +122,7 @@ options:
     required: false
     default: null
     version_added: "2.0"
-  classic_link_vpc_security_groups"
+  classic_link_vpc_security_groups:
     description:
        - A list of security group id’s with which to associate the ClassicLink VPC instances.
     required: false


### PR DESCRIPTION
Fairly simple change that allows for classiclink integration for Launch Configs.
