### PR TITLE
no_log to iam password

### DIFF
--- a/cloud/amazon/iam.py
+++ b/cloud/amazon/iam.py
@@ -509,7 +509,7 @@ def main():
         groups=dict(type='list', default=None, required=False),
         state=dict(
             default=None, required=True, choices=['present', 'absent', 'update']),
-        password=dict(default=None, required=False),
+        password=dict(default=None, required=False, no_log=True),
         update_password=dict(default='always', required=False, choices=['always', 'on_create']),
         access_key_state=dict(default=None, required=False, choices=[
             'active', 'inactive', 'create', 'remove',


### PR DESCRIPTION
The password supplied shouldn't be logged. Simple patch.
