### PR TITLE
Fixing ec2_asg termination_policy

### DIFF
--- a/cloud/amazon/ec2_asg.py
+++ b/cloud/amazon/ec2_asg.py
@@ -794,7 +794,7 @@ def main():
             health_check_type=dict(default='EC2', choices=['EC2', 'ELB']),
             default_cooldown=dict(type='int', default=300),
             wait_for_instances=dict(type='bool', default=True),
-            termination_policies=dict(type='list', default=None)
+            termination_policies=dict(type='list', default='Default')
         ),
     )
     


### PR DESCRIPTION
If this isnt set, it wont launch the instances because it needs to default to "Default" despite what boto docs say.
