### PR TITLE
No need for .keys on volumes list

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -1020,7 +1020,7 @@ class DockerManager(object):
 
             expected_volume_keys = set((image['ContainerConfig']['Volumes'] or {}).keys())
             if self.volumes:
-                expected_volume_keys.update(self.volumes.keys())
+                expected_volume_keys.update(self.volumes)
 
             actual_volume_keys = set((container['Config']['Volumes'] or {}).keys())
 


### PR DESCRIPTION
Since https://github.com/ansible/ansible-modules-core/commit/c3f92cca210db1f7042bfce1ff90645255f0b49e changed "volumes" to be a list instead of a dictionary, we don't need (and cannot) use .keys on volumes when appending to set.
Reported as bug https://github.com/ansible/ansible-modules-core/issues/1957
