### PR TITLE
Change the default flag value to None to prevent AWS complaining: "In…

### DIFF
--- a/cloud/amazon/ec2.py
+++ b/cloud/amazon/ec2.py
@@ -701,7 +701,7 @@ def create_block_device(module, ec2, volume):
                            volume_type=volume.get('device_type'),
                            delete_on_termination=volume.get('delete_on_termination', False),
                            iops=volume.get('iops'),
-                           encrypted=volume.get('encrypted', False))
+                           encrypted=volume.get('encrypted', None))
 
 def boto_supports_param_in_spot_request(ec2, param):
     """


### PR DESCRIPTION
…stance creation failed => InvalidBlockDeviceMapping: the encrypted flag cannot be specified since device /dev/sda1 has a snapshot specified."
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

ansible 2.0.0 (devel 908b2b8caf) last updated 2015/07/07 16:20:02 (GMT +300)
  lib/ansible/modules/core: (devel abdd96ed1e) last updated 2015/07/07 16:19:55 (GMT +300)
  lib/ansible/modules/extras: (devel b6d3306f49) last updated 2015/07/07 16:19:56 (GMT +300)
  v1/ansible/modules/core:  not found - use git submodule update --init v1/ansible/modules/core
  v1/ansible/modules/extras:  not found - use git submodule update --init v1/ansible/modules/extras
  configured module search path = None
##### Ansible Configuration:

Not applicable. My ansible configuration is quite default.
##### Environment:

AWS
##### Summary:

I encountered this problem when creating a ec2 instance from Centos 7 AMI image (from marketplace). Even with providing "encrypted: false" AWS api complains of the flag value. Setting the value to None which is boto default prevents problem. This is also backwards compatible.
##### Steps To Reproduce:

If this is a bug ticket, please enter the steps you use to reproduce the problem in the space below.  If this is a feature request, please enter the steps you would use to use the feature.  If an example playbook is useful, please include a short reproducer inline, indented by four spaces.  If a longer one is necessary, linking to one uploaded to gist.github.com would be great.  Much appreciated!

```
  - name: Locate Centos AMI image
    ec2_ami_find:
      region: "{{ aws_region }}
      owner: "aws-marketplace"
      architecture: x86_64
      virtualization_type: hvm
      name: "CentOS 7 x86_64 (2014_09_29) EBS HVM-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-d2a117ba.2"
      no_result_action: fail
    register: ami_find

  - name: Create plain AMI creation ec2 instance
    local_action:
      module: ec2
      key_name: "{{keypair}}"
      instance_type: "{{ec2_instance_type}}"
      image: "{{ ami_find.results[0].ami_id}}"
      region: "{{aws_region}}"
      count: 1
      wait: yes
      volumes:
        - device_name: /dev/sda1 #This is the root volume
          device_type: gp2 # SSD
          volume_size: 16
          delete_on_termination: false # Protect the data from accidental destruction
      vpc_subnet_id: "{{ ec2_vpc_subnet_id }}"
      assign_public_ip: yes
```
##### Expected Results:

Instance is created correctly with configured root volume.
##### Actual Results:

```
AWS complains:
"Instance creation failed => InvalidBlockDeviceMapping: the encrypted flag cannot be specified since device /dev/sda1 has a snapshot specified."
```
