### PR TITLE
Fix incorrect var name for api_version

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -1012,7 +1012,7 @@ class DockerManager(object):
                 self.module.fail_json(msg=str(e))
 
             #For v1.19 API and above use HostConfig, otherwise use Config
-            if docker_api_version >= 1.19:
+            if api_version >= 1.19:
                 actual_mem = container['HostConfig']['Memory']
             else:
                 actual_mem = container['Config']['Memory']


### PR DESCRIPTION
Fix inconsistent variable name docker_api_version to api_version.
