### PR TITLE
Powershell throwing 'The variable cannot be retrieved because it has not been set' error

### DIFF
--- a/windows/setup.ps1
+++ b/windows/setup.ps1
@@ -79,7 +79,7 @@ Set-Attr $result.ansible_facts "ansible_powershell_version" $psversion
 $winrm_https_listener_parent_path = Get-ChildItem -Path WSMan:\localhost\Listener -Recurse | Where-Object {$_.PSChildName -eq "Transport" -and $_.Value -eq "HTTPS"} | select PSParentPath
 $winrm_https_listener_path = $null
 $https_listener = $null
-
+$winrm_cert_thumbprint = $null
 
 if ($winrm_https_listener_parent_path ) {
     $winrm_https_listener_path = $winrm_https_listener_parent_path.PSParentPath.Substring($winrm_https_listener_parent_path.PSParentPath.LastIndexOf("\"))

--- a/windows/setup.ps1
+++ b/windows/setup.ps1
@@ -77,6 +77,7 @@ $psversion = $PSVersionTable.PSVersion.Major
 Set-Attr $result.ansible_facts "ansible_powershell_version" $psversion
 
 $winrm_https_listener_parent_path = Get-ChildItem -Path WSMan:\localhost\Listener -Recurse | Where-Object {$_.PSChildName -eq "Transport" -and $_.Value -eq "HTTPS"} | select PSParentPath
+$winrm_https_listener_path = $null
 
 if ($winrm_https_listener_parent_path ) {
     $winrm_https_listener_path = $winrm_https_listener_parent_path.PSParentPath.Substring($winrm_https_listener_parent_path.PSParentPath.LastIndexOf("\"))

--- a/windows/setup.ps1
+++ b/windows/setup.ps1
@@ -80,6 +80,7 @@ $winrm_https_listener_parent_path = Get-ChildItem -Path WSMan:\localhost\Listene
 $winrm_https_listener_path = $null
 $https_listener = $null
 $winrm_cert_thumbprint = $null
+$uppercase_cert_thumbprint = $null
 
 if ($winrm_https_listener_parent_path ) {
     $winrm_https_listener_path = $winrm_https_listener_parent_path.PSParentPath.Substring($winrm_https_listener_parent_path.PSParentPath.LastIndexOf("\"))

--- a/windows/setup.ps1
+++ b/windows/setup.ps1
@@ -78,6 +78,8 @@ Set-Attr $result.ansible_facts "ansible_powershell_version" $psversion
 
 $winrm_https_listener_parent_path = Get-ChildItem -Path WSMan:\localhost\Listener -Recurse | Where-Object {$_.PSChildName -eq "Transport" -and $_.Value -eq "HTTPS"} | select PSParentPath
 $winrm_https_listener_path = $null
+$https_listener = $null
+
 
 if ($winrm_https_listener_parent_path ) {
     $winrm_https_listener_path = $winrm_https_listener_parent_path.PSParentPath.Substring($winrm_https_listener_parent_path.PSParentPath.LastIndexOf("\"))


### PR DESCRIPTION
When a variable is previously unitialized in the script, powershell is throwing an error message: The variable '$foo' cannot be retrieved because it has not been set.

This was happening for the following in windows/setup.ps1:

$winrm_https_listener_path
$https_listener
$winrm_cert_thumbprint
$uppercase_cert_thumbprint
