### PR TITLE
Fix compatibility issues of docker module with docker clients < 1.19 and docker-py < 0.5.3

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -1432,6 +1432,9 @@ class DockerManager(object):
         else:
             params['host_config']['Memory'] = mem_limit
 
+        major, minor, patch = get_docker_py_versioninfo()
+        if (major == 0 and minor <= 5 and patch <= 3):
+            del params['cpuset']
 
         def do_create(count, params):
             results = []


### PR DESCRIPTION
Deploying a docker container with the following playbook-snippet fails:

``` yaml
- name: Deploy Docker container
  sudo: True
  docker:
    registry: "http://private-docker-registry"
    insecure_registry: yes
    docker_api_version: 1.17
    pull: always
    state: running
    image: "private-docker-registry/IMAGE_NAME" 
    name: CONTAINER_NAME
```

Error:

```
Traceback (most recent call last):
  File "/home/volker/.ansible/tmp/ansible-tmp-1443173773.77-177469793583468/docker", line 3489, in <module>
    main()
  File "/home/volker/.ansible/tmp/ansible-tmp-1443173773.77-177469793583468/docker", line 1712, in main
    started(manager, containers, count, name)
  File "/home/volker/.ansible/tmp/ansible-tmp-1443173773.77-177469793583468/docker", line 1559, in started
    created = manager.create_containers(delta)
  File "/home/volker/.ansible/tmp/ansible-tmp-1443173773.77-177469793583468/docker", line 1434, in create_containers
    params['host_config']['Memory'] = mem_limit
KeyError: 'host_config'

```

The problem is that the current docker modules fails at detecting api_version 1.17. This is fixed with 2026fe34ddf959c35ea42c8235ef5ee274423311

---

The second problem is an older docker-py version which results in the following error:

```
Traceback (most recent call last):
  File "/home/volker/.ansible/tmp/ansible-tmp-1443168797.18-81738364339485/docker", line 3496, in <module>
    main()
  File "/home/volker/.ansible/tmp/ansible-tmp-1443168797.18-81738364339485/docker", line 1719, in main
    started(manager, containers, count, name)
  File "/home/volker/.ansible/tmp/ansible-tmp-1443168797.18-81738364339485/docker", line 1566, in started
    created = manager.create_containers(delta)
  File "/home/volker/.ansible/tmp/ansible-tmp-1443168797.18-81738364339485/docker", line 1454, in create_containers
    containers = do_create(count, params)
  File "/home/volker/.ansible/tmp/ansible-tmp-1443168797.18-81738364339485/docker", line 1447, in do_create
    result = self.client.create_container(**params)
TypeError: create_container() got an unexpected keyword argument 'cpuset'

```

This is fixed with 93432d94afc68eb8fa7e1e59646805e3ec470c21
