### PR TITLE
assemble: add file validation support.

### DIFF
--- a/files/assemble.py
+++ b/files/assemble.py
@@ -85,6 +85,13 @@ options:
     required: false
     default: false
     version_added: "2.0"
+  validate:
+    description:
+      - The validation command to run before copying into place.  The path to the file to
+        validate is passed in via '%s' which must be present as in the sshd example below.
+        The command is passed securely so shell features like expansion and pipes won't work.
+    required: false
+    default: ""
 author: "Stephen Fromm (@sfromm)"
 extends_documentation_fragment: files
 '''
@@ -95,6 +102,9 @@ EXAMPLES = '''
 
 # When a delimiter is specified, it will be inserted in between each fragment
 - assemble: src=/etc/someapp/fragments dest=/etc/someapp/someapp.conf delimiter='### START FRAGMENT ###'
+
+# Copy a new "sshd_config" file into place, after passing validation with sshd
+- assemble: src=/etc/ssh/conf.d/ dest=/etc/ssh/sshd_config validate='sshd -t -f %s'
 '''
 
 # ===========================================
@@ -155,6 +165,7 @@ def main():
             remote_src=dict(default=False, type='bool'),
             regexp = dict(required=False),
             ignore_hidden = dict(default=False, type='bool'),
+            validate = dict(required=False, type='str'),
         ),
         add_file_common_args=True
     )
@@ -170,6 +181,7 @@ def main():
     regexp    = module.params['regexp']
     compiled_regexp = None
     ignore_hidden = module.params['ignore_hidden']
+    validate = module.params.get('validate', None)
 
     if not os.path.exists(src):
         module.fail_json(msg="Source (%s) does not exist" % src)
@@ -192,6 +204,13 @@ def main():
     if path_hash != dest_hash:
         if backup and dest_hash is not None:
             module.backup_local(dest)
+        if validate:
+            if "%s" not in validate:
+                module.fail_json(msg="validate must contain %%s: %s" % validate)
+            (rc, out, err) = module.run_command(validate % path)
+            if rc != 0:
+                module.fail_json(msg="failed to validate: rc:%s error:%s" % (rc, err))
+
         shutil.copy(path, dest)
         changed = True
 


### PR DESCRIPTION
This PR adds an validate option to the assemble module. I works like the copy or template module.

Fixes #577
