### PR TITLE
Error message & doc improvement for ipv4_range

### DIFF
--- a/cloud/google/gce_net.py
+++ b/cloud/google/gce_net.py
@@ -212,7 +212,7 @@ def main():
         # user wants to create a new network that doesn't yet exist
         if name and not network:
             if not ipv4_range:
-                module.fail_json(msg="Missing required 'ipv4_range' parameter",
+                module.fail_json(msg="Network '" + name + "' is not found. To create network, 'ipv4_range' parameter is required",
                     changed=False)
 
             try:

--- a/cloud/google/gce_net.py
+++ b/cloud/google/gce_net.py
@@ -40,6 +40,7 @@ options:
   ipv4_range:
     description:
       - the IPv4 address range in CIDR notation for the network
+        this parameter is not mandatory when you specified existing network in name parameter, but when you create new network, this parameter is mandatory
     required: false
     aliases: ['cidr']
   fwname:


### PR DESCRIPTION
This PR clarify when `ipv4_range` is required and when it isn't.

According to the document, `ipv4_range` is not required parameter, but when you try to create new network, error message says that `ipv4_range` is necessary.
I read source code and found when `ipv4_range` is mandatory. I believe it should be clearly stated in doc and error message.
