### PR TITLE
Expose cache_parameter_group_name in elasticache module

### DIFF
--- a/cloud/amazon/elasticache.py
+++ b/cloud/amazon/elasticache.py
@@ -43,6 +43,11 @@ options:
       - The version number of the cache engine
     required: false
     default: none
+  cache_parameter_group_name:
+    description:
+        - The name of the cache parameter group to associate with this cache cluster. If this argument is omitted, the default cache parameter group for the specified engine will be used.
+    required: false
+    default: none
   node_type:
     description:
       - The compute and memory capacity of the nodes in the cache cluster
@@ -150,11 +155,12 @@ class ElastiCacheManager(object):
     def __init__(self, module, name, engine, cache_engine_version, node_type,
                  num_nodes, cache_port, cache_subnet_group,
                  cache_security_groups, security_group_ids, zone, wait,
-                 hard_modify, region, **aws_connect_kwargs):
+                 hard_modify, region, cache_parameter_group_name=None, **aws_connect_kwargs):
         self.module = module
         self.name = name
         self.engine = engine
         self.cache_engine_version = cache_engine_version
+        self.cache_parameter_group_name = cache_parameter_group_name
         self.node_type = node_type
         self.num_nodes = num_nodes
         self.cache_port = cache_port
@@ -214,6 +220,7 @@ class ElastiCacheManager(object):
                                                       cache_node_type=self.node_type,
                                                       engine=self.engine,
                                                       engine_version=self.cache_engine_version,
+                                                      cache_parameter_group_name=self.cache_parameter_group_name,
                                                       cache_security_group_names=self.cache_security_groups,
                                                       security_group_ids=self.security_group_ids,
                                                       cache_subnet_group_name=self.cache_subnet_group,
@@ -293,7 +300,8 @@ class ElastiCacheManager(object):
                                                   cache_security_group_names=self.cache_security_groups,
                                                   security_group_ids=self.security_group_ids,
                                                   apply_immediately=True,
-                                                  engine_version=self.cache_engine_version)
+                                                  engine_version=self.cache_engine_version,
+                                                  cache_parameter_group_name=self.cache_parameter_group_name)
         except boto.exception.BotoServerError, e:
             self.module.fail_json(msg=e.message)
 
@@ -478,6 +486,7 @@ def main():
             name={'required': True},
             engine={'required': False, 'default': 'memcached'},
             cache_engine_version={'required': False},
+            cache_parameter_group_name={'required': False},
             node_type={'required': False, 'default': 'cache.m1.small'},
             num_nodes={'required': False, 'default': None, 'type': 'int'},
             cache_port={'required': False, 'type': 'int'},
@@ -505,6 +514,7 @@ def main():
     state = module.params['state']
     engine = module.params['engine']
     cache_engine_version = module.params['cache_engine_version']
+    cache_parameter_group_name = module.params['cache_parameter_group_name']
     node_type = module.params['node_type']
     num_nodes = module.params['num_nodes']
     cache_port = module.params['cache_port']
@@ -530,12 +540,15 @@ def main():
         module.fail_json(msg=str("Either region or AWS_REGION or EC2_REGION environment variable or boto config aws_region or ec2_region must be set."))
 
     elasticache_manager = ElastiCacheManager(module, name, engine,
-                                             cache_engine_version, node_type,
+                                             cache_engine_version,
+                                             node_type,
                                              num_nodes, cache_port,
                                              cache_subnet_group,
                                              cache_security_groups,
                                              security_group_ids, zone, wait,
-                                             hard_modify, region, **aws_connect_kwargs)
+                                             hard_modify, region,
+                                             cache_parameter_group_name=cache_parameter_group_name,
+                                             **aws_connect_kwargs)
 
     if state == 'present':
         elasticache_manager.ensure_present()


### PR DESCRIPTION
The cache_parameter_group_name was not previously exposed in
elasticachy.py, I have exposed it, as optional.
