### PR TITLE
Fixed bug, when MX records pointed to ORIGIN(@) caused unintentional …

### DIFF
--- a/cloud/digital_ocean/digital_ocean_domain.py
+++ b/cloud/digital_ocean/digital_ocean_domain.py
@@ -195,7 +195,7 @@ def core(module):
             records = domain.records()
             at_record = None
             for record in records:
-                if record.name == "@":
+                if record.name == "@" and record.record_type == 'A':
                     at_record = record
 
             if not at_record.data == getkeyordie("ip"):


### PR DESCRIPTION
If we have domain which has only one A Origin record , everything works fine. 
But , when domain managed by Digital Ocean has MX records which points to Origin (@), calling task digital_ocean_domain will cause unintentional change of one of the A records. For example if we have following records in domain testdom.com:

```
A @  1.1.1.1
A   mail   2.2.2.2
A  webmail 2.2.2.2
MX @ "v=spf1 mx ~all" 
```

and we use task which should finished in OK state because domain testdom.com exists with corrct origin record:

```
- name: "ensure that domain testdom.com exists in DO DNS"
  digital_ocean_domain: >
    client_id=xxx
    api_key=xxx
    state=present
    ip=1.1.1.1
    name=testdom.com
```

webmail A record is changed to 1.1.1.1, which is not correct and can negatively affect production systems. 

Root cause for this bug is that algorithm searches for Origin record in all records and not only in A records.
