### PR TITLE
Revert "win_get_url re-download file only if modified"

### DIFF
--- a/windows/win_get_url.ps1
+++ b/windows/win_get_url.ps1
@@ -1,7 +1,7 @@
 #!powershell
 # This file is part of Ansible.
 #
-# (c)) 2015, Paul Durivage <paul.durivage@rackspace.com>, Tal Auslander <tal@cloudshare.com>
+# Copyright 2014, Paul Durivage <paul.durivage@rackspace.com>
 #
 # Ansible is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -40,40 +40,14 @@ Else {
     Fail-Json $result "missing required argument: dest"
 }
 
-$force = Get-Attr -obj $params -name "force" "no" | ConvertTo-Bool
+$client = New-Object System.Net.WebClient
 
-If ($force -or -not (Test-Path $dest)) {
-    $client = New-Object System.Net.WebClient
-
-    Try {
-        $client.DownloadFile($url, $dest)
-        $result.changed = $true
-    }
-    Catch {
-        Fail-Json $result "Error downloading $url to $dest"
-    }
+Try {
+    $client.DownloadFile($url, $dest)
+    $result.changed = $true
 }
-Else {
-    Try {
-        $webRequest = [System.Net.HttpWebRequest]::Create($url)
-        $webRequest.IfModifiedSince = ([System.IO.FileInfo]$dest).LastWriteTime
-        $webRequest.Method = "GET"
-        [System.Net.HttpWebResponse]$webResponse = $webRequest.GetResponse()
-        
-        $stream = New-Object System.IO.StreamReader($response.GetResponseStream())
-        
-        $stream.ReadToEnd() | Set-Content -Path $dest -Force -ErrorAction Stop
-        
-        $result.changed = $true
-    }
-    Catch [System.Net.WebException] {
-        If ($_.Exception.Response.StatusCode -ne [System.Net.HttpStatusCode]::NotModified) {
-            Fail-Json $result "Error downloading $url to $dest"
-        }
-    }
-    Catch {
-        Fail-Json $result "Error downloading $url to $dest"
-    }
+Catch {
+    Fail-Json $result "Error downloading $url to $dest"
 }
 
 Set-Attr $result.win_get_url "url" $url


### PR DESCRIPTION
Faced the following issue while using win_get_url for getting a remote build 
fatal: [remote_winodws_ip]: FAILED! => {"changed": false, "failed": true, "msg": "Error downloading http://<jenkins_server_ip>/jenkins/view/Trunk/job/router/lastSuccessfulBuild/artifact/router/conf/router-service-context.xml to D:\router\router-service-context.xml Exception calling \"DownloadFile\" with \"2\" argument(s): \"An exception occurred during a WebClient request.\""}
