### PR TITLE
fix authorized_keys in check_mode

### DIFF
--- a/system/authorized_key.py
+++ b/system/authorized_key.py
@@ -138,7 +138,7 @@ import shlex
 class keydict(dict):
 
     """ a dictionary that maintains the order of keys as they are added """
-    
+
     # http://stackoverflow.com/questions/2328235/pythonextend-the-dict-class
 
     def __init__(self, *args, **kw):
@@ -146,7 +146,7 @@ class keydict(dict):
         self.itemlist = super(keydict,self).keys()
     def __setitem__(self, key, value):
         self.itemlist.append(key)
-        super(keydict,self).__setitem__(key, value)        
+        super(keydict,self).__setitem__(key, value)
     def __iter__(self):
         return iter(self.itemlist)
     def keys(self):
@@ -154,7 +154,7 @@ class keydict(dict):
     def values(self):
         return [self[key] for key in self]
     def itervalues(self):
-        return (self[key] for key in self)    
+        return (self[key] for key in self)
 
 def keyfile(module, user, write=False, path=None, manage_dir=True):
     """
@@ -167,6 +167,13 @@ def keyfile(module, user, write=False, path=None, manage_dir=True):
     :param bool manage_dir: if True, create and set ownership of the parent dir of the authorized_keys file
     :return: full path string to authorized_keys for user
     """
+
+    if module.check_mode:
+        if path is None:
+            module.fail_json(msg="You must provide full path to key file in check mode")
+        else:
+            keysfile = path
+            return keysfile
 
     try:
         user_entry = pwd.getpwnam(user)
@@ -214,8 +221,8 @@ def keyfile(module, user, write=False, path=None, manage_dir=True):
     return keysfile
 
 def parseoptions(module, options):
-    ''' 
-    reads a string containing ssh-key options 
+    '''
+    reads a string containing ssh-key options
     and returns a dictionary of those options
     '''
     options_dict = keydict() #ordered dict
@@ -246,7 +253,7 @@ def parsekey(module, raw_key):
         'ssh-ed25519',
         'ecdsa-sha2-nistp256',
         'ecdsa-sha2-nistp384',
-        'ecdsa-sha2-nistp521', 
+        'ecdsa-sha2-nistp521',
         'ssh-dss',
         'ssh-rsa',
     ]


### PR DESCRIPTION
This change is in response to issue #1515.
Original pull request #1580.

The original problem is: in authorized_key module you have no idea about users
which will be created by Ansible at first run. I can propose next two ways to
solve this problem:
1. Combine modules system/user.py and system/authorized_key.py in one module
    (so you will know everything about users in that module)
2. Use small workaround: add my commit and always provide 'path' parameter
    for authorized_key module during runs with --check option.
