### PR TITLE
Upstream docs show launch_config_name as required.

### DIFF
--- a/cloud/amazon/ec2_asg.py
+++ b/cloud/amazon/ec2_asg.py
@@ -43,7 +43,7 @@ options:
   launch_config_name:
     description:
       - Name of the Launch configuration to use for the group. See the ec2_lc module for managing these.
-    required: false
+    required: true
   min_size:
     description:
       - Minimum number of instances in group


### PR DESCRIPTION
http://docs.aws.amazon.com/AutoScaling/latest/APIReference/API_AutoScalingGroup.html

Fixes ansible/ansible#11209

Ansible behavior is correct, this commit just updates the docs to
reflect that correctness.
