### PR TITLE
Task to copy a file remotely

### DIFF
--- a/files/copy_remotely.py
+++ b/files/copy_remotely.py
@@ -1,0 +1,87 @@
+#!/usr/bin/python
+
+# -*- coding: utf-8 -*-
+
+# (c) 2015, Alexis Seigneurin <alexis@seigneurin.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import shutil
+
+DOCUMENTATION = '''
+---
+module: copy_remotely
+short_description: Copies a file from the remote server to the remote server.
+description:
+     - Copies a file but, unlike the M(file) module, the copy is performed on the
+       remote server.
+       The copy is only performed if the source and destination files are different
+       (different MD5 sums) or if the destination file does not exist.
+       The destination directory is created if missing.
+version_added: ""
+options:
+  src:
+    description:
+      - Path to the file to copy.
+    required: true
+    default: null
+  dest:
+    description:
+      - Path to the destination file.
+    required: true
+    default: null
+'''
+
+EXAMPLES = '''
+- copy_remotely: src=/tmp/foo.conf dest=/etc/foo.conf
+'''
+
+def main():
+      module = AnsibleModule(
+          argument_spec = dict(
+              src       = dict(required=True),
+              dest      = dict(required=True),
+          )
+      )
+
+      src = module.params['src']
+      dest = module.params['dest']
+
+      if not os.path.exists(src):
+          module.fail_json(msg="Source file not found: %s" % src)
+
+      src_md5 = module.md5(src)
+      dest_md5 = module.md5(dest)
+
+      changed = False
+
+      # create the target directory if missing
+      dest_dir = os.path.dirname(dest)
+      if not os.path.isdir(dest_dir):
+          os.makedirs(dest_dir)
+          changed = True
+
+      # copy the file if newer
+      if src_md5 != dest_md5:
+          shutil.copyfile(src, dest)
+          changed = True
+
+      module.exit_json(changed=changed, src_md5=src_md5, dest_md5=dest_md5)
+
+
+from ansible.module_utils.basic import *
+
+main()


### PR DESCRIPTION
I would like to submit this task that copies a file from the remote server to the remote server. This task differs from the "copy" task that copies a file from the local host to the remote server.

The copy is only performed if the MD5 sum of the file has changed, making this task idempotent, as opposed to executing the "cp" shell command.

Let me know if this makes sense or if there is a better alternative.
