### PR TITLE
ec2_vol: Added missing "needs 2.0" doc

### DIFF
--- a/cloud/amazon/ec2_vol.py
+++ b/cloud/amazon/ec2_vol.py
@@ -146,6 +146,7 @@ EXAMPLES = '''
 # Example: Launch an instance and then add a volume if not already attached
 #   * Volume will be created with the given name if not already created.
 #   * Nothing will happen if the volume is already attached.
+#   * Requires Ansible 2.0
 
 - ec2:
     keypair: "{{ keypair }}"


### PR DESCRIPTION
The ability to find-or-create a volume was added in 2.0. Added note to
the example.
