### PR TITLE
Custom Windows Facts

### DIFF
--- a/system/setup.py
+++ b/system/setup.py
@@ -54,12 +54,14 @@ notes:
       install I(facter) and I(ohai) means you can avoid Ruby-dependencies on your
       remote systems. (See also M(facter) and M(ohai).)
     - The filter option filters only the first level subkey below ansible_facts.
-    - If the target host is Windows, you will not currently have the ability to use
-      C(fact_path) or C(filter) as this is provided by a simpler implementation of the module.
-      Different facts are returned for Windows hosts.
+    - If the target host is Windows you can now use C(fact_path). Make sure that this path 
+      exists on the target host. Files in this path MUST be PowerShell scripts (*.ps1) and 
+      their output must be formattable in JSON (Ansible will take care of this). Test the 
+      output of your scripts.
 author:
     - "Ansible Core Team"
     - "Michael DeHaan"
+    - "David O'Brien @david_obrien davidobrien1985"
 '''
 
 EXAMPLES = """
@@ -74,6 +76,9 @@ ansible all -m setup -a 'filter=facter_*'
 
 # Display only facts about certain interfaces.
 ansible all -m setup -a 'filter=ansible_eth[0-2]'
+
+# Display facts from Windows hosts with custom facts stored in C(C:\\custom_facts).
+ansible windows -m setup -a "fact_path='c:\\custom_facts'"
 """
 
 

--- a/system/setup.py
+++ b/system/setup.py
@@ -35,7 +35,7 @@ options:
         description:
             - path used for local ansible facts (*.fact) - files in this dir
               will be run (if executable) and their results be added to ansible_local facts
-              if a file is not executable it is read.
+              if a file is not executable it is read. Check notes for Windows options. (from 2.1 on)
               File/results format can be json or ini-format
         required: false
         default: '/etc/ansible/facts.d'
@@ -54,10 +54,13 @@ notes:
       install I(facter) and I(ohai) means you can avoid Ruby-dependencies on your
       remote systems. (See also M(facter) and M(ohai).)
     - The filter option filters only the first level subkey below ansible_facts.
+    - If the target host is Windows, you will not currently have the ability to use
+      C(filter) as this is provided by a simpler implementation of the module.
     - If the target host is Windows you can now use C(fact_path). Make sure that this path 
       exists on the target host. Files in this path MUST be PowerShell scripts (*.ps1) and 
       their output must be formattable in JSON (Ansible will take care of this). Test the 
       output of your scripts.
+      This option was added in Ansible 2.1.
 author:
     - "Ansible Core Team"
     - "Michael DeHaan"

--- a/windows/setup.ps1
+++ b/windows/setup.ps1
@@ -35,7 +35,7 @@ Function Get-CustomFacts {
   $FactsFiles = Get-ChildItem -Path $factpath | Where-Object -FilterScript {($PSItem.PSIsContainer -eq $false) -and ($PSItem.Extension -eq '.ps1')}
 
   foreach ($FactsFile in $FactsFiles) {
-      $out = . $($FactsFile.FullName)
+      $out = & $($FactsFile.FullName)
       Set-Attr $result.ansible_facts "ansible_$(($FactsFile.Name).Split('.')[0])" $out
   }
 }


### PR DESCRIPTION
As explained here: https://github.com/ansible/ansible-modules-core/issues/1865

Following changes to setup.ps1:
- added Function Get-CustomFacts
- enabled parsing of params and using facts_path
  -- this will enable current users to easily understand what this variable is for
- any ps1 file in facts_path will be executed (obviously a security issue, but it's the same on Unix), make sure regular users can't access this folder!

I strongly rely on the person writing those custom ps1 files. They will have to make sure that their code returns data in a nice manner.
