### PR TITLE
iam: don't delete passwords by default

### DIFF
--- a/cloud/amazon/iam.py
+++ b/cloud/amazon/iam.py
@@ -280,12 +280,6 @@ def update_user(module, iam, name, new_name, new_path, key_state, key_count, key
                     module.fail_json(changed=False, msg="Passsword doesn't conform to policy")
                 else:
                     module.fail_json(msg=error_msg)
-    else:
-        try:
-            iam.delete_login_profile(name)
-            changed = True
-        except boto.exception.BotoServerError:
-            pass
 
     if key_state == 'create':
         try:


### PR DESCRIPTION
The IAM module has an `update_password` option, similar to the system/user and mysql_user modules. Contrary to those modules, if the `password` and `update_password` are omitted, the module will delete the login profile (aka the password) for the given IAM user.

e.g. the following task:

``` yaml
- name:
  iam:
    iam_type: user
    name: jdavila
    groups: [Mario]
```

will delete @defionscode's password while adding him to the Mario group.

I posit that this is bad behavior for the following reasons:
1. It is unintuitive. With the same arguments, the system/user module, something most Ansible users have used extensively, will not tamper with the password of the given user. More generally, it's doing something specific and destructive without being explicitly asked.
2. It is undocumented. The description for this option is identical to the system/user module, even though the behavior is quite different. Even the examples, which have two user tasks that would trigger this behavior if a password was present, fail to mention this behavior.
3. It is likely to cause havoc. I unintentionally locked out a bunch of users from our systems as a result of this unconventional behavior. I am sure that a lot of other sysadmins will be burned by this if the current behavior is maintained.

If there is a need to delete login profiles via Ansible, I would argue that that should be handled via an explicit, _non-default_ option. The current behavior has too many drawbacks.
