### PR TITLE
Provide correct kwargs to rds2 connection when making a final snapshot

### DIFF
--- a/cloud/amazon/rds.py
+++ b/cloud/amazon/rds.py
@@ -715,7 +715,10 @@ def delete_db_instance_or_snapshot(module, conn):
         if instance_name:
             if snapshot:
                 params["skip_final_snapshot"] = False
-                params["final_snapshot_id"] = snapshot
+                if has_rds2:
+                    params["final_db_snapshot_identifier"] = snapshot
+                else:
+                    params["final_snapshot_id"] = snapshot
             else:
                 params["skip_final_snapshot"] = True
             result = conn.delete_db_instance(instance_name, **params)


### PR DESCRIPTION
When deleting an RDS instance and providing a `snapshot` parameter to the `rds` module, you get a traceback if you're using boto's `rds2` connection:

```
TASK: [Take snapshot and remove RDS instance] ********************************* 
failed: [127.0.0.1] => {"failed": true, "parsed": false}
Traceback (most recent call last):
  File "/home/flyte/.ansible/tmp/ansible-tmp-1435672516.87-197705542632515/rds", line 2822, in <module>
    main()
  File "/home/flyte/.ansible/tmp/ansible-tmp-1435672516.87-197705542632515/rds", line 1012, in main
    invocations[module.params.get('command')](module, conn)
  File "/home/flyte/.ansible/tmp/ansible-tmp-1435672516.87-197705542632515/rds", line 714, in delete_db_instance_or_snapshot
    result = conn.delete_db_instance(instance_name, **params)
  File "/home/flyte/.ansible/tmp/ansible-tmp-1435672516.87-197705542632515/rds", line 443, in delete_db_instance
    result = self.connection.delete_db_instance(instance_name, **params)['DeleteDBInstanceResponse']['DeleteDBInstanceResult']['DBInstance']
TypeError: delete_db_instance() got an unexpected keyword argument 'final_snapshot_id'
```

This is because the [function signature has changed](https://boto.readthedocs.org/en/latest/ref/rds2.html#boto.rds2.layer1.RDSConnection.delete_db_instance) in `rds2` from [what it is](https://boto.readthedocs.org/en/latest/ref/rds.html#boto.rds.RDSConnection.delete_dbinstance) in standard `rds`.

This patch detects the usage of `rds2` in the same way it does in other parts of the module and provides the correct arguments for both types of RDS connection.

Fixes [this bug](https://github.com/terranodo/ansible-worldmap/issues/1) which seems to have been reported on the wrong project.
