### PR TITLE
Fix indentation in os_server documentation

### DIFF
--- a/cloud/openstack/os_server.py
+++ b/cloud/openstack/os_server.py
@@ -137,7 +137,7 @@ options:
         - Boot instance from a volume
      required: false
      default: None
-     terminate_volume:
+   terminate_volume:
      description:
         - If true, delete volume when deleting instance (if booted from volume)
      default: false


### PR DESCRIPTION
The indentation bug has the unfortunate effect of making it seem like `root_volume` deletes an instance's volume.
