### PR TITLE
Allow a mac address to be specified with vsphere_guest

### DIFF
--- a/cloud/vmware/vsphere_guest.py
+++ b/cloud/vmware/vsphere_guest.py
@@ -1223,7 +1223,7 @@ def main():
         'nic1': {
             'type': basestring,
             'network': basestring,
-            'network_type': basestring,
+            'network_type': basestring
         }
     }
 


### PR DESCRIPTION
When adding network interfaces on a new virtual machine you're unable to manually specify a mac address. This patch will allow an optional element to set the mac address.
