### PR TITLE
Add support for selinux user when adding a new user

### DIFF
--- a/system/user.py
+++ b/system/user.py
@@ -52,7 +52,7 @@ options:
     seuser:
         required: false
         description:
-            - Optionally sets the seuser type (user_u).
+            - Optionally sets the seuser type (user_u) on selinux enabled systems.
     group:
         required: false
         description:

--- a/system/user.py
+++ b/system/user.py
@@ -49,6 +49,10 @@ options:
             - Optionally when used with the -u option, this option allows to
               change the user ID to a non-unique value.
         version_added: "1.1"
+    seuser:
+        required: false
+        description:
+            - Optionally sets the seuser type (user_u).
     group:
         required: false
         description:
@@ -254,6 +258,7 @@ class User(object):
         self.name       = module.params['name']
         self.uid        = module.params['uid']
         self.non_unique  = module.params['non_unique']
+        self.seuser     = module.params['seuser']
         self.group      = module.params['group']
         self.groups     = module.params['groups']
         self.comment    = module.params['comment']
@@ -321,6 +326,9 @@ class User(object):
             if self.non_unique:
                 cmd.append('-o')
 
+        if self.seuser is not None:
+            cmd.append('-Z')
+            cmd.append(self.seuser)
         if self.group is not None:
             if not self.group_exists(self.group):
                 self.module.fail_json(msg="Group %s does not exist" % self.group)
@@ -2050,6 +2058,8 @@ def main():
             shell=dict(default=None, type='str'),
             password=dict(default=None, type='str'),
             login_class=dict(default=None, type='str'),
+            # following options are specific to selinux
+            seuser=dict(default=None, type='str'),
             # following options are specific to userdel
             force=dict(default='no', type='bool'),
             remove=dict(default='no', type='bool'),


### PR DESCRIPTION
useradd modification, from man:
-Z, --selinux-user SEUSER
  The SELinux user for the user's login. The default is to leave this field blank, which causes the
  system to select the default SELinux user.

Add the param "seuser" to set the seuser-name when adding a new user for a system with support for selinux.
