### PR TITLE
remove checking of stderr for insserv

### DIFF
--- a/system/service.py
+++ b/system/service.py
@@ -827,12 +827,12 @@ class LinuxService(Service):
 
             if self.enable:
                 (rc, out, err) = self.execute_command("%s %s" % (self.enable_cmd, self.name))
-                if (rc != 0) or (err != ''):
+                if (rc != 0):
                     self.module.fail_json(msg=("Failed to install service. rc: %s, out: %s, err: %s" % (rc, out, err)))
                 return (rc, out, err)
             else:
                 (rc, out, err) = self.execute_command("%s -r %s" % (self.enable_cmd, self.name))
-                if (rc != 0) or (err != ''):
+                if (rc != 0):
                     self.module.fail_json(msg=("Failed to remove service. rc: %s, out: %s, err: %s" % (rc, out, err)))
                 return (rc, out, err)
 


### PR DESCRIPTION
stderr of insserv can also contain warnings which can be ignored. checking rc only is more accurate.
fixes #1502
