### PR TITLE
Bugfix pull request: pip installations from requirement files containing urls always changed

### DIFF
--- a/packaging/language/pip.py
+++ b/packaging/language/pip.py
@@ -310,9 +310,11 @@ def main():
 
     # Automatically apply -e option to extra_args when source is a VCS url. VCS
     # includes those beginning with svn+, git+, hg+ or bzr+
+    has_vcs = False
     if name:
         if name.startswith('svn+') or name.startswith('git+') or \
                 name.startswith('hg+') or name.startswith('bzr+'):
+            has_vcs = True
             args_list = []  # used if extra_args is not used at all
             if extra_args:
                 args_list = extra_args.split(' ')
@@ -335,8 +337,7 @@ def main():
     if module.check_mode:
         if extra_args or requirements or state == 'latest' or not name:
             module.exit_json(changed=True)
-        elif name.startswith('svn+') or name.startswith('git+') or \
-                name.startswith('hg+') or name.startswith('bzr+'):
+        elif has_vcs:
             module.exit_json(changed=True)
 
         freeze_cmd = '%s freeze' % pip
@@ -353,7 +354,7 @@ def main():
         changed = (state == 'present' and not is_present) or (state == 'absent' and is_present)
         module.exit_json(changed=changed, cmd=freeze_cmd, stdout=out, stderr=err)
 
-    if requirements:
+    if requirements or has_vcs:
         freeze_cmd = '%s freeze' % pip
         out_freeze_before = module.run_command(freeze_cmd, cwd=this_dir)[1]
     else:

--- a/packaging/language/pip.py
+++ b/packaging/language/pip.py
@@ -353,6 +353,12 @@ def main():
         changed = (state == 'present' and not is_present) or (state == 'absent' and is_present)
         module.exit_json(changed=changed, cmd=freeze_cmd, stdout=out, stderr=err)
 
+    if requirements:
+        freeze_cmd = '%s freeze' % pip
+        out_freeze_before = module.run_command(freeze_cmd, cwd=this_dir)[1]
+    else:
+        out_freeze_before = None
+
     rc, out_pip, err_pip = module.run_command(cmd, path_prefix=path_prefix, cwd=this_dir)
     out += out_pip
     err += err_pip
@@ -365,7 +371,11 @@ def main():
     if state == 'absent':
         changed = 'Successfully uninstalled' in out_pip
     else:
-        changed = 'Successfully installed' in out_pip
+        if out_freeze_before is None:
+            changed = 'Successfully installed' in out_pip
+        else:
+            out_freeze_after = module.run_command(freeze_cmd, cwd=this_dir)[1]
+            changed = out_freeze_before != out_freeze_after
 
     module.exit_json(changed=changed, cmd=cmd, name=name, version=version,
                      state=state, requirements=requirements, virtualenv=env,


### PR DESCRIPTION
The issue is still present in ansible 1.9.2. To reproduce the bug, from an ansible checkout dir:

```
echo '-e git+https://github.com/dvarrazzo/pyiso8601#egg=pyiso8601' > testreq.txt
./hacking/test-module -m v2/ansible/modules/core/packaging/language/pip.py -a "requirements=`pwd`/testreq.txt virtualenv=`pwd`/testenv"
```

running the pip command twice, the second output should return "changed: false"; it always returns "changed: true" instead.

Should fix ansible/ansible#1705
