### PR TITLE
os/apt.py: Add support for passing --allow-unauthenticated

### DIFF
--- a/packaging/os/apt.py
+++ b/packaging/os/apt.py
@@ -73,6 +73,12 @@ options:
     required: false
     default: "no"
     choices: [ "yes", "no" ]
+  allow_unauthenticated:
+    description:
+      - Ignore if packages cannot be authenticated. This is useful for bootstrapping environments that manage their own apt-key setup.
+    required: false
+    default: "no"
+    choices: [ "yes", "no" ]
   upgrade:
     description:
       - 'If yes or safe, performs an aptitude safe-upgrade.'
@@ -362,7 +368,8 @@ def expand_pkgspec_from_fnmatches(m, pkgspec, cache):
 def install(m, pkgspec, cache, upgrade=False, default_release=None,
             install_recommends=None, force=False,
             dpkg_options=expand_dpkg_options(DPKG_OPTIONS),
-            build_dep=False, autoremove=False, only_upgrade=False):
+            build_dep=False, autoremove=False, only_upgrade=False,
+            allow_unauthenticated=False):
     pkg_list = []
     packages = ""
     pkgspec = expand_pkgspec_from_fnmatches(m, pkgspec, cache)
@@ -420,6 +427,9 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
             cmd += " -o APT::Install-Recommends=yes"
         # install_recommends is None uses the OS default
 
+        if allow_unauthenticated:
+            cmd += " --allow-unauthenticated"
+
         rc, out, err = m.run_command(cmd)
         if rc:
             return (False, dict(msg="'%s' failed: %s" % (cmd, err), stdout=out, stderr=err))
@@ -428,7 +438,7 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
     else:
         return (True, dict(changed=False))
 
-def install_deb(m, debs, cache, force, install_recommends, dpkg_options):
+def install_deb(m, debs, cache, force, install_recommends, allow_unauthenticated, dpkg_options):
     changed=False
     deps_to_install = []
     pkgs_to_install = []
@@ -583,7 +593,8 @@ def main():
             upgrade = dict(choices=['no', 'yes', 'safe', 'full', 'dist']),
             dpkg_options = dict(default=DPKG_OPTIONS),
             autoremove = dict(type='bool', default=False, aliases=['autoclean']),
-            only_upgrade = dict(type='bool', default=False)
+            only_upgrade = dict(type='bool', default=False),
+            allow_unauthenticated = dict(default='no', aliases=['allow-unauthenticated'], type='bool'),
         ),
         mutually_exclusive = [['package', 'upgrade', 'deb']],
         required_one_of = [['package', 'upgrade', 'update_cache', 'deb']],
@@ -621,6 +632,7 @@ def main():
     updated_cache = False
     updated_cache_time = 0
     install_recommends = p['install_recommends']
+    allow_unauthenticated = p['allow_unauthenticated']
     dpkg_options = expand_dpkg_options(p['dpkg_options'])
     autoremove = p['autoremove']
 
@@ -684,6 +696,7 @@ def main():
                 module.fail_json(msg="deb only supports state=present")
             install_deb(module, p['deb'], cache,
                         install_recommends=install_recommends,
+                        allow_unauthenticated=allow_unauthenticated,
                         force=force_yes, dpkg_options=p['dpkg_options'])
 
         packages = p['package']
@@ -706,7 +719,8 @@ def main():
                     install_recommends=install_recommends,
                     force=force_yes, dpkg_options=dpkg_options,
                     build_dep=state_builddep, autoremove=autoremove,
-                    only_upgrade=p['only_upgrade'])
+                    only_upgrade=p['only_upgrade'],
+                    allow_unauthenticated=allow_unauthenticated)
             (success, retvals) = result
             retvals['cache_updated']=updated_cache
             retvals['cache_update_time']=updated_cache_time


### PR DESCRIPTION
This is useful for packages that bootstrap their own apt-key setup - only
the initial installation will require overriding. Notable examples are the
Dropbox and Google Chrome packages.

(Setting force=yes is far too strong: I only want to bypass
authentication!)

Signed-off-by: Chris Lamb chris@chris-lamb.co.uk
