### PR TITLE
add support

### DIFF
--- a/system/cron.py
+++ b/system/cron.py
@@ -123,6 +123,11 @@ options:
     version_added: "2.0"
     required: false
     default: false
+  rootdir:
+    description:
+      - If the job should be modified in jail or chroot
+    required: false
+    default: null
 requirements:
   - cron
 author:


### PR DESCRIPTION
This adds support of FreeBSD jails in system modules (cron, user, group, service). It's remote jail connector, the idea is to manage jails remotely from parent host without ssh in jail (this may be due to security restrictions). Add a parameter 'wrapper' exec command where necessary - jexec (part of base) or just chroot, the second parameter will be 'rootdir' to specify the root path to jail.  

Example of inventory file:

```
[jail-www]
jail-www.domain.com ansible_ssh_host=host-www.domain.com
```

Examples of task:

```
- service: name=nginx state=started rootdir=/data/jail0  wrapper='/home/ansible/scripts/jail_wrapper /data/jail0'
- cron: name="rotate anftpd" minute=0 hour=0 user=root job="echo" rootdir=/data/jail0
- group: name=test gid=10034 rootdir=/data/jail0
- user: name=test comment="Test Sandbox" uid=10023 createhome=yes shell=/bin/sh rootdir=/data/jail0 generate_ssh_key=yes ssh_key_bits=2048 ssh_key_file=.ssh/id_rsa
```

Ansible user would write "wrapper" himself.

Example here:

```
#!/usr/bin/python

import sys
import os
import subprocess
import re

len(sys.argv) > 2 or sys.exit('Number of arguments must be > 2')
jname = sys.argv[1]
exestr = ''
jid = 0
ret = -1

exestr = ' '.join(sys.argv[2:])

def run_process(exe):
    p = subprocess.Popen(exe, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
    retcode = p.wait()
    if retcode: sys.exit(ret)
    return p.stdout.readlines()

for line in run_process('jls'):
    line = line.strip()
    if re.match('JID', line): continue
    m = line.split()
    if m[2] == jname:
        jid = m[0]
        break

if jid > 0:
    status = os.system('echo \'' + exestr + '\' | jexec ' + jid + ' sh')
    ret = os.WEXITSTATUS(status)
    if ret is None: ret = 0
sys.exit(ret)
```
