### PR TITLE
another solution to apt_repository/repos_urls traceback on Debian (PR #1738, bug #1684)

### DIFF
--- a/packaging/os/apt_repository.py
+++ b/packaging/os/apt_repository.py
@@ -438,7 +438,7 @@ def main():
     if isinstance(distro, aptsources_distro.UbuntuDistribution):
         sourceslist = UbuntuSourcesList(module,
             add_ppa_signing_keys_callback=get_add_ppa_signing_key_callback(module))
-    elif isinstance(distro, aptsources_distro.DebianDistribution) or isinstance(distro, aptsources_distro.Distribution):
+    elif isinstance(distro, aptsources_distro.Distribution):
         sourceslist = SourcesList(module)
     else:
         module.fail_json(msg='Module apt_repository supports only Debian and Ubuntu.')

--- a/packaging/os/apt_repository.py
+++ b/packaging/os/apt_repository.py
@@ -390,7 +390,7 @@ class UbuntuSourcesList(SourcesList):
                     continue
 
                 if source_line.startswith('ppa:'):
-                    source, ppa_owner, ppa_name = self._expand_ppa(i[3])
+                    source, ppa_owner, ppa_name = self._expand_ppa(source_line)
                     _repositories.append(source)
                 else:
                     _repositories.append(source_line)

--- a/packaging/os/apt_repository.py
+++ b/packaging/os/apt_repository.py
@@ -423,24 +423,24 @@ def main():
     )
 
     params = module.params
-    if params['install_python_apt'] and not HAVE_PYTHON_APT and not module.check_mode:
-        install_python_apt(module)
-
     repo = module.params['repo']
     state = module.params['state']
     update_cache = module.params['update_cache']
     sourceslist = None
 
-    if HAVE_PYTHON_APT:
-        if isinstance(distro, aptsources_distro.UbuntuDistribution):
-            sourceslist = UbuntuSourcesList(module,
-                add_ppa_signing_keys_callback=get_add_ppa_signing_key_callback(module))
-        elif HAVE_PYTHON_APT and \
-            isinstance(distro, aptsources_distro.DebianDistribution) or isinstance(distro, aptsources_distro.Distribution):
-            sourceslist = SourcesList()
+    if not HAVE_PYTHON_APT:
+        if params['install_python_apt']:
+            install_python_apt(module)
+        else:
+            module.fail_json(msg='python-apt is not installed, and install_python_apt is False')
+
+    if isinstance(distro, aptsources_distro.UbuntuDistribution):
+        sourceslist = UbuntuSourcesList(module,
+            add_ppa_signing_keys_callback=get_add_ppa_signing_key_callback(module))
+    elif isinstance(distro, aptsources_distro.DebianDistribution) or isinstance(distro, aptsources_distro.Distribution):
+        sourceslist = SourcesList()
     else:
-        module.fail_json(msg='Module apt_repository supports only Debian and Ubuntu. ' + \
-                             'You may be seeing this because python-apt is not installed, but you requested that it not be auto-installed')
+        module.fail_json(msg='Module apt_repository supports only Debian and Ubuntu.')
 
     sources_before = sourceslist.dump()
 

--- a/packaging/os/apt_repository.py
+++ b/packaging/os/apt_repository.py
@@ -360,6 +360,10 @@ class UbuntuSourcesList(SourcesList):
         if line.startswith('ppa:'):
             source, ppa_owner, ppa_name = self._expand_ppa(line)
 
+            if source in self.repos_urls:
+                # repository already exists
+                return
+
             if self.add_ppa_signing_keys_callback is not None:
                 info = self._get_ppa_info(ppa_owner, ppa_name)
                 if not self._key_already_exists(info['signing_key_fingerprint']):
@@ -445,13 +449,8 @@ def main():
 
     sources_before = sourceslist.dump()
 
-    if repo.startswith('ppa:'):
-        expanded_repo = sourceslist._expand_ppa(repo)[0]
-    else:
-        expanded_repo = repo
-
     try:
-        if state == 'present' and expanded_repo not in sourceslist.repos_urls:
+        if state == 'present':
             sourceslist.add_source(repo)
         elif state == 'absent':
             sourceslist.remove_source(repo)


### PR DESCRIPTION
This fixes the `i[3]` reference in one commit, and adds a Debian version of `repos_urls` without ppa handling. This does work on Debian and should work on Ubuntu (since the code hasn't changed there, except to call `_expand_ppa` with the right arguments).
