### PR TITLE
Two fixes for ec2_elb_lb module to make stickiness work with undefined expiration period 

### DIFF
--- a/cloud/amazon/ec2_elb_lb.py
+++ b/cloud/amazon/ec2_elb_lb.py
@@ -755,21 +755,25 @@ class ElbManager(object):
             if self.stickiness['type'] == 'loadbalancer':
                 policy = []
                 policy_type = 'LBCookieStickinessPolicyType'
-                if self.stickiness['enabled'] == True:
+
+                if self.module.boolean(self.stickiness['enabled']) == True:
 
                     if 'expiration' not in self.stickiness:
                         self.module.fail_json(msg='expiration must be set when type is loadbalancer')
+
+                    expiration = self.stickiness['expiration'] if self.stickiness['expiration'] is not 0 else None
 
                     policy_attrs = {
                         'type': policy_type,
                         'attr': 'lb_cookie_stickiness_policies',
                         'method': 'create_lb_cookie_stickiness_policy',
                         'dict_key': 'cookie_expiration_period',
-                        'param_value': self.stickiness['expiration']
+                        'param_value': expiration
                     }
                     policy.append(self._policy_name(policy_attrs['type']))
+
                     self._set_stickiness_policy(elb_info, listeners_dict, policy, **policy_attrs)
-                elif self.stickiness['enabled'] == False:
+                elif self.module.boolean(self.stickiness['enabled']) == False:
                     if len(elb_info.policies.lb_cookie_stickiness_policies):
                         if elb_info.policies.lb_cookie_stickiness_policies[0].policy_name == self._policy_name(policy_type):
                             self.changed = True
@@ -781,7 +785,7 @@ class ElbManager(object):
             elif self.stickiness['type'] == 'application':
                 policy = []
                 policy_type = 'AppCookieStickinessPolicyType'
-                if self.stickiness['enabled'] == True:
+                if self.module.boolean(self.stickiness['enabled']) == True:
 
                     if 'cookie' not in self.stickiness:
                         self.module.fail_json(msg='cookie must be set when type is application')
@@ -795,7 +799,7 @@ class ElbManager(object):
                     }
                     policy.append(self._policy_name(policy_attrs['type']))
                     self._set_stickiness_policy(elb_info, listeners_dict, policy, **policy_attrs)
-                elif self.stickiness['enabled'] == False:
+                elif self.module.boolean(self.stickiness['enabled']) == False:
                     if len(elb_info.policies.app_cookie_stickiness_policies):
                         if elb_info.policies.app_cookie_stickiness_policies[0].policy_name == self._policy_name(policy_type):
                             self.changed = True


### PR DESCRIPTION
Convert enabled value to boolean to actually work, make sure we can set expiration period to 0(None) to disable it
