### PR TITLE
docker: fix parsing of docker __version__ string

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -481,6 +481,7 @@ def get_docker_py_versioninfo():
                     if not char.isdigit():
                         nondigit = part[idx:]
                         digit = part[:idx]
+                        break
                 if digit:
                     version.append(int(digit))
                 if nondigit:


### PR DESCRIPTION
If `docker.__version__` contains non-digit characters, such as:

```
>>> import docker
>>> docker.__version__
'1.4.0-dev'
```

Then `get_docker_py_versioninfo` will fail with:

```
ValueError: invalid literal for int() with base 10: '0-de'
```

This patch corrects the parsing of the version string so that
`get_docker_py_versioninfo` in this example would return:

```
(1, 4, 0, '-dev')
```
