### PR TITLE
Change uri debug example

### DIFF
--- a/network/basics/uri.py
+++ b/network/basics/uri.py
@@ -269,7 +269,7 @@ def url_filename(url):
 
 def uri(module, url, dest, user, password, body, body_format, method, headers, redirects, socket_timeout, validate_certs):
     # To debug
-    #httplib2.debug = 4
+    #httplib2.debuglevel = 4
 
     # Handle Redirects
     if redirects == "all" or redirects == "yes":


### PR DESCRIPTION
As per the httplib2 docs, the right attribute to set is 'debuglevel', not 'debug'. https://code.google.com/p/httplib2/wiki/Examples
