### PR TITLE
Bugfix for creating ec2_metric_alarm without specifying dimensions:

### DIFF
--- a/cloud/amazon/ec2_metric_alarm.py
+++ b/cloud/amazon/ec2_metric_alarm.py
@@ -184,8 +184,11 @@ def create_metric_alarm(connection, module):
         comparisons = {'<=' : 'LessThanOrEqualToThreshold', '<' : 'LessThanThreshold', '>=' : 'GreaterThanOrEqualToThreshold', '>' : 'GreaterThanThreshold'}
         alarm.comparison = comparisons[comparison]
 
-        dim1 = module.params.get('dimensions', {})
+        dim1 = module.params.get('dimensions')
         dim2 = alarm.dimensions
+        
+        if not dim1:
+         dim1 = {}
 
         for keys in dim1:
             if not isinstance(dim1[keys], list):

--- a/cloud/amazon/ec2_metric_alarm.py
+++ b/cloud/amazon/ec2_metric_alarm.py
@@ -188,7 +188,7 @@ def create_metric_alarm(connection, module):
         dim2 = alarm.dimensions
         
         if not dim1:
-         dim1 = {}
+            dim1 = {}
 
         for keys in dim1:
             if not isinstance(dim1[keys], list):


### PR DESCRIPTION
Adding {} to module.params.get does not work
