### PR TITLE
Fix add user with require ssl

### DIFF
--- a/database/mysql/mysql_user.py
+++ b/database/mysql/mysql_user.py
@@ -339,9 +339,9 @@ def privileges_unpack(priv):
     if '*.*' not in output:
         output['*.*'] = ['USAGE']
 
-    # if we are only specifying something like REQUIRESSL in *.* we still need
-    # to add USAGE as a privilege to avoid syntax errors
-    if priv.find('REQUIRESSL') != -1 and 'USAGE' not in output['*.*']:
+    # if we are only specifying something like REQUIRESSL and/or GRANT (=WITH GRANT OPTION) in *.*
+    # we still need to add USAGE as a privilege to avoid syntax errors
+    if 'REQUIRESSL' in priv and not set(output['*.*']).difference(set('GRANT', 'REQUIRESSL')):
         output['*.*'].append('USAGE')
 
     return output
@@ -367,10 +367,10 @@ def privileges_grant(cursor, user,host,db_table,priv):
     priv_string = ",".join([p for p in priv if p not in ('GRANT', 'REQUIRESSL')])
     query = ["GRANT %s ON %s" % (priv_string, mysql_quote_identifier(db_table, 'table'))]
     query.append("TO %s@%s")
-    if 'GRANT' in priv:
-        query.append("WITH GRANT OPTION")
     if 'REQUIRESSL' in priv:
         query.append("REQUIRE SSL")
+    if 'GRANT' in priv:
+        query.append("WITH GRANT OPTION")
     query = ' '.join(query)
     cursor.execute(query, (user, host))
 

--- a/database/mysql/mysql_user.py
+++ b/database/mysql/mysql_user.py
@@ -341,7 +341,7 @@ def privileges_unpack(priv):
 
     # if we are only specifying something like REQUIRESSL and/or GRANT (=WITH GRANT OPTION) in *.*
     # we still need to add USAGE as a privilege to avoid syntax errors
-    if 'REQUIRESSL' in priv and not set(output['*.*']).difference(set('GRANT', 'REQUIRESSL')):
+    if 'REQUIRESSL' in priv and not set(output['*.*']).difference(set(['GRANT', 'REQUIRESSL'])):
         output['*.*'].append('USAGE')
 
     return output


### PR DESCRIPTION
This fixes the require ssl option when adding a user. No need to use append_privs anymore, which makes it impossible to make an idempotent task.
Also fixed the order of the appended options (require ssl and with grant) to make it possible to combine grant and require ssl.

For example:
- mysql_user: name=bob priv=_._:ALL,REQUIRESSL state=present
- mysql_user: name=bob priv=_._:ALL,GRANT,REQUIRESSL state=present
