### PR TITLE
Add stop_timeout option to docker module

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -320,6 +320,12 @@ options:
     default: false
     aliases: []
     version_added: "2.0"
+  stop_timeout:
+    description:
+      - How many seconds to wait for the container to stop before killing it.
+    required: false
+    default: 10
+    version_added: "2.0"
 author:
     - "Cove Schneider (@cove)"
     - "Joshua Conner (@joshuaconner)"
@@ -597,6 +603,7 @@ class DockerManager(object):
             'cap_add': ((0, 5, 0), '1.14'),
             'cap_drop': ((0, 5, 0), '1.14'),
             'read_only': ((1, 0, 0), '1.17'),
+            'stop_timeout': ((0, 5, 0), '1.0'),
             # Clientside only
             'insecure_registry': ((0, 5, 0), '0.0')
             }
@@ -1472,7 +1479,7 @@ class DockerManager(object):
 
     def stop_containers(self, containers):
         for i in containers:
-            self.client.stop(i['Id'])
+            self.client.stop(i['Id'], self.module.params.get('stop_timeout'))
             self.increment_counter('stopped')
 
         return [self.client.wait(i['Id']) for i in containers]
@@ -1668,6 +1675,7 @@ def main():
             cap_add         = dict(default=None, type='list'),
             cap_drop        = dict(default=None, type='list'),
             read_only       = dict(default=None, type='bool'),
+            stop_timeout    = dict(default=10, type='int'),
         ),
         required_together = (
             ['tls_client_cert', 'tls_client_key'],


### PR DESCRIPTION
Docker provides a `timeout` parameter to specify how long to wait for a container to stop before forcibly killing it. This pull request exposes this to ansible through the `stop_timeout` option.
