### PR TITLE
docker: permit empty or false pid

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -1270,6 +1270,10 @@ class DockerManager(object):
             if params['restart_policy']['Name'] == 'on-failure':
                 params['restart_policy']['MaximumRetryCount'] = optionals['restart_policy_retry']
 
+        # docker_py only accepts 'host' or None
+        if 'pid' in optionals and not optionals['pid']:
+            optionals['pid'] = None
+
         if optionals['pid'] is not None:
             self.ensure_capability('pid')
             params['pid_mode'] = optionals['pid']


### PR DESCRIPTION
The `docker` Python module only accepts `None` or `'host'` as arguments.
This makes it difficult to conditionally set the `pid` attribute using
standard Ansible syntax.

This change converts any value that evaluates as boolean `False` to
`None`, which includes empty strings:

```
pid:
```

As well as an explicit `false`:

```
pid: false
```

This permits the following to work as intended:

```
- hosts: localhost
  tasks:
  - name: starting container
    docker:
      docker_api_version: 1.18
      image: larsks/mini-httpd
      name: web
      pid: "{{ container_pid|default('') }}"
```

If `container_pid` is set to `host` somewhere, this will create a
Docker container with `pid=host`; otherwise, this will create a
container with normal isolated pid namespace.
