### PR TITLE
Add hostname support for Kali linux 2.0

### DIFF
--- a/system/hostname.py
+++ b/system/hostname.py
@@ -491,6 +491,11 @@ class DebianHostname(Hostname):
     distribution = 'Debian'
     strategy_class = DebianStrategy
 
+class KaliHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Kali'
+    strategy_class = DebianStrategy
+
 class UbuntuHostname(Hostname):
     platform = 'Linux'
     distribution = 'Ubuntu'


### PR DESCRIPTION
This patch allows the hostname module to detect and set the hostname for a
Kali Linux 2.0 installation. Without this patch, the hostname module raises
the following error

```
 hostname module cannot be used on platform Linux (Kali)
```

Kali is based off of Debian.

ansible version: 1.9.1
