### PR TITLE
Fix hashbang for openstack novaclient modules

### DIFF
--- a/cloud/openstack/_glance_image.py
+++ b/cloud/openstack/_glance_image.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Benno Joy <benno@ansible.com>

--- a/cloud/openstack/_nova_compute.py
+++ b/cloud/openstack/_nova_compute.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #coding: utf-8 -*-
 
 # (c) 2013, Benno Joy <benno@ansible.com>

--- a/cloud/openstack/_nova_keypair.py
+++ b/cloud/openstack/_nova_keypair.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #coding: utf-8 -*-
 
 # (c) 2013, Benno Joy <benno@ansible.com>

--- a/cloud/openstack/_quantum_floating_ip.py
+++ b/cloud/openstack/_quantum_floating_ip.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #coding: utf-8 -*-
 
 # (c) 2013, Benno Joy <benno@ansible.com>

--- a/cloud/openstack/_quantum_floating_ip_associate.py
+++ b/cloud/openstack/_quantum_floating_ip_associate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #coding: utf-8 -*-
 
 # (c) 2013, Benno Joy <benno@ansible.com>

--- a/cloud/openstack/_quantum_network.py
+++ b/cloud/openstack/_quantum_network.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #coding: utf-8 -*-
 
 # (c) 2013, Benno Joy <benno@ansible.com>

--- a/cloud/openstack/_quantum_subnet.py
+++ b/cloud/openstack/_quantum_subnet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #coding: utf-8 -*-
 
 # (c) 2013, Benno Joy <benno@ansible.com>


### PR DESCRIPTION
Hardcoded `/usr/bin/python` hashbang makes it unsuable in virtualenv.
It results with error:
`failed=True msg='novaclient is required for this module'` if ansible
is not installed globally.
