### PR TITLE
Fix for modifying the size of an RDS instance.

### DIFF
--- a/cloud/amazon/rds.py
+++ b/cloud/amazon/rds.py
@@ -917,6 +917,7 @@ def validate_parameters(required_vars, valid_vars, module):
             'subnet': 'db_subnet_group_name',
             'license_model': 'license_model',
             'option_group': 'option_group_name',
+            'size': 'allocated_storage',
             'iops': 'iops',
             'new_instance_name': 'new_instance_id',
             'apply_immediately': 'apply_immediately',


### PR DESCRIPTION
When attempting to modify the size of an RDS instance Ansible succeeds and
returns a "changed" status. However, no changes are applied to the RDS
instance. Boto is looking for a keyword parameter of "allocated_storage" to
update the size, and this parameter wasn't being included.

This fixes #636. 
