### PR TITLE
[docker] Prevent unnecessary reloads due to the net parameter

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -1108,8 +1108,8 @@ class DockerManager(object):
 
             # NETWORK MODE
 
-            expected_netmode = self.module.params.get('net') or ''
-            actual_netmode = container['HostConfig']['NetworkMode']
+            expected_netmode = self.module.params.get('net') or 'bridge'
+            actual_netmode = container['HostConfig']['NetworkMode'] or 'bridge'
             if actual_netmode != expected_netmode:
                 self.reload_reasons.append('net ({0} => {1})'.format(actual_netmode, expected_netmode))
                 differing.append(container)


### PR DESCRIPTION
I'm seeing a failure in my test repository right now because the `net` parameter is inconsistently defaulted:

```
"reload_reasons": "net (bridge => )"
```

This triggers an unnecessary reload when the `net` parameter is unspecified.
