### PR TITLE
Docker module: restarted should update the container when necessary

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -1586,6 +1586,10 @@ def restarted(manager, containers, count, name):
 
     containers.refresh()
 
+    for container in manager.get_differing_containers():
+        manager.stop_containers([container])
+        manager.remove_containers([container])
+
     manager.restart_containers(containers.running)
     started(manager, containers, count, name)
 


### PR DESCRIPTION
The docker module documentation states the following:

"reloaded" (added in Ansible 1.9) asserts that all matching containers are running and restarts any that have any images or configuration out of date. "restarted" unconditionally restarts (or starts) the matching containers

From this, I understand that:
- with pull=always and state=reloaded, ansible will update and restart a container if there is a new version or configuration avaialble, and do nothing otherwise.
- with pull=always and state=restarted, ansible will update the container if there is a new version of that container, and always restart it, even if there are no changes in the docker container or config.

Actual behaviour is that state=restarted will restart the container but never update it if there is a new version, even if pull=always is set.
