### PR TITLE
Do not erroneously mask exceptions in docker module

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -389,6 +389,7 @@ from urlparse import urlparse
 try:
     import docker.client
     import docker.utils
+    import docker.errors
     from requests.exceptions import RequestException
 except ImportError:
     HAS_DOCKER_PY = False
@@ -1322,7 +1323,10 @@ class DockerManager(object):
 
         try:
             containers = do_create(count, params)
-        except:
+        except docker.errors.APIError as e:
+            if e.response.status_code != 404:
+                raise
+
             self.pull_image()
             containers = do_create(count, params)
 


### PR DESCRIPTION
There was a catch-all `except` statement in `create_containers`:

```
    try:
        containers = do_create(count, params)
    except:
        self.pull_image()
        containers = do_create(count, params)
```

This would mask a variety of errors that should be exposed, including
API compatability errors (as in #1707) and common Python exceptions (KeyError, ValueError, etc) that could result from errors in the code.

This change makes the `except` statement more specific, and only attempts to pull the image and start a container if the original create attempt failed due to a 404 error from the docker API.
