### PR TITLE
Fix the acl module

### DIFF
--- a/files/acl.py
+++ b/files/acl.py
@@ -172,7 +172,7 @@ def build_command(module, mode, path, follow, default, recursive, entry=''):
         cmd.append('--recursive')
 
     if not follow:
-        cmd.append('-h')
+        cmd.append('--physical')
 
     if default:
         if(mode == 'rm'):

--- a/files/acl.py
+++ b/files/acl.py
@@ -127,12 +127,10 @@ def split_entry(entry):
     ''' splits entry and ensures normalized return'''
 
     a = entry.split(':')
-    a.reverse()
-    try:
-        p, e, t = a
-    except ValueError, e:
-        print "wtf?? %s => %s" % (entry, a)
-        raise e
+    if len(a) == 2:
+        a.append(None)
+
+    t, e, p = a
 
     if t.startswith("u"):
         t = "user"

--- a/files/acl.py
+++ b/files/acl.py
@@ -21,7 +21,7 @@ module: acl
 version_added: "1.4"
 short_description: Sets and retrieves file ACL information.
 description:
-     - Sets and retrieves file ACL information.
+    - Sets and retrieves file ACL information.
 notes:
     - As of Ansible 2.0, this module only supports Linux distributions.
 options:
@@ -122,6 +122,7 @@ acl:
     sample: [ "user::rwx", "group::rwx", "other::rwx" ]
 '''
 
+
 def split_entry(entry):
     ''' splits entry and ensures normalized return'''
 
@@ -161,7 +162,7 @@ def build_entry(etype, entity, permissions=None):
 
 
 def build_command(module, mode, path, follow, default, recursive, entry=''):
-    '''Builds and returns agetfacl/setfacl command.'''
+    '''Builds and returns a getfacl/setfacl command.'''
     if mode == 'set':
         cmd = [module.get_bin_path('setfacl', True)]
         cmd.append('-m "%s"' % entry)

--- a/files/acl.py
+++ b/files/acl.py
@@ -276,10 +276,10 @@ def main():
         if etype or entity or permissions:
             module.fail_json(msg="'entry' MUST NOT be set when 'entity', 'etype' or 'permissions' are set.")
 
-        if state == 'present' and entry.count(":") != 3:
+        if state == 'present' and entry.count(":") != 2:
             module.fail_json(msg="'entry' MUST have 3 sections divided by ':' when 'state=present'.")
 
-        if state == 'absent' and entry.count(":") != 2:
+        if state == 'absent' and entry.count(":") != 1:
             module.fail_json(msg="'entry' MUST have 2 sections divided by ':' when 'state=absent'.")
 
         default, etype, entity, permissions = split_entry(entry)

--- a/files/acl.py
+++ b/files/acl.py
@@ -275,6 +275,9 @@ def main():
         if state == 'absent' and entry.count(":") != 1:
             module.fail_json(msg="'entry' MUST have 2 sections divided by ':' when 'state=absent'.")
 
+        if state == 'query':
+            module.fail_json(msg="'entry' MUST NOT be set when 'state=query'.")
+
         etype, entity, permissions = split_entry(entry)
 
     changed = False

--- a/files/acl.py
+++ b/files/acl.py
@@ -128,16 +128,11 @@ def split_entry(entry):
 
     a = entry.split(':')
     a.reverse()
-    if len(a) == 3:
-        a.append(False)
     try:
-        p, e, t, d = a
+        p, e, t = a
     except ValueError, e:
         print "wtf?? %s => %s" % (entry, a)
         raise e
-
-    if d:
-        d = True
 
     if t.startswith("u"):
         t = "user"
@@ -150,7 +145,7 @@ def split_entry(entry):
     else:
         t = None
 
-    return [d, t, e, p]
+    return [t, e, p]
 
 
 def build_entry(etype, entity, permissions=None):
@@ -282,7 +277,7 @@ def main():
         if state == 'absent' and entry.count(":") != 1:
             module.fail_json(msg="'entry' MUST have 2 sections divided by ':' when 'state=absent'.")
 
-        default, etype, entity, permissions = split_entry(entry)
+        etype, entity, permissions = split_entry(entry)
 
     changed = False
     msg = ""

--- a/files/acl.py
+++ b/files/acl.py
@@ -199,8 +199,8 @@ def acl_changed(module, cmd):
 
     for line in lines:
         if not line.endswith('*,*'):
-            return False
-    return True
+            return True
+    return False
 
 
 def run_acl(module, cmd, check_rc=True):


### PR DESCRIPTION
While trying to re-BSD-ize the acl module, I have noticed that #150 shipped a few bugs :-(
- When testing the `setfacl` command to run, the wrong boolean was returned, making the command never run when it should... and run when it shouldn't!
- The check for the well-formedness of `entry` was wrong
- Removing an acl would have unexpected behavior when using `entry`

Other commits are here to support the 3 bug fixes above.

(Look at full commit messages for more info)
