### PR TITLE
Core module fix-ups

### DIFF
--- a/database/mysql/mysql_db.py
+++ b/database/mysql/mysql_db.py
@@ -326,7 +326,7 @@ def main():
     if state in ['dump','import']:
         if target is None:
             module.fail_json(msg="with state=%s target is required" % (state))
-	if db == 'all':
+        if db == 'all':
             connect_to_db = 'mysql'
             db = 'mysql'
             all_databases = True

--- a/packaging/os/apt.py
+++ b/packaging/os/apt.py
@@ -230,10 +230,10 @@ def package_status(m, pkgname, version, cache, state):
             try:
                 provided_packages = cache.get_providing_packages(pkgname)
                 if provided_packages:
-		    is_installed = False
+                    is_installed = False
                     # when virtual package providing only one package, look up status of target package 
                     if cache.is_virtual_package(pkgname) and len(provided_packages) == 1:
-			package = provided_packages[0]
+                        package = provided_packages[0]
                         installed, upgradable, has_files = package_status(m, package.name, version, cache, state='install')
                         if installed:
                             is_installed = True

--- a/source_control/subversion.py
+++ b/source_control/subversion.py
@@ -121,7 +121,7 @@ class Subversion(object):
     def checkout(self):
         '''Creates new svn working directory if it does not already exist.'''
         self._exec(["checkout", "-r", self.revision, self.repo, self.dest])
-		
+
     def export(self, force=False):
         '''Export svn repo to directory'''
         cmd = ["export"]

--- a/system/group.py
+++ b/system/group.py
@@ -121,7 +121,7 @@ class Group(object):
         if len(cmd) == 1:
             return (None, '', '')
         if self.module.check_mode:
-	    return (0, '', '')
+            return (0, '', '')
         cmd.append(self.name)
         return self.execute_command(cmd)
 

--- a/windows/win_copy.py
+++ b/windows/win_copy.py
@@ -18,8 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
-import time
 
 DOCUMENTATION = '''
 ---


### PR DESCRIPTION
This PR addresses a few small fix ups in for core modules.
1. Replace tabbed indentation with spaces for mysql_db module
2. Replaced tabbed indentation with spaces for apt module
3. Replaced tabbed indentation with spaces for subversion module
4. Replaced tabbed indentation with spaces for group module
5. Remove unnecessary imports in a docs only file for win_copy
