### PR TITLE
Use HostConfig object when creating container with Docker Remote API > 1.15

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -530,6 +530,7 @@ class DockerManager(object):
             'extra_hosts': ((0, 7, 0), '1.3.1'),
             'pid': ((1, 0, 0), '1.17'),
             'log_driver': ((1, 2, 0), '1.18'),
+            'host_config': ((0, 7, 0), '1.15'),
             # Clientside only
             'insecure_registry': ((0, 5, 0), '0.0')
             }
@@ -738,6 +739,52 @@ class DockerManager(object):
             return exposed
         else:
             return None
+
+    def get_start_params(self):
+        """
+        Create start params
+        """
+        params = {
+            'lxc_conf': self.lxc_conf,
+            'binds': self.binds,
+            'port_bindings': self.port_bindings,
+            'publish_all_ports': self.module.params.get('publish_all_ports'),
+            'privileged': self.module.params.get('privileged'),
+            'links': self.links,
+            'network_mode': self.module.params.get('net'),
+        }
+
+        optionals = {}
+        for optional_param in ('dns', 'volumes_from', 'restart_policy',
+                'restart_policy_retry', 'pid'):
+            optionals[optional_param] = self.module.params.get(optional_param)
+
+        if optionals['dns'] is not None:
+            self.ensure_capability('dns')
+            params['dns'] = optionals['dns']
+
+        if optionals['volumes_from'] is not None:
+            self.ensure_capability('volumes_from')
+            params['volumes_from'] = optionals['volumes_from']
+
+        if optionals['restart_policy'] is not None:
+            self.ensure_capability('restart_policy')
+            params['restart_policy'] = { 'Name': optionals['restart_policy'] }
+            if params['restart_policy']['Name'] == 'on-failure':
+                params['restart_policy']['MaximumRetryCount'] = optionals['restart_policy_retry']
+
+        if optionals['pid'] is not None:
+            self.ensure_capability('pid')
+            params['pid_mode'] = optionals['pid']
+
+        return params
+
+    def get_host_config(self):
+        """
+        Create HostConfig object
+        """
+        params = self.get_start_params()
+        return docker.utils.create_host_config(**params)
 
     def get_port_bindings(self, ports):
         """
@@ -1292,16 +1339,10 @@ class DockerManager(object):
         return docker.utils.create_host_config(**params)
 
     def create_containers(self, count=1):
-        try:
-            mem_limit = _human_to_bytes(self.module.params.get('memory_limit'))
-        except ValueError as e:
-            self.module.fail_json(msg=str(e))
-
         params = {'image':        self.module.params.get('image'),
                   'command':      self.module.params.get('command'),
                   'ports':        self.exposed_ports,
                   'volumes':      self.volumes,
-                  'mem_limit':    mem_limit,
                   'environment':  self.env,
                   'hostname':     self.module.params.get('hostname'),
                   'domainname':   self.module.params.get('domainname'),
@@ -1309,8 +1350,10 @@ class DockerManager(object):
                   'name':         self.module.params.get('name'),
                   'stdin_open':   self.module.params.get('stdin_open'),
                   'tty':          self.module.params.get('tty'),
-                  'host_config':  self.create_host_config(),
                   }
+
+        if self.ensure_capability('host_config', fail=False):
+            params['host_config'] = self.get_host_config()
 
         def do_create(count, params):
             results = []
@@ -1333,6 +1376,11 @@ class DockerManager(object):
         return containers
 
     def start_containers(self, containers):
+        params = {}
+
+        if not self.ensure_capability('host_config', fail=False):
+            params = self.get_start_params()
+
         for i in containers:
             self.client.start(i)
             self.increment_counter('started')


### PR DESCRIPTION
This is mlosev's patch (from #1208), rebased against devel as of
2790af2.  It resolves #1707, which was caused by an API incompatibility
between the docker module and server API version 1.19.
