### PR TITLE
authorized_key: fix example in documentation

### DIFF
--- a/system/authorized_key.py
+++ b/system/authorized_key.py
@@ -112,8 +112,10 @@ EXAMPLES = '''
                   key_options='no-port-forwarding,from="10.0.1.1"'
 
 # Set up authorized_keys exclusively with one key
-- authorized_key: user=root key=public_keys/doe-jane state=present
+- authorized_key: user=root key="{{ item }}" state=present
                    exclusive=yes
+  with_file:
+    - public_keys/doe-jane
 '''
 
 # Makes sure the public key line is present or absent in the user's .ssh/authorized_keys.


### PR DESCRIPTION
'key=' cannot be pointing to a file name; it needs to be the key itself as a string (or a URL).
