### PR TITLE
Fix win_lineinfile to pass integration tests 

### DIFF
--- a/windows/win_lineinfile.ps1
+++ b/windows/win_lineinfile.ps1
@@ -387,8 +387,11 @@ Elseif (Test-Path $dest) {
 	$found = $FALSE;
 	Foreach ($encoding in $sortedlist.GetValueList()) {
 		$preamble = $encoding.GetPreamble();
-		If ($preamble) {
-			Foreach ($i in 0..$preamble.Length) {
+		If ($preamble -and $bom) {
+			Foreach ($i in 0..($preamble.Length - 1)) {
+				If ($i -ge $bom.Length) {
+					break;
+				}
 				If ($preamble[$i] -ne $bom[$i]) {
 					break;
 				}
@@ -427,7 +430,7 @@ If ($state -eq "present") {
 }
 Else {
 
-	If ($regex -eq $FALSE -and $line -eq $FALSE) {
+	If ($regexp -eq $FALSE -and $line -eq $FALSE) {
 		Fail-Json (New-Object psobject) "one of line= or regexp= is required with state=absent";
 	}
 	


### PR DESCRIPTION
Also fixes errors that surface when strict mode is enabled (changes from https://github.com/ansible/ansible/pull/12047 that will be resubmitted).

Enables all tests added in https://github.com/ansible/ansible/pull/11790 to pass.
