### PR TITLE
added windows facts ansible_lastboot, ansible_uptime_seconds

### DIFF
--- a/windows/setup.ps1
+++ b/windows/setup.ps1
@@ -25,7 +25,7 @@ $result = New-Object psobject @{
     changed = $false
 };
 
-$win32_os = Get-WmiObject Win32_OperatingSystem
+$win32_os = Get-CimInstance Win32_OperatingSystem
 $osversion = [Environment]::OSVersion
 $memory = @()
 $memory += Get-WmiObject win32_Physicalmemory
@@ -65,6 +65,9 @@ Set-Attr $result.ansible_facts "ansible_distribution" $osversion.VersionString
 Set-Attr $result.ansible_facts "ansible_distribution_version" $osversion.Version.ToString()
 
 Set-Attr $result.ansible_facts "ansible_totalmem" $capacity
+
+Set-Attr $result.ansible_facts "ansible_lastboot" $win32_os.lastbootuptime.ToString("u")
+Set-Attr $result.ansible_facts "ansible_uptime_seconds" $([System.Convert]::ToInt64($(Get-Date).Subtract($win32_os.lastbootuptime).TotalSeconds))
 
 $ips = @()
 Foreach ($ip in $netcfg.IPAddress) { If ($ip) { $ips += $ip } }


### PR DESCRIPTION
switched OS object to Get-CimInstance since we need a DateTime object for lastbootuptime
