### PR TITLE
Added the 'hw_interfaces' array

### DIFF
--- a/cloud/vmware/vsphere_guest.py
+++ b/cloud/vmware/vsphere_guest.py
@@ -1092,6 +1092,7 @@ def gather_facts(vm):
         'hw_product_uuid': vm.properties.config.uuid,
         'hw_processor_count': vm.properties.config.hardware.numCPU,
         'hw_memtotal_mb': vm.properties.config.hardware.memoryMB,
+        'hw_interfaces':[],
     }
     netInfo = vm.get_property('net')
     netDict = {}
@@ -1114,6 +1115,7 @@ def gather_facts(vm):
             'macaddress_dash': entry.macAddress.replace(':', '-'),
             'summary': entry.deviceInfo.summary,
         }
+        facts['hw_interfaces'].append('eth'+str(ifidx))
 
         ifidx += 1
 


### PR DESCRIPTION
The 'hw_interfaces' array lists the names of all interfaces present on the VM, just as 'ansible_interfaces' lists the names of the interfaces seen seen by the operating system
