### PR TITLE
Fixed parameter validation when creating a volume from a snapshot

### DIFF
--- a/cloud/amazon/ec2_vol.py
+++ b/cloud/amazon/ec2_vol.py
@@ -436,11 +436,11 @@ def main():
 
     # Delaying the checks until after the instance check allows us to get volume ids for existing volumes
     # without needing to pass an unused volume_size
-    if not volume_size and not (id or name):
-        module.fail_json(msg="You must specify an existing volume with id or name or a volume_size")
+    if not volume_size and not (id or name or snapshot):
+        module.fail_json(msg="You must specify volume_size or identify an existing volume by id, name, or snapshot")
 
-    if volume_size and id:
-        module.fail_json(msg="Cannot specify volume_size and id")
+    if volume_size and (id or snapshot):
+        module.fail_json(msg="Cannot specify volume_size together with id or snapshot")
 
     if state == 'absent':
         delete_volume(module, ec2)


### PR DESCRIPTION
The parameter validation in ec2_vol does not account for volumes to be created from snapshots.

fixes #139

This fix was provided also on this pull request: https://github.com/ansible/ansible-modules-core/pull/1289 but underlying code has changed so I created this new pull request to get issue fixed.
