### PR TITLE
Fix win_user error from #1241

### DIFF
--- a/windows/win_user.ps1
+++ b/windows/win_user.ps1
@@ -146,6 +146,7 @@ If ($state -eq 'present') {
             If ($password -ne $null) {
                 $user_obj.SetPassword($password)
             }
+            $user_obj.SetInfo()
             $result.changed = $true
         }
         ElseIf (($password -ne $null) -and ($update_password -eq 'always')) {


### PR DESCRIPTION
If creating a new user, save user before trying to read/set other properties.  Fixes #1241
