### PR TITLE
fix ugly documentation

### DIFF
--- a/cloud/amazon/cloudformation.py
+++ b/cloud/amazon/cloudformation.py
@@ -79,7 +79,8 @@ options:
     required: false
     version_added: "2.0"
   template_format:
-    description: For local templates, allows specification of json or yaml format
+    description:
+    - For local templates, allows specification of json or yaml format
     default: json
     choices: [ json, yaml ]
     required: false


### PR DESCRIPTION
current version dumps a character per line in the docs: http://docs.ansible.com/ansible/cloudformation_module.html
