### PR TITLE
Return an iterable instead of None

### DIFF
--- a/cloud/amazon/ec2_metric_alarm.py
+++ b/cloud/amazon/ec2_metric_alarm.py
@@ -184,7 +184,7 @@ def create_metric_alarm(connection, module):
         comparisons = {'<=' : 'LessThanOrEqualToThreshold', '<' : 'LessThanThreshold', '>=' : 'GreaterThanOrEqualToThreshold', '>' : 'GreaterThanThreshold'}
         alarm.comparison = comparisons[comparison]
 
-        dim1 = module.params.get('dimensions')
+        dim1 = module.params.get('dimensions', {})
         dim2 = alarm.dimensions
 
         for keys in dim1:


### PR DESCRIPTION
By default `.get()` will return `None` on a key that doesn't exist. This
causes a `TypeError` in the `for` loop a few lines down. This change simply
returns an iterable type to avoid the error.

There is a weird case if the play has dimensions originally and then get removed in later runs, but I think that is a separate issue. This simply fixes the problem of the alarm not changing when no dimension is specified.

Ref: https://github.com/ansible/ansible-modules-core/issues/1611
