### PR TITLE
Fix documentation of authorized_key.py

### DIFF
--- a/system/authorized_key.py
+++ b/system/authorized_key.py
@@ -109,7 +109,7 @@ EXAMPLES = '''
 # Using key_options:
 - authorized_key: user=charlie
                   key="{{ lookup('file', '/home/charlie/.ssh/id_rsa.pub') }}"
-                  key_options='no-port-forwarding,host="10.0.1.1"'
+                  key_options='no-port-forwarding,from="10.0.1.1"'
 
 # Set up authorized_keys exclusively with one key
 - authorized_key: user=root key=public_keys/doe-jane state=present


### PR DESCRIPTION
man for sshd http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man8/sshd.8?query=sshd
says there's no "host" option but "from".
