### PR TITLE
Service module incorrectly handles lines not ending in a newline

### DIFF
--- a/system/service.py
+++ b/system/service.py
@@ -359,7 +359,7 @@ class Service(object):
                         self.changed = True
 
             # Add line to the list.
-            new_rc_conf.append(rcline)
+            new_rc_conf.append(rcline.strip() + '\n')
 
         # We are done with reading the current rc.conf, close it.
         RCFILE.close()


### PR DESCRIPTION
When using `service: name=sshd enabled=yes`, with an rc.conf that looks like

``` bash
syslogd_enable="NO"\n
sendmail_enable="NONE"\n
cron_enable="YES"
```

(new lines shown for clarity)

The service module results in:

``` bash
syslogd_enable="NO"\n
sendmail_enable="NONE"\n
cron_enable="YES"sshd_enable="YES"\n
```

This PR forces every line to end in a new line. With this in place, the new rc.conf is:

``` bash
syslogd_enable="NO"\n
sendmail_enable="NONE"\n
cron_enable="YES"\n
sshd_enable="YES"\n

```
