### PR TITLE
Allowing users to use yaml dicts instead of strings for metadata

### DIFF
--- a/cloud/google/gce.py
+++ b/cloud/google/gce.py
@@ -327,7 +327,7 @@ def create_instances(module, gce, instance_names):
     # [ {'key': key1, 'value': value1}, {'key': key2, 'value': value2}, ...]
     if metadata:
         try:
-            md = literal_eval(metadata)
+            md = metadata
             if not isinstance(md, dict):
                 raise ValueError('metadata must be a dict')
         except ValueError, e:


### PR DESCRIPTION
This allows users to define metadata for instances using conventional YAML syntax rather than formatted strings within the YAML. This also brings the GCE behaviour more in line the the EC2 behaviour (where tags are specified as YAML dicts)
