### PR TITLE
ec2_vpc_net refactor

### DIFF
--- a/cloud/amazon/ec2_vpc_net.py
+++ b/cloud/amazon/ec2_vpc_net.py
@@ -59,6 +59,7 @@ options:
       - The tags you want attached to the VPC. This is independent of the name value, note if you pass a 'Name' key it would override the Name of the VPC if it's different.
     default: None
     required: false
+    aliases: [ 'resource_tags' ]
   state:
     description:
       - The state of the VPC. Either absent or present.
@@ -186,7 +187,7 @@ def main():
             dns_support = dict(type='bool', default=True),
             dns_hostnames = dict(type='bool', default=True),
             dhcp_opts_id = dict(type='str', default=None, required=False),
-            tags = dict(type='dict', required=False, default=None),
+            tags = dict(type='dict', required=False, default=None, aliases=['resource_tags']),
             state = dict(choices=['present', 'absent'], default='present'),
             multi_ok = dict(type='bool', default=False)
         )

--- a/cloud/amazon/ec2_vpc_net.py
+++ b/cloud/amazon/ec2_vpc_net.py
@@ -145,7 +145,7 @@ def update_vpc_tags(vpc, module, vpc_obj, tags, name):
     tags.update({'Name': name})
     try:
         current_tags = dict((t.name, t.value) for t in vpc.get_all_tags(filters={'resource-id': vpc_obj.id}))
-        if sorted(current_tags) != sorted(tags):
+        if cmp(tags, current_tags):
             vpc.create_tags(vpc_obj.id, tags)
             return True
         else:


### PR DESCRIPTION
- doc updates
  - added choices for bool options
  - removed empty alias
  - corrected examples to use correct module name
- moved attribute check to start of module so it fails before making any changes (if dns_hostnames and not dns_support:)
- passed vpc object instead of vpc id from vpc_exists method.  ID can be accessed as value of object and allows other attributes to be included in exit_json statement
- removed vpc_needs_update method in favor of checking each attribute individually.  This allows exit_json to be called with the same attributes every time
  - misc spelling corrections
