### PR TITLE
removed required together for resource pools, clusters, and templates

### DIFF
--- a/cloud/vmware/vsphere_guest.py
+++ b/cloud/vmware/vsphere_guest.py
@@ -1256,8 +1256,7 @@ def main():
                 'vm_hardware',
                 'esxi'
             ],
-            ['resource_pool', 'cluster'],
-            ['from_template', 'resource_pool', 'template_src'],
+            ['from_template', 'template_src'],
         ],
     )
 


### PR DESCRIPTION
**TL;DR**
Fixes inability to deploy from template on vsphere environments without resource pools or clusters, by removing the requirement of resource_pool and cluster, and resource_pool and template options.

**Explanation**
1) In vSphere, clusters and resource pools are one-way independent. i.e. You can have clusters without having resource pools (which is a common deployment), however resource pool _does_ require a cluster. Since this is a one-way requirement, it would be better to remove the requirement in this module, and document the facts, thus allowing users to deploy templates regardless of their vSphere environment.
2) Cluster would be required _only_ when the  vsphere environment is in fact clustered. Obviously, in an unclustered environment it _is not_, though templates can still be deployed - Hence the reason for removing the requirement entirely. A better solution would be to document the facts and allow users to configure playbooks as required by their environment.
