### PR TITLE
ec2 - allow use of volume_type in volumes dict

### DIFF
--- a/cloud/amazon/ec2.py
+++ b/cloud/amazon/ec2.py
@@ -216,7 +216,7 @@ options:
   volumes:
     version_added: "1.5"
     description:
-      - "a list of volume dicts, each containing device name and optionally ephemeral id or snapshot id. Size and type (and number of iops for io device type) must be specified for a new volume or a root volume, and may be passed for a snapshot volume. For any volume, a volume size less than 1 will be interpreted as a request not to create the volume. Encrypt the volume by passing 'encrypted: true' in the volume dict."
+      - a list of hash/dictionaries of volumes to add to the new instance; '[{"key":"value", "key":"value"}]'; keys allowed are - device_name (str; required), delete_on_termination (bool; False), device_type (deprecated), ephemeral (str), encrypted (bool; False), snapshot (str), volume_type (str), iops (int) - device_type is deprecated use volume_type, iops must be set when volume_type='io1', ephemeral and snapshot are mutually exclusive.
     required: false
     default: null
     aliases: []
@@ -295,7 +295,7 @@ EXAMPLES = '''
     volumes:
       - device_name: /dev/sdb
         snapshot: snap-abcdef12
-        device_type: io1
+        volume_type: io1
         iops: 1000
         volume_size: 100
         delete_on_termination: true
@@ -710,11 +710,21 @@ def create_block_device(module, ec2, volume):
     # Not aware of a way to determine this programatically
     # http://aws.amazon.com/about-aws/whats-new/2013/10/09/ebs-provisioned-iops-maximum-iops-gb-ratio-increased-to-30-1/
     MAX_IOPS_TO_SIZE_RATIO = 30
+
+    # device_type has been used historically to represent volume_type, 
+    # however ec2_vol uses volume_type, as does the BlockDeviceType, so 
+    # we add handling for either/or but not both
+    if all(key in volume for key in ['device_type','volume_type']):
+        module.fail_json(msg = 'device_type is a deprecated name for volume_type. Do not use both device_type and volume_type')
+
+    # get whichever one is set, or NoneType if neither are set
+    volume_type = volume.get('device_type') or volume.get('volume_type')
+
     if 'snapshot' not in volume and 'ephemeral' not in volume:
         if 'volume_size' not in volume:
             module.fail_json(msg = 'Size must be specified when creating a new volume or modifying the root volume')
     if 'snapshot' in volume:
-        if 'device_type' in volume and volume.get('device_type') == 'io1' and 'iops' not in volume:
+        if volume_type == 'io1' and 'iops' not in volume:
             module.fail_json(msg = 'io1 volumes must have an iops value set')
         if 'iops' in volume:
             snapshot = ec2.get_all_snapshots(snapshot_ids=[volume['snapshot']])[0]
@@ -729,10 +739,11 @@ def create_block_device(module, ec2, volume):
     return BlockDeviceType(snapshot_id=volume.get('snapshot'),
                            ephemeral_name=volume.get('ephemeral'),
                            size=volume.get('volume_size'),
-                           volume_type=volume.get('device_type'),
+                           volume_type=volume_type,
                            delete_on_termination=volume.get('delete_on_termination', False),
                            iops=volume.get('iops'),
                            encrypted=volume.get('encrypted', None))
+
 def boto_supports_param_in_spot_request(ec2, param):
     """
     Check if Boto library has a <param> in its request_spot_instances() method. For example, the placement_group parameter wasn't added until 2.3.0.


### PR DESCRIPTION
For some reason, `device_type` was used to specify the volume_type.  This differs with both the ec2_vol module, and also the BlockDeviceType parameter name.   This PR adds handling for `volume_type` while keeping `device_type` for backward compatibility.

Test output is [here](https://gist.github.com/halberom/523f788633ff74e97b20)

I didn't note an alias in the param description, because it's a sub key, and I wasn't sure how to specify it.

I also have no idea about deprecation warnings, how to add, or when to - as it might be nice to deprecate the device_type.
