### PR TITLE
Make ALL_IN_SCHEMA for tables affect views

### DIFF
--- a/database/postgresql/postgresql_privs.py
+++ b/database/postgresql/postgresql_privs.py
@@ -315,7 +315,7 @@ class Connection(object):
         query = """SELECT relname
                    FROM pg_catalog.pg_class c
                    JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-                   WHERE nspname = %s AND relkind = 'r'"""
+                   WHERE nspname = %s AND relkind in ('r', 'v')"""
         self.cursor.execute(query, (schema,))
         return [t[0] for t in self.cursor.fetchall()]
 


### PR DESCRIPTION
ALL TABLES is considered to include views, so we must check for reltypes
'r' and 'v', not just 'r'. This bug was introduced due to using a
custom, backwards-compatible version of "ALL TABLES IN SCHEMA".
