### PR TITLE
Fix service enabled check failure on FreeBSD

### DIFF
--- a/system/service.py
+++ b/system/service.py
@@ -988,7 +988,7 @@ class FreeBsdService(Service):
 
         try:
             return self.service_enable_rcconf()
-        except:
+        except Exception:
             self.module.fail_json(msg='unable to set rcvar')
 
     def service_control(self):


### PR DESCRIPTION
On FreeBSD, service module's "enabled" fails with `--check` when state is "changed" like below

```
% ansible -i =(echo localhost) localhost -c local -m service -a "name=sendmail enabled=no" --check
localhost | FAILED >> {
    "failed": true,
    "msg": "{\"msg\": \"changing service enablement\", \"changed\": true}\n{\"msg\": \"unable to set rcvar\", \"failed\": true}\n",
    "parsed": false
}
```

This patch fixes above issue.

Related Issues are  #5159, #5160 and #5162
