### PR TITLE
New version of ec2_elb module supporting multi instances

### DIFF
--- a/cloud/amazon/ec2_elb.py
+++ b/cloud/amazon/ec2_elb.py
@@ -19,22 +19,22 @@ DOCUMENTATION = """
 module: ec2_elb
 short_description: De-registers or registers instances from EC2 ELBs
 description:
-  - This module de-registers or registers an AWS EC2 instance from the ELBs
+  - This module de-registers or registers an AWS EC2 instance(s) from the ELBs
     that it belongs to.
-  - Returns fact "ec2_elbs" which is a list of elbs attached to the instance
+  - Returns fact "ec2_elbs" which is a list of elbs attached to the instance(s)
     if state=absent is passed as an argument.
   - Will be marked changed when called only if there are ELBs found to operate on.
 version_added: "1.2"
-author: "John Jarvis (@jarv)"
+author: John Jarvis
 options:
   state:
     description:
-      - register or deregister the instance
+      - register or deregister the instance(s)
     required: true
     choices: ['present', 'absent']
-  instance_id:
+  instance_ids:
     description:
-      - EC2 Instance ID
+      - list of EC2 Instance ID (alias of instance_id)
     required: true
   ec2_elbs:
     description:
@@ -48,14 +48,14 @@ options:
     aliases: ['aws_region', 'ec2_region']
   enable_availability_zone:
     description:
-      - Whether to enable the availability zone of the instance on the target ELB if the availability zone has not already
+      - Whether to enable the availability zone of the instance(s) on the target ELB if the availability zone has not already
         been enabled. If set to no, the task will fail if the availability zone is not enabled on the ELB.
     required: false
     default: yes
     choices: [ "yes", "no" ]
   wait:
     description:
-      - Wait for instance registration or deregistration to complete successfully before returning.  
+      - Wait for instance(s) registration or deregistration to complete successfully before returning.  
     required: false
     default: yes
     choices: [ "yes", "no" ] 
@@ -69,7 +69,7 @@ options:
     version_added: "1.5"
   wait_timeout:
     description:
-      - Number of seconds to wait for an instance to change state. If 0 then this module may return an error if a transient error occurs. If non-zero then any transient errors are ignored until the timeout is reached. Ignored when wait=no.
+      - Number of seconds to wait for an instance(s) to change state. If 0 then this module may return an error if a transient error occurs. If non-zero then any transient errors are ignored until the timeout is reached. Ignored when wait=no.
     required: false
     default: 0
     version_added: "1.6"
@@ -98,69 +98,87 @@ post_tasks:
     with_items: ec2_elbs
 """
 
+RETURN = '''
+ansible_facts:
+    description: a dict with the key "ec2_elbs" with as value the list names of lb managed.
+    returned: success
+    type: dict
+    sample: "ec2_elbs": ["lb-name1", "lb-name2", "lb-name3"]}
+elb_changed:
+    description: a dict with lb name has key and for each name the list of instance_id updated.
+    returned: success
+    type: dict
+    sample: { "lb-name1": ["i-12345678","i-34567890"], "lb-name2": [], "lb-name3": ["i-12345678"] }
+wait_attempt:
+    description: a dict with lb name has key and for each name the number of attempt to have expected state for all these instances. Make sense only with wait true. 
+    returned: success
+    type: dict
+    sample: { "lb-name1": 4, "lb-name2": 0, "lb-name3": 1 }
+'''
+
 import time
+import sys
+import os
+import copy
 
 try:
     import boto
     import boto.ec2
-    import boto.ec2.autoscale
     import boto.ec2.elb
     from boto.regioninfo import RegionInfo
-    HAS_BOTO = True
 except ImportError:
-    HAS_BOTO = False
-
+    print "failed=True msg='boto required for this module'"
+    sys.exit(1)
 
 class ElbManager:
     """Handles EC2 instance ELB registration and de-registration"""
 
