### PR TITLE
S3 Multipart PUT Support

### DIFF
--- a/cloud/amazon/s3.py
+++ b/cloud/amazon/s3.py
@@ -401,7 +401,8 @@ def upload_multipart_s3file(module, s3, bucket, obj, src, expiry, metadata, encr
 
         # Set permissions and get URL for completed file
         mp_key = bucket.get_key(completed_mpart.key_name)
-        mp_key.set_acl(module.params.get('permission'))
+        for acl in module.params.get('permission'):
+            mp_key.set_acl(acl)
         url = mp_key.generate_url(expiry)
         module.exit_json(msg="PUT operation complete", url=url, changed=True)
     except s3.provider.storage_copy_error, e:

--- a/cloud/amazon/s3.py
+++ b/cloud/amazon/s3.py
@@ -371,8 +371,8 @@ def upload_multipart_s3file(module, s3, bucket, obj, src, expiry, metadata, encr
     """
     Uploads file in multiple parts. AWS min/max chunk size: 5MB/5GB
     """
-    if chunk_size_in_mb < 5 or chunk_size_in_mb > 5000:
-        module.fail_json(msg='Chunk Size must be between 5 and 5000 MB. Default: 1024')
+    if chunk_size_in_mb < 5 or chunk_size_in_mb > 5120:
+        module.fail_json(msg='Chunk Size must be between 5MB and 5GB. Default: 1024')
 
     bucket = s3.lookup(bucket)
     mpart = bucket.initiate_multipart_upload(obj, encrypt_key=encrypt, headers=headers)


### PR DESCRIPTION
### Adds S3 support for multipart PUT operations

Feature from issue #2038. AWS has a default single PUT operation limit of 5GB, but an overall filesize limit of 5TB. To get above single operation file limits, the multipart API can be used. Note that individual "parts" must have a minimum size of 5MB and a maximum of 5GB.
#### New options: "multipart" (bool), "chunk_size" (int)

Necessary to specify multipart upload and checksum process. See [here](http://permalink.gmane.org/gmane.comp.file-systems.s3.s3tools/583). Boto handles md5 checks for individual file parts, but AWS does not assign etag the md5 of the final file; probably because a maximally large file of 5TB would be relatively expensive to compute.  This is important if we are to maintain the expected "overwrite" functionality checking etag. 

Multipart S3 keys have a special etag value derived from the md5 hexdigest of the _concatenated md5 byte arrays of each file part_. Therefore, etag value is different if chunk size changes for the same file.
#### New S3 "modes":  "list_multipart", "cancel_multipart"

Multipart upload "parts" will take up space in S3 even if the upload is interrupted or otherwise fails. These "modes"/commands are helpful to discover and cleanup incomplete multipart operations which would potentially take up disk space (and therefore $$$) until they are terminated or completed. See [boto docs](https://boto.readthedocs.org/en/latest/ref/s3.html?highlight=multipart#module-boto.s3.multipart) and [AWS docs](http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadInitiate.html)
- "list_multipart" returns all of the unique multipart IDs and their corresponding S3 key names.
- "cancel_multipart" cancels all of the multipart operations for a specific S3 key name.
