### PR TITLE
authorized_keys: fix creating .ssh directory

### DIFF
--- a/system/authorized_key.py
+++ b/system/authorized_key.py
@@ -188,7 +188,7 @@ def keyfile(module, user, write=False, path=None, manage_dir=True):
 
     if manage_dir:
         if not os.path.exists(sshdir):
-            os.mkdir(sshdir, 0700)
+            os.mkdirs(sshdir, 0700)
             if module.selinux_enabled():
                 module.set_default_selinux_context(sshdir, False)
         os.chown(sshdir, uid, gid)


### PR DESCRIPTION
fixes #59

During creating authorized_keys file next cases are possible:
1. User already created and home directory already created
2. User already created, home directory unsetted in /etc/passwd (manualy) and doesn't exists
3. User already created, home directory seted in /etc/passwd file and doesn't exists
4. User doesn't exists

1'th case works fine in Ansible 1.9.x
2'nd case not works and can't be handled
3'th case not works in Ansible 1.9.x and devel and can be fixed by this patch (using os.mkdirs insted os.mkdir)
4.th case not works and can't be handled

So, in my mind, this proposal looks nice and Ansible team should apply this patch.
