### PR TITLE
Backport issue #133 fix to stable-1.9 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ addons:
       - python2.4
       - python2.6
 script:
-  - python2.4 -m compileall -fq -x 'cloud/|/accelerate.py' .
   - python2.4 -m compileall -fq cloud/amazon/_ec2_ami_search.py cloud/amazon/ec2_facts.py
   - python2.6 -m compileall -fq .
   - python2.7 -m compileall -fq .

--- a/packaging/os/apt_repository.py
+++ b/packaging/os/apt_repository.py
@@ -267,14 +267,18 @@ class SourcesList(object):
     def dump(self):
         return '\n'.join([str(i) for i in self])
 
+    def _choice(self, new, old):
+        if new is None:
+            return old
+        return new
+
     def modify(self, file, n, enabled=None, source=None, comment=None):
         '''
         This function to be used with iterator, so we don't care of invalid sources.
         If source, enabled, or comment is None, original value from line ``n`` will be preserved.
         '''
         valid, enabled_old, source_old, comment_old = self.files[file][n][1:]
-        choice = lambda new, old: old if new is None else new
-        self.files[file][n] = (n, valid, choice(enabled, enabled_old), choice(source, source_old), choice(comment, comment_old))
+        self.files[file][n] = (n, valid, self._choice(enabled, enabled_old), self._choice(source, source_old), self._choice(comment, comment_old))
 
     def _add_valid_source(self, source_new, comment_new, file):
         # We'll try to reuse disabled source if we have it.

--- a/packaging/os/apt_repository.py
+++ b/packaging/os/apt_repository.py
@@ -370,6 +370,25 @@ class UbuntuSourcesList(SourcesList):
             source = self._parse(line, raise_if_invalid_or_disabled=True)[2]
         self._remove_valid_source(source)
 
+    @property
+    def repos_urls(self):
+        _repositories = []
+        for parsed_repos in self.files.values():
+            for parsed_repo in parsed_repos:
+                enabled = parsed_repo[1]
+                source_line = parsed_repo[3]
+
+                if not enabled:
+                    continue
+
+                if source_line.startswith('ppa:'):
+                    source, ppa_owner, ppa_name = self._expand_ppa(i[3])
+                    _repositories.append(source)
+                else:
+                    _repositories.append(source_line)
+
+        return _repositories
+
 
 def get_add_ppa_signing_key_callback(module):
     def _run_command(command):
@@ -417,8 +436,13 @@ def main():
 
     sources_before = sourceslist.dump()
 
+    if repo.startswith('ppa:'):
+        expanded_repo = sourceslist._expand_ppa(repo)[0]
+    else:
+        expanded_repo = repo
+
     try:
-        if state == 'present':
+        if state == 'present' and expanded_repo not in sourceslist.repos_urls:
             sourceslist.add_source(repo)
         elif state == 'absent':
             sourceslist.remove_source(repo)


### PR DESCRIPTION
This takes d435d5ce0ae2597fdde4600dd07edbb8c9c4fdfe from the devel branch and backports it to the `stable-1.9` branch, so the issue can be fixed in a future 1.9 release.

I had deploys fail the other day on apt_repository because it was attempting to hit launchpad.net to validate a cert for a PPA that already existed on the system. So this would be a nice fix to have. Original commit message from d435d5ce0ae2597fdde4600dd07edbb8c9c4fdfe follows below...

---

This change is in response to issue #133.

The original problem is: apt_repository.py connect to launchpad on
every playbook run. In this patch apt_repository.py checks if required
repository already exists or not. If no - paa will be added, if yes -
just skip actions.