-    def __init__(self, module, instance_id=None, ec2_elbs=None,
+    def __init__(self, module, instance_ids=[], ec2_elbs=None,
                  region=None, **aws_connect_params):
         self.module = module
-        self.instance_id = instance_id
+        self.instance_ids = instance_ids
         self.region = region
         self.aws_connect_params = aws_connect_params
         self.lbs = self._get_instance_lbs(ec2_elbs)
         self.changed = False
+        self.elb_changed = dict()
+        self.wait_attempt = dict()
 
     def deregister(self, wait, timeout):
         """De-register the instance from all ELBs and wait for the ELB
         to report it out-of-service"""
 
+
+        initial_states = dict()
         for lb in self.lbs:
-            initial_state = self._get_instance_health(lb) 
-            if initial_state is None:
-                # Instance isn't registered with this load
-                # balancer. Ignore it and try the next one.
-                continue
+            initial_states[lb.name] = self._get_instance_health(lb) 
+            lb.deregister_instances(self.instance_ids)
 
-            lb.deregister_instances([self.instance_id])
-
-            # The ELB is changing state in some way. Either an instance that's
-            # InService is moving to OutOfService, or an instance that's
-            # already OutOfService is being deregistered.
-            self.changed = True
-
-            if wait:
-                self._await_elb_instance_state(lb, 'OutOfService', initial_state, timeout)
+        if wait:
+            for lb in self.lbs:
+                self._await_elb_instance_state(lb, 'OutOfService', initial_states[lb.name], timeout)
+        else:
+            # We cannot assume no change was made if we don't wait
+            # to find out
+            self.changed = True                
 
     def register(self, wait, enable_availability_zone, timeout):
         """Register the instance for all ELBs and wait for the ELB
         to report the instance in-service"""
+        
+        initial_states = dict()
         for lb in self.lbs:
-            initial_state = self._get_instance_health(lb)
-
+            initial_states[lb.name] = self._get_instance_health(lb)            
             if enable_availability_zone:
-                self._enable_availailability_zone(lb)
-
-            lb.register_instances([self.instance_id])
-
-            if wait:
-                self._await_elb_instance_state(lb, 'InService', initial_state, timeout)
-            else:
-                # We cannot assume no change was made if we don't wait
-                # to find out
-                self.changed = True
+                self._enable_availailability_zone(lb)            
+            lb.register_instances(self.instance_ids)            
+        if wait:
+            for lb in self.lbs:
+                self._await_elb_instance_state(lb, 'InService', initial_states[lb.name], timeout)
+        else:
+            # We cannot assume no change was made if we don't wait
+            # to find out
+            self.changed = True
 
     def exists(self, lbtest):
         """ Verify that the named ELB actually exists """
@@ -176,64 +194,53 @@ class ElbManager:
         """Enable the current instance's availability zone in the provided lb.
         Returns True if the zone was enabled or False if no change was made.
         lb: load balancer"""
-        instance = self._get_instance()
-        if instance.placement in lb.availability_zones:
-            return False
-
-        lb.enable_zones(zones=instance.placement)
+        instances = self._get_instance()
+        for instance in instances:
+            if instance.placement in lb.availability_zones:
+                return False
+            lb.enable_zones(zones=instance.placement)
 
         # If successful, the new zone will have been added to
         # lb.availability_zones
-        return instance.placement in lb.availability_zones
+        return True
+#         return instance.placement in lb.availability_zones
 
-    def _await_elb_instance_state(self, lb, awaited_state, initial_state, timeout):
+    def _await_elb_instance_state(self, lb, awaited_state, initial_states, timeout):
         """Wait for an ELB to change state
         lb: load balancer
         awaited_state : state to poll for (string)"""
 
-        wait_timeout = time.time() + timeout
+        self.elb_changed[lb.name] = []
+        self.wait_attempt[lb.name] = 0
+        max_time = time.time() + timeout
         while True:
-            instance_state = self._get_instance_health(lb)
+            instance_states = self._get_instance_health(lb)
+            instances_not_ok = copy.deepcopy(self.instance_ids) 
+            for instance_id,instance_state in instance_states.iteritems():
+                if instance_state.state == awaited_state:
+                    instances_not_ok.remove(instance_id)                    
+                    # Check the current state against the initial state, and only set
+                    # changed if they are different.
+                    if instance_state.state != initial_states[instance_id].state:
+                        self.changed = True
+                        self.elb_changed[lb.name].append(instance_id)
 
-            if not instance_state:
-                msg = ("The instance %s could not be put in service on %s."
-                       " Reason: Invalid Instance")
-                self.module.fail_json(msg=msg % (self.instance_id, lb))
-
-            if instance_state.state == awaited_state:
-                # Check the current state against the initial state, and only set
-                # changed if they are different.
-                if (initial_state is None) or (instance_state.state != initial_state.state):
-                    self.changed = True
+            if len(instances_not_ok) == 0:
                 break
-            elif self._is_instance_state_pending(instance_state):
-                # If it's pending, we'll skip further checks andd continue waiting
-                pass
-            elif (awaited_state == 'InService'
-                  and instance_state.reason_code == "Instance"
-                  and time.time() >= wait_timeout):
-                # If the reason_code for the instance being out of service is
-                # "Instance" this indicates a failure state, e.g. the instance
-                # has failed a health check or the ELB does not have the
-                # instance's availabilty zone enabled. The exact reason why is
-                # described in InstantState.description.
-                msg = ("The instance %s could not be put in service on %s."
-                       " Reason: %s")
-                self.module.fail_json(msg=msg % (self.instance_id,
-                                                 lb,
-                                                 instance_state.description))
-            time.sleep(1)
+            
+            if time.time() >= max_time:
+                msg = "Timeout exceeded when waiting states instances of LB {0}".format(
+                    lb.name
+                )
+                self.module.fail_json(
+                    msg=msg,
+                    wait_attempt=self.wait_attempt
+                )
+            
+            self.wait_attempt[lb.name] = self.wait_attempt[lb.name] + 1
+            # min healthcheck interval
+            time.sleep(5)
 
-    def _is_instance_state_pending(self, instance_state):
-        """
-        Determines whether the instance_state is "pending", meaning there is
-        an operation under way to bring it in service.
-        """
-        # This is messy, because AWS provides no way to distinguish between
-        # an instance that is is OutOfService because it's pending vs. OutOfService
-        # because it's failing health checks. So we're forced to analyze the
-        # description, which is likely to be brittle.
-        return (instance_state and 'pending' in instance_state.description)
 
     def _get_instance_health(self, lb):
         """
@@ -241,22 +248,21 @@ class ElbManager:
         certain error conditions.
         """
         try:
-            status = lb.get_instance_health([self.instance_id])[0]
+            instancestate_list = lb.get_instance_health(self.instance_ids)
+            instance_states = dict(
+                 (instance_state.instance_id,instance_state)
+                 for instance_state in instancestate_list  
+            )
         except boto.exception.BotoServerError, e:
             if e.error_code == 'InvalidInstance':
-                return None
-            else:
-                raise
-        return status
+                self.module.fail_json(msg=str(e))
+        return instance_states
 
     def _get_instance_lbs(self, ec2_elbs=None):
-        """Returns a list of ELBs attached to self.instance_id
+        """Returns a list of ELBs attached to self.instance_ids
         ec2_elbs: an optional list of elb names that will be used
                   for elb lookup instead of returning what elbs
-                  are attached to self.instance_id"""
-
-        if not ec2_elbs:
-           ec2_elbs = self._get_auto_scaling_group_lbs()
+                  are attached to self.instance_ids"""
 
         try:
             elb = connect_to_aws(boto.ec2.elb, self.region, 
@@ -270,66 +276,45 @@ class ElbManager:
             lbs = sorted(lb for lb in elbs if lb.name in ec2_elbs)
         else:
             lbs = []
+            
+            instances_searched = Set(self.instance_ids)
             for lb in elbs:
-                for info in lb.instances:
-                    if self.instance_id == info.id:
-                        lbs.append(lb)
+                
+                instances_lb = Set([
+                    info.id
+                    for info in lb.instances
+                ])
+                if instances_searched.issubset(instances_lb):
+                    lbs.append(lb)
+
         return lbs
 
-    def _get_auto_scaling_group_lbs(self):
-        """Returns a list of ELBs associated with self.instance_id
-           indirectly through its auto scaling group membership"""
-
-        try:
-           asg = connect_to_aws(boto.ec2.autoscale, self.region, **self.aws_connect_params)
-        except (boto.exception.NoAuthHandlerFound, StandardError), e:
-            self.module.fail_json(msg=str(e))
-
-        asg_instances = asg.get_all_autoscaling_instances([self.instance_id])
-        if len(asg_instances) > 1:
-           self.module.fail_json(msg="Illegal state, expected one auto scaling group instance.")
-
-        if not asg_instances:
-           asg_elbs = []
-        else:
-           asg_name = asg_instances[0].group_name
-
-           asgs = asg.get_all_groups([asg_name])
-           if len(asg_instances) != 1:
-              self.module.fail_json(msg="Illegal state, expected one auto scaling group.")
-
-           asg_elbs = asgs[0].load_balancers
-
-        return asg_elbs
-
     def _get_instance(self):
-        """Returns a boto.ec2.InstanceObject for self.instance_id"""
+        """Returns a boto.ec2.InstanceObject for self.instance_ids"""
         try:
             ec2 = connect_to_aws(boto.ec2, self.region, 
                                  **self.aws_connect_params)
         except (boto.exception.NoAuthHandlerFound, StandardError), e:
             self.module.fail_json(msg=str(e))
-        return ec2.get_only_instances(instance_ids=[self.instance_id])[0]
+        only_instances = ec2.get_only_instances(instance_ids=self.instance_ids)
+        return only_instances
 
 
 def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
             state={'required': True},
-            instance_id={'required': True},
+            instance_ids={'required': True, 'type':'list', 'aliases':["instance_id"] },
             ec2_elbs={'default': None, 'required': False, 'type':'list'},
             enable_availability_zone={'default': True, 'required': False, 'type': 'bool'},
             wait={'required': False, 'default': True, 'type': 'bool'},
-            wait_timeout={'requred': False, 'default': 0, 'type': 'int'}
+            wait_timeout={'required': False, 'default': 0, 'type': 'int'}
         )
     )
 
     module = AnsibleModule(
         argument_spec=argument_spec,
     )
