### PR TITLE
s3 module: Add missing version tag to "encrypt" parameter

### DIFF
--- a/cloud/amazon/s3.py
+++ b/cloud/amazon/s3.py
@@ -50,6 +50,7 @@ options:
       - When set for PUT mode, asks for server-side encryption
     required: false
     default: no
+    version_added: "2.0"
   expiration:
     description:
       - Time limit (in seconds) for the URL generated and returned by S3/Walrus when performing a mode=put or mode=geturl operation.


### PR DESCRIPTION
Hi
The current documentation does not specify when the encrypt parameters was added like it does for other parameters thus implying that it is available in the latest stable 1.9 release. I am adding the version information here on the assumption that it was added for 2.0. Looks like the parameter itself was added in commit 40eef6c3ecd940817acd900e5451afd7883098e4.

Cheers,
Apoorva
