### PR TITLE
win_msi: document extra_args

### DIFF
--- a/windows/win_msi.py
+++ b/windows/win_msi.py
@@ -34,6 +34,10 @@ options:
         description:
             - File system path to the MSI file to install
         required: true
+    extra_args:
+        description:
+            - Additional arguments to pass to the msiexec.exe command
+        required: false
     state:
         description:
             - Whether the MSI file should be installed or uninstalled


### PR DESCRIPTION
The extra_args parameter was not documented. It's needed for installing some MSIs.
