### PR TITLE
return health of instances and counts

### DIFF
--- a/cloud/amazon/ec2_elb_lb.py
+++ b/cloud/amazon/ec2_elb_lb.py
@@ -393,11 +393,11 @@ class ElbManager(object):
 
             # status of instances behind the ELB
             if info['instances']:
-                info['instance_health'] = [ dict({
-                    "instance_id": instance_state.instance_id,
-                    "reason_code": instance_state.reason_code,
-                    "state": instance_state.state,
-                }) for instance_state in self.elb_conn.describe_instance_health(self.name)]
+                info['instance_health'] = [ dict(
+                    instance_id = instance_state.instance_id,
+                    reason_code = instance_state.reason_code,
+                    state = instance_state.state
+                ) for instance_state in self.elb_conn.describe_instance_health(self.name)]
             else:
                 info['instance_health'] = []
 
@@ -409,7 +409,7 @@ class ElbManager(object):
                   elif instance_state['state'] == "OutOfService":
                     info['out_of_service_count'] += 1
                   else:
-                    info['unknown_instance_state_count'] =+ 1
+                    info['unknown_instance_state_count'] += 1
 
             if check_elb.health_check:
                 info['health_check'] = {


### PR DESCRIPTION
Formerly #584.

Adds a list of dictionaries of the instances behind ELB and the count of InService and OutOfService instances. This is useful if you want to be able to determine whether or not to proceed with Deregistering  instance(s) based upon an operational threshold. E.g. ensure there are N InService instances prior to executing a rolling upgrade.
