### PR TITLE
docker module: fix regressions introduced by f38186c and 80aca4b

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -1525,7 +1525,8 @@ def present(manager, containers, count, name):
     delta = count - len(containers.deployed)
 
     if delta > 0:
-        containers.notice_changed(manager.create_containers(delta))
+        created = manager.create_containers(delta)
+        containers.notice_changed(manager.get_inspect_containers(created))
 
     if delta < 0:
         # If both running and stopped containers exist, remove
@@ -1540,8 +1541,8 @@ def present(manager, containers, count, name):
             to_remove.append(c)
 
         manager.stop_containers(to_stop)
+        containers.notice_changed(manager.get_inspect_containers(to_remove))
         manager.remove_containers(to_remove)
-        containers.notice_changed(to_remove)
 
 def started(manager, containers, count, name):
     '''Ensure that exactly `count` matching containers exist and are running.'''
@@ -1557,13 +1558,13 @@ def started(manager, containers, count, name):
 
         created = manager.create_containers(delta)
         manager.start_containers(created)
-        containers.notice_changed(created)
+        containers.notice_changed(manager.get_inspect_containers(created))
 
     if delta < 0:
         excess = containers.running[0:-delta]
+        containers.notice_changed(manager.get_inspect_containers(excess))
         manager.stop_containers(excess)
         manager.remove_containers(excess)
-        containers.notice_changed(excess)
 
 def reloaded(manager, containers, count, name):
     '''
@@ -1597,7 +1598,7 @@ def stopped(manager, containers, count, name):
     containers.refresh()
 
     manager.stop_containers(containers.running)
-    containers.notice_changed(containers.running)
+    containers.notice_changed(manager.get_inspect_containers(containers.running))
 
 def killed(manager, containers, count, name):
     '''Kill any matching containers that are running.'''
@@ -1605,7 +1606,7 @@ def killed(manager, containers, count, name):
     containers.refresh()
 
     manager.kill_containers(containers.running)
-    containers.notice_changed(containers.running)
+    containers.notice_changed(manager.get_inspect_containers(containers.running))
 
 def absent(manager, containers, count, name):
     '''Stop and remove any matching containers.'''
@@ -1613,8 +1614,8 @@ def absent(manager, containers, count, name):
     containers.refresh()
 
     manager.stop_containers(containers.running)
+    containers.notice_changed(manager.get_inspect_containers(containers.deployed))
     manager.remove_containers(containers.deployed)
-    containers.notice_changed(containers.deployed)
 
 def main():
     module = AnsibleModule(
@@ -1727,9 +1728,8 @@ def main():
         module.exit_json(changed=manager.has_changed(),
                          msg=manager.get_summary_message(),
                          summary=manager.counters,
-                         containers=containers.changed,
                          reload_reasons=manager.get_reload_reason_message(),
-                         ansible_facts=_ansible_facts(manager.get_inspect_containers(containers.changed)))
+                         ansible_facts=_ansible_facts(containers.changed))
 
     except DockerAPIError as e:
         module.fail_json(changed=manager.has_changed(), msg="Docker API Error: %s" % e.explanation)


### PR DESCRIPTION
Currently docker facts are broken since  80aca4b

1/ Fix in commit f38186c introduced a regression when removing a container:

```
failed: [localhost] => {"changed": true, "failed": true}
msg: Docker API Error: no such id:   ef7b1bafa9950645ca...
```

manager.get_inspect_containers() is invoked on a non existing container

2/ facts are not returned with consistent information depending what state is requested to the module

This pull request propose a fix to return consistent information and don't fail when removing containers.
