### PR TITLE
#1842 backport fixup: module is now self.module

### DIFF
--- a/packaging/os/apt_repository.py
+++ b/packaging/os/apt_repository.py
@@ -240,8 +240,8 @@ class SourcesList(object):
                 fd, tmp_path = tempfile.mkstemp(prefix=".%s-" % fn, dir=d)
 
                 # allow the user to override the default mode
-                this_mode = module.params['mode']
-                module.set_mode_if_different(tmp_path, this_mode, False)
+                this_mode = self.module.params['mode']
+                self.module.set_mode_if_different(tmp_path, this_mode, False)
 
                 f = os.fdopen(fd, 'w')
                 for n, valid, enabled, source, comment in sources:


### PR DESCRIPTION
stable-1.9 contained two more references to `module` than devel did, so the backport of #1842 caused build failures such as https://travis-ci.org/debops/ansible-nodejs/builds/73512508#L582

Reported by drybjed on IRC.
