### PR TITLE
checking remote_group_id while comparing os_security_group_rule

### DIFF
--- a/cloud/openstack/os_security_group_rule.py
+++ b/cloud/openstack/os_security_group_rule.py
@@ -213,12 +213,14 @@ def _find_matching_rule(module, secgroup):
     remote_ip_prefix = module.params['remote_ip_prefix']
     ethertype = module.params['ethertype']
     direction = module.params['direction']
+    remote_group_id = module.params['remote_group']
 
     for rule in secgroup['security_group_rules']:
         if (protocol == rule['protocol']
                 and remote_ip_prefix == rule['remote_ip_prefix']
                 and ethertype == rule['ethertype']
                 and direction == rule['direction']
+                and remote_group_id == rule['remote_group_id']
                 and _ports_match(protocol,
                                  module.params['port_range_min'],
                                  module.params['port_range_max'],


### PR DESCRIPTION
Adding check for remote_group_id creating a new os_security_group_rule

I had two had two services in front of other, we are creating one security group per app.

so I needed to create security groups like

APP1
direction: ingress, protocol: tcp, port: 8080, remote_ip_prefix: 10.10.10.10/32

APP2
direction: ingress, protocol: tcp, port: 8080, remote_ip_prefix: 10.10.10.11/32

APP3
Rule 1. direction: ingress, protocol: tcp, port: 8080, remote_group: APP1[id]
Rule 2. direction: ingress, protocol: tcp, port: 8080, remote_group: APP1[id]

but currently I can't add rules for APP3 because while creating module checks for pre-existance of a rule
But it only compares for direction, ports, remote_ip, protocol, ip_type values

So due to this Rule 1, and Rule 2 (above for APP3) are being considered as same.
