### PR TITLE
mem_limit client version check

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -1404,12 +1404,12 @@ class DockerManager(object):
             mem_limit = _human_to_bytes(self.module.params.get('memory_limit'))
         except ValueError as e:
             self.module.fail_json(msg=str(e))
+        api_version = self.client.version()['ApiVersion']
 
         params = {'image':        self.module.params.get('image'),
                   'command':      self.module.params.get('command'),
                   'ports':        self.exposed_ports,
                   'volumes':      self.volumes,
-                  'mem_limit':    mem_limit,
                   'environment':  self.env,
                   'hostname':     self.module.params.get('hostname'),
                   'domainname':   self.module.params.get('domainname'),
@@ -1421,9 +1421,15 @@ class DockerManager(object):
                   'host_config':  self.create_host_config(),
                   'user':         self.module.params.get('docker_user'),
                   }
-
         if self.ensure_capability('host_config', fail=False):
             params['host_config'] = self.get_host_config()
+
+        #For v1.19 API and above use HostConfig, otherwise use Config
+        if api_version < 1.19:
+            params['mem_limit'] = mem_limit
+        else:
+            params['host_config']['mem_limit'] = mem_limit
+
 
         def do_create(count, params):
             results = []


### PR DESCRIPTION
Hey,
   This adds a docker client version check when setting the mem_limit param. Should fix #1602 
