### PR TITLE
Don't fail in authorized_key check_mode if user exists

### DIFF
--- a/system/authorized_key.py
+++ b/system/authorized_key.py
@@ -169,16 +169,15 @@ def keyfile(module, user, write=False, path=None, manage_dir=True):
     :return: full path string to authorized_keys for user
     """
 
-    if module.check_mode:
-        if path is None:
-            module.fail_json(msg="You must provide full path to key file in check mode")
-        else:
-            keysfile = path
-            return keysfile
+    if module.check_mode and path is not None:
+        keysfile = path
+        return keysfile
 
     try:
         user_entry = pwd.getpwnam(user)
     except KeyError, e:
+        if module.check_mode and path is None:
+            module.fail_json(msg="Either user must exist or you must provide full path to key file in check mode")
         module.fail_json(msg="Failed to lookup user %s: %s" % (user, str(e)))
     if path is None:
         homedir    = user_entry.pw_dir


### PR DESCRIPTION
PR #1651 fixed issue #1515 but the requirement for path to be defined is unnecessarily strict, and breaks existing usage of check_mode where a user and key already exists.

If the user has previously been created a path isn't necessary.
