### PR TITLE
apt: check for "0 upgraded" to be at the beginning of the line

### DIFF
--- a/packaging/os/apt.py
+++ b/packaging/os/apt.py
@@ -179,8 +179,8 @@ APT_ENV_VARS = dict(
 )
 
 DPKG_OPTIONS = 'force-confdef,force-confold'
-APT_GET_ZERO = "0 upgraded, 0 newly installed"
-APTITUDE_ZERO = "0 packages upgraded, 0 newly installed"
+APT_GET_ZERO = "\n0 upgraded, 0 newly installed"
+APTITUDE_ZERO = "\n0 packages upgraded, 0 newly installed"
 APT_LISTS_PATH = "/var/lib/apt/lists"
 APT_UPDATE_SUCCESS_STAMP_PATH = "/var/lib/apt/periodic/update-success-stamp"
 


### PR DESCRIPTION
Fixes #1678.

Tested manually: I checked that `apt: upgrade=dist` reports `"changed": false` when nothing needs to be upgraded.

I wanted to add a unit test, but didn't, because I couldn't find any existing tests for the upgrade action of the apt module.
