### PR TITLE
The tilde expansion doesn't work with user.home

### DIFF
--- a/system/user.py
+++ b/system/user.py
@@ -271,6 +271,9 @@ class User(object):
         self.update_password = module.params['update_password']
         self.expires = None
 
+        if module.params['home'] is not None:
+            self.home = os.path.expanduser(module.params['home'])
+
         if module.params['expires']:
             try:
                 self.expires = time.gmtime(module.params['expires'])


### PR DESCRIPTION
Calling `os.path.expanduser` on `module.params['home']` makes it possible to something like this:

``` yml
home: "{{ item.home | default('~' + item.name) }}"
```

Without this change the above seems to work but the task is always changed:

```
<127.0.0.1> REMOTE_MODULE user append=False password=VALUE_HIDDEN home='~consectetur' groups='' state=present remove=False system=False name=consectetur group=consectetur shell=/bin/bash update_password=always comment='Consecte tur'
changed: [ubuntu-1404] => (item={'comment': 'Consecte tur', 'password': '$6$fEAh6bTPeOrw$ftGhu4tt.TA950BKAuTOOB5E4RymyN/wnDEuC45FOOlA/iyseKZtC0U8VaIhnDC1KsgpRzHkxZ/yje9zcrRXW1', 'name': 'consectetur'}) => {"append": false, "changed": true, "comment": "Consecte tur", "group": 5002, "groups": "", "home": "/home/consectetur", "item": {"comment": "Consecte tur", "name": "consectetur", "password": "$6$fEAh6bTPeOrw$ftGhu4tt.TA950BKAuTOOB5E4RymyN/wnDEuC45FOOlA/iyseKZtC0U8VaIhnDC1KsgpRzHkxZ/yje9zcrRXW1"}, "move_home": false, "name": "consectetur", "password": "NOT_LOGGING_PASSWORD", "shell": "/bin/bash", "state": "present", "stderr": "usermod: no changes\n", "uid": 1000}
```

Probably because of this check:

``` python
if self.home is not None and info[5] != self.home:
```