-
-    if not HAS_BOTO:
-        module.fail_json(msg='boto required for this module')
 
     region, ec2_url, aws_connect_params = get_aws_connection_info(module)
 
@@ -344,8 +329,9 @@ def main():
     if module.params['state'] == 'present' and 'ec2_elbs' not in module.params:
         module.fail_json(msg="ELBs are required for registration")
 
-    instance_id = module.params['instance_id']
-    elb_man = ElbManager(module, instance_id, ec2_elbs, 
+    instance_ids = module.params['instance_ids']
+    
+    elb_man = ElbManager(module, instance_ids, ec2_elbs, 
                          region=region, **aws_connect_params)
 
     if ec2_elbs is not None:
@@ -360,7 +346,12 @@ def main():
         elb_man.deregister(wait, timeout)
 
     ansible_facts = {'ec2_elbs': [lb.name for lb in elb_man.lbs]}
-    ec2_facts_result = dict(changed=elb_man.changed, ansible_facts=ansible_facts)
+    ec2_facts_result = dict(
+        changed=elb_man.changed,
+        elb_changed=elb_man.elb_changed,
+        ansible_facts=ansible_facts,
+        wait_attempt=elb_man.wait_attempt,
+    )
 
     module.exit_json(**ec2_facts_result)
 


### PR DESCRIPTION
- Change way to wait. Instead of looping on each ELB to register or deregister it, we try to register/deregister them all at once and then wait for all to be in the wanted state => Optimise time to wait
- Increase waiting time between 2 retries with minimal healthcheck interval (5s), to avoid reaching "Exceeded rate limit" message in EC2 API. Could be optimized by taking the healthcheck interval value of the LB.
- Add new parameter "instances" aliasing "instance" for compatibility with previous version.
- Add new returned values and add documentation on it
- Behaviour for _enable_availailability_zone method in multi instances mode has not been tested
