### PR TITLE
Added documentation for the config_template module

### DIFF
--- a/files/config_template.py
+++ b/files/config_template.py
@@ -1,0 +1,85 @@
+# this is a virtual module that is entirely implemented server side
+#
+# (c) 2015, Kevin Carter <kevin.carter@rackspace.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = """
+---
+module: config_template
+version_added: 2.0.0
+short_description: >
+  Renders template files providing a create/update override interface
+description:
+  - The module contains the template functionality with the ability to
+    override items in config, in transit, though the use of an simple
+    dictionary without having to write out various temp files on target
+    machines. The module renders all of the potential jinja a user could
+    provide in both the template file and in the override dictionary which
+    is ideal for deployers whom may have lots of different configs using a
+    similar code base.
+  - The module is an extension of the **copy** module and all of its
+    attributes can be used here.
+options:
+  src:
+    description:
+      - Path of a template file on the local server. This can be a relative
+        or absolute path.
+    required: true
+  dest:
+    description:
+      - Location to render the template to on the remote machine.
+    required: true
+  config_overrides:
+    description:
+      - A dictionary (hash) used to update or override items within a
+        configuration template file. The dictionary data structure may be
+        nested. If the target config file is an ini file the nested keys in
+        the ``config_overrides`` will be used as section headers.
+    required: true
+  config_type:
+    description:
+      - A string value indicating the target configuration type.
+    choices:
+      - ini
+      - json
+      - yaml
+    required: true
+author: Kevin Carter
+"""
+
+EXAMPLES = """
+  - name: run config template ini
+    config_template:
+      src: templates/test.ini.j2
+      dest: /tmp/test.ini
+      config_overrides: {}
+      config_type: ini
+
+  - name: run config template json
+    config_template:
+      src: templates/test.json.j2
+      dest: /tmp/test.json
+      config_overrides: {}
+      config_type: json
+
+  - name: run config template yaml
+    config_template:
+      src: templates/test.yaml.j2
+      dest: /tmp/test.yaml
+      config_overrides: {}
+      config_type: yaml
+"""


### PR DESCRIPTION
The change relates to PR  https://github.com/ansible/ansible/pull/12555
This is the documentation on how to use the plugin and creates a
virtual module allowing the `config_template` module to be
called like all other libraries.

Signed-off-by: Kevin Carter kevin.carter@rackspace.com
