### PR TITLE
win_get_url: add force to module docs, default to force=yes

### DIFF
--- a/windows/win_get_url.ps1
+++ b/windows/win_get_url.ps1
@@ -40,7 +40,7 @@ Else {
     Fail-Json $result "missing required argument: dest"
 }
 
-$force = Get-Attr -obj $params -name "force" "no" | ConvertTo-Bool
+$force = Get-Attr -obj $params -name "force" "yes" | ConvertTo-Bool
 
 If ($force -or -not (Test-Path $dest)) {
     $client = New-Object System.Net.WebClient

--- a/windows/win_get_url.py
+++ b/windows/win_get_url.py
@@ -27,20 +27,28 @@ module: win_get_url
 version_added: "1.7"
 short_description: Fetches a file from a given URL
 description:
-     - Fetches a file from a URL and saves to locally
+ - Fetches a file from a URL and saves to locally
 options:
   url:
     description:
       - The full URL of a file to download
     required: true
     default: null
-    aliases: []
   dest:
     description:
-      - The absolute path of the location to save the file at the URL. Be sure to include a filename and extension as appropriate.
+      - The absolute path of the location to save the file at the URL. Be sure
+        to include a filename and extension as appropriate.
+    required: true
+    default: null
+  force:
+    description:
+      - If C(yes), will always download the file.  If C(no), will only
+        download the file if it does not exist or the remote file has been
+        modified more recently than the local file.
+    version_added: "2.0"
     required: false
+    choices: [ "yes", "no" ]
     default: yes
-    aliases: []
 author: "Paul Durivage (@angstwad)"
 '''
 
@@ -54,4 +62,10 @@ $ ansible -i hosts -c winrm -m win_get_url -a "url=http://www.example.com/earthr
   win_get_url:
     url: 'http://www.example.com/earthrise.jpg'
     dest: 'C:\Users\RandomUser\earthrise.jpg'
+
+- name: Download earthrise.jpg to 'C:\Users\RandomUser\earthrise.jpg' only if modified
+  win_get_url:
+    url: 'http://www.example.com/earthrise.jpg'
+    dest: 'C:\Users\RandomUser\earthrise.jpg'
+    force: no
 '''


### PR DESCRIPTION
Additional changes following https://github.com/ansible/ansible-modules-core/pull/1485 as suggested by @bcoca.  Default `force` to `yes` preserves the existing behavior of the module if `force` isn't specified.
