### PR TITLE
Add HTTP Proxy options for win_get_url module

### DIFF
--- a/windows/win_get_url.ps1
+++ b/windows/win_get_url.ps1
@@ -44,6 +44,15 @@ $force = Get-Attr -obj $params -name "force" "yes" | ConvertTo-Bool
 
 If ($force -or -not (Test-Path $dest)) {
     $client = New-Object System.Net.WebClient
+    if($params.proxy_url) {
+        $proxy_url = $params.proxy_url
+        $user = $params.user
+        $pass = $params.pass
+        $proxy_server = New-Object System.Net.WebProxy($proxy_url, $true)
+        $credential = New-Object System.Net.NetworkCredential($user, $pass)
+        $proxy_server.Credentials = $credential
+        $client.Proxy = $proxy_server
+    }
 
     Try {
         $client.DownloadFile($url, $dest)

--- a/windows/win_get_url.ps1
+++ b/windows/win_get_url.ps1
@@ -46,10 +46,10 @@ If ($force -or -not (Test-Path $dest)) {
     $client = New-Object System.Net.WebClient
     if($params.proxy_url) {
         $proxy_url = $params.proxy_url
-        $user = $params.user
-        $pass = $params.pass
+        $proxy_username = $params.proxy_username
+        $proxy_password = $params.proxy_password
         $proxy_server = New-Object System.Net.WebProxy($proxy_url, $true)
-        $credential = New-Object System.Net.NetworkCredential($user, $pass)
+        $credential = New-Object System.Net.NetworkCredential($proxy_username, $proxy_password)
         $proxy_server.Credentials = $credential
         $client.Proxy = $proxy_server
     }

--- a/windows/win_get_url.ps1
+++ b/windows/win_get_url.ps1
@@ -44,6 +44,10 @@ $skip_certificate_validation = Get-Attr $params "skip_certificate_validation" $f
 $username = Get-Attr $params "username"
 $password = Get-Attr $params "password"
 
+$proxy_url = $params.proxy_url
+$proxy_username = $params.proxy_username
+$proxy_password = $params.proxy_password
+
 if($skip_certificate_validation){
   [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}
 }
@@ -53,15 +57,12 @@ $force = Get-Attr -obj $params -name "force" "yes" | ConvertTo-Bool
 If ($force -or -not (Test-Path $dest)) {
     $client = New-Object System.Net.WebClient
 
-    if($params.proxy_url) {
-        $proxy_url = $params.proxy_url
-        if($proxy_username -and $proxy_passworda){
-            $proxy_username = $params.proxy_username
-            $proxy_password = $params.proxy_password
+    if($proxy_url){
+        $proxy_server = New-Object System.Net.WebProxy($proxy_url, $true)
+        if($proxy_username -and $proxy_password){
             $proxy_credential = New-Object System.Net.NetworkCredential($proxy_username, $proxy_password)
             $proxy_server.Credentials = $proxy_credential
         }
-        $proxy_server = New-Object System.Net.WebProxy($proxy_url, $true)
         $client.Proxy = $proxy_server
     }
 

--- a/windows/win_get_url.py
+++ b/windows/win_get_url.py
@@ -65,6 +65,27 @@ options:
       - Skip SSL certificate validation if true
     required: false
     default: false
+  proxy_url:
+    description:
+      - The full URL of the proxy server a file to download through it.
+    version_added: "2.0"
+    required: false
+    choices: null
+    default: null
+  proxy_username:
+    description:
+      - Name of the user for authorization of the proxy server.
+    version_added: "2.0"
+    required: false
+    choices: null
+    default: null
+  proxy_password:
+    description:
+      - Password of the user for authorization of the proxy server.
+    version_added: "2.0"
+    required: false
+    choices: null
+    default: null
 '''
 
 EXAMPLES = '''
@@ -83,4 +104,12 @@ $ ansible -i hosts -c winrm -m win_get_url -a "url=http://www.example.com/earthr
     url: 'http://www.example.com/earthrise.jpg'
     dest: 'C:\Users\RandomUser\earthrise.jpg'
     force: no
+
+- name: Download earthrise.jpg to 'C:\Users\RandomUser\earthrise.jpg' through the proxy server.
+  win_get_url:
+    url: 'http://www.example.com/earthrise.jpg'
+    dest: 'C:\Users\RandomUser\earthrise.jpg'
+    proxy_url: 'http://10.0.0.1:8080'
+    proxy_username: 'username'
+    proxy_password: 'password'
 '''

--- a/windows/win_get_url.py
+++ b/windows/win_get_url.py
@@ -56,14 +56,14 @@ options:
     required: false
     choices: null
     default: null
-  user:
+  proxy_username:
     description:
       - Name of the user for authorization of the proxy server.
     version_added: "2.0"
     required: false
     choices: null
     default: null
-  pass:
+  proxy_password:
     description:
       - Password of the user for authorization of the proxy server.
     version_added: "2.0"

--- a/windows/win_get_url.py
+++ b/windows/win_get_url.py
@@ -49,7 +49,30 @@ options:
     required: false
     choices: [ "yes", "no" ]
     default: yes
-author: "Paul Durivage (@angstwad)"
+  proxy_url:
+    description:
+      - The full URL of the proxy server a file to download through it.
+    version_added: "2.0"
+    required: false
+    choices: null
+    default: null
+  user:
+    description:
+      - Name of the user for authorization of the proxy server.
+    version_added: "2.0"
+    required: false
+    choices: null
+    default: null
+  pass:
+    description:
+      - Password of the user for authorization of the proxy server.
+    version_added: "2.0"
+    required: false
+    choices: null
+    default: null
+author:
+    - "Paul Durivage (@angstwad)"
+    - "Takeshi Kuramochi (tksarah)"
 '''
 
 EXAMPLES = '''
@@ -68,4 +91,12 @@ $ ansible -i hosts -c winrm -m win_get_url -a "url=http://www.example.com/earthr
     url: 'http://www.example.com/earthrise.jpg'
     dest: 'C:\Users\RandomUser\earthrise.jpg'
     force: no
+
+- name: Download earthrise.jpg to 'C:\Users\RandomUser\earthrise.jpg' through the proxy server.
+  win_get_url:
+    url: 'http://www.example.com/earthrise.jpg'
+    dest: 'C:\Users\RandomUser\earthrise.jpg'
+    proxy_url: 'http://10.0.0.1:8080'
+    user: 'username'
+    pass: 'password'
 '''

--- a/windows/win_get_url.py
+++ b/windows/win_get_url.py
@@ -97,6 +97,6 @@ $ ansible -i hosts -c winrm -m win_get_url -a "url=http://www.example.com/earthr
     url: 'http://www.example.com/earthrise.jpg'
     dest: 'C:\Users\RandomUser\earthrise.jpg'
     proxy_url: 'http://10.0.0.1:8080'
-    user: 'username'
-    pass: 'password'
+    proxy_username: 'username'
+    proxy_password: 'password'
 '''


### PR DESCRIPTION
I think that some enterprise user make have an authentication http proxy when they use win_get_url module. If this module has parameter for these , I think It is useful. I modified to add 'proxy_url' , 'user' and 'pass' options.

```
win_get_url:
  url: 'https://example.com/download-file.jpg'
  proxy_url: 'http://10.0.0.1:8080'
  user: 'username'
  pass: 'password'
  dest: '/tmp/download-file.jpg'
```
