### PR TITLE
`docker` `docker_api_version` fix, and `docker_image` boot2docker/docker-machine fixes

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -1034,7 +1034,7 @@ class DockerManager(object):
                 self.module.fail_json(msg=str(e))
 
             #For v1.19 API and above use HostConfig, otherwise use Config
-            if docker_api_version >= 1.19:
+            if api_version >= 1.19:
                 actual_mem = container['HostConfig']['Memory']
             else:
                 actual_mem = container['Config']['Memory']

--- a/cloud/docker/docker_image.py
+++ b/cloud/docker/docker_image.py
@@ -160,14 +160,99 @@ class DockerImageManager:
         self.name = self.module.params.get('name')
         self.tag = self.module.params.get('tag')
         self.nocache = self.module.params.get('nocache')
-        docker_url = urlparse(module.params.get('docker_url'))
-        self.client = docker.Client(
-            base_url=docker_url.geturl(),
-            version=module.params.get('docker_api_version'),
-            timeout=module.params.get('timeout'))
+        # docker_url = urlparse(module.params.get('docker_url'))
+        # self.client = docker.Client(
+        #     base_url=docker_url.geturl(),
+        #     version=module.params.get('docker_api_version'),
+        #     timeout=module.params.get('timeout'))
         self.changed = False
         self.log = []
         self.error_msg = None
+
+        # RG: Copied client options loading from docker.py -- should probably be shared code:
+
+        # Connect to the docker server using any configured host and TLS settings.
+
+        env_host = os.getenv('DOCKER_HOST')
+        env_docker_verify = os.getenv('DOCKER_TLS_VERIFY')
+        env_cert_path = os.getenv('DOCKER_CERT_PATH')
+        env_docker_hostname = os.getenv('DOCKER_TLS_HOSTNAME')
+
+        docker_url = module.params.get('docker_url')
+        if not docker_url:
+            if env_host:
+                docker_url = env_host
+            else:
+                docker_url = 'unix://var/run/docker.sock'
+
+        docker_api_version = module.params.get('docker_api_version')
+
+        tls_client_cert = module.params.get('tls_client_cert', None)
+        if not tls_client_cert and env_cert_path:
+            tls_client_cert = os.path.join(env_cert_path, 'cert.pem')
+
+        tls_client_key = module.params.get('tls_client_key', None)
+        if not tls_client_key and env_cert_path:
+            tls_client_key = os.path.join(env_cert_path, 'key.pem')
+
+        tls_ca_cert = module.params.get('tls_ca_cert')
+        if not tls_ca_cert and env_cert_path:
+            tls_ca_cert = os.path.join(env_cert_path, 'ca.pem')
+
+        tls_hostname = module.params.get('tls_hostname')
+        if tls_hostname is None:
+            if env_docker_hostname:
+                tls_hostname = env_docker_hostname
+            else:
+                parsed_url = urlparse(docker_url)
+                if ':' in parsed_url.netloc:
+                    tls_hostname = parsed_url.netloc[:parsed_url.netloc.rindex(':')]
+                else:
+                    tls_hostname = parsed_url
+        if not tls_hostname:
+            tls_hostname = True
+
+        # use_tls can be one of four values:
+        # no: Do not use tls
+        # encrypt: Use tls.  We may do client auth.  We will not verify the server
+        # verify: Use tls.  We may do client auth.  We will verify the server
+        # None: Only use tls if the parameters for client auth were specified
+        #   or tls_ca_cert (which requests verifying the server with
+        #   a specific ca certificate)
+        use_tls = module.params.get('use_tls')
+        if use_tls is None and env_docker_verify is not None:
+            use_tls = 'verify'
+
+        tls_config = None
+        if use_tls != 'no':
+            params = {}
+
+            # Setup client auth
+            if tls_client_cert and tls_client_key:
+                params['client_cert'] = (tls_client_cert, tls_client_key)
+
+            # We're allowed to verify the connection to the server
+            if use_tls == 'verify' or (use_tls is None and tls_ca_cert):
+                if tls_ca_cert:
+                    params['ca_cert'] = tls_ca_cert
+                    params['verify'] = True
+                    params['assert_hostname'] = tls_hostname
+                else:
+                    params['verify'] = True
+                    params['assert_hostname'] = tls_hostname
+            elif use_tls == 'encrypt':
+                params['verify'] = False
+
+            if params:
+                # See https://github.com/docker/docker-py/blob/d39da11/docker/utils/utils.py#L279-L296
+                docker_url = docker_url.replace('tcp://', 'https://')
+                tls_config = docker.tls.TLSConfig(**params)
+
+        self.client = docker.Client(base_url=docker_url,
+                                    version=docker_api_version,
+                                    tls=tls_config)
+
+
 
     def get_log(self, as_string=True):
         return "".join(self.log) if as_string else self.log
@@ -243,12 +328,18 @@ def main():
             tag                = dict(required=False, default="latest"),
             nocache            = dict(default=False, type='bool'),
             state              = dict(default='present', choices=['absent', 'present', 'build']),
-            docker_url         = dict(default='unix://var/run/docker.sock'),
-            docker_api_version = dict(required=False,
-                                      default=DEFAULT_DOCKER_API_VERSION,
-                                      type='str'),
+            docker_url         = dict(),
+            use_tls            = dict(default=None, choices=['no', 'encrypt', 'verify']),
+            tls_client_cert    = dict(required=False, default=None, type='str'),
+            tls_client_key     = dict(required=False, default=None, type='str'),
+            tls_ca_cert        = dict(required=False, default=None, type='str'),
+            tls_hostname       = dict(required=False, type='str', default=None),
+            docker_api_version = dict(required=False, default=DEFAULT_DOCKER_API_VERSION, type='str'),
             timeout            = dict(default=600, type='int'),
-        )
+        ),
+        required_together = (
+            ['tls_client_cert', 'tls_client_key'],
+        ),
     )
     if not HAS_DOCKER_CLIENT:
         module.fail_json(msg='docker-py is needed for this module')


### PR DESCRIPTION
Fixes:
 #1450 - `docker_image` now accepts all of the TLS and host options/ENV variable as the `docker` module:
- `docker_url` (`DOCKER_HOST`)
- `use_tls` (`DOCKER_TLS_VERIFY` _being set at all_)
- `tls_client_cert` (`DOCKER_CERT_PATH`)
- `tls_hostname` (`DOCKER_TLS_HOSTNAME`)
- `docker_api_version`
- `tls_client_cert`
- `tls_client_key`
- `tls_ca_cert`

?? (I couldn't find it again) - “NameError: global name 'docker_api_version' is not defined” (it was a pretty clear bug in the code, easy fix)

Helps with (but doesn't fix):
 #1711 - `docker_image` now supporting `use_tls: "encrypt"` allows a workaround

-Rob

PS: Sorry for the mixing of fixes to two modules, but I found the `docker` module error while working on the `docker_image` bug, and it was a single-line obvious fix.
