### PR TITLE
Bugfix Pull Request: Fix incorrect variable in group.py: user -> group

### DIFF
--- a/system/group.py
+++ b/system/group.py
@@ -390,7 +390,7 @@ def main():
     group = Group(module)
 
     module.debug('Group instantiated - platform %s' % group.platform)
-    if user.distribution:
+    if group.distribution:
         module.debug('Group instantiated - distribution %s' % group.distribution)
 
     rc = None


### PR DESCRIPTION
##### Issue Type: Bugfix Pull Request
##### Ansible Version:

ansible 2.0.0 (devel a1f6de8745) last updated 2015/10/03 00:27:29 (GMT +100)
  lib/ansible/modules/core: (detached HEAD dbc860daaa) last updated 2015/10/03 01:20:12 (GMT +100)
  lib/ansible/modules/extras: (detached HEAD 9f5420e459) last updated 2015/10/03 00:27:42 (GMT +100)
  config file = 
  configured module search path = None
##### Environment:

Fedora release 21 Python 2.7.8
##### Summary:

An incorrect variable in `system/group.py` causes an exception. This PR should fix it.
##### Steps To Reproduce:

```
ansible localhost -m group -vvC -a 'name=test'
```
##### Expected Results:

Results obtained with this PR included:

```
localhost | SUCCESS => {
    "changed": false, 
    "gid": 1001, 
    "name": "test", 
    "state": "present", 
    "system": false
}
```
##### Actual Results:

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: NameError: global name 'user' is not defined
localhost | FAILED! => {
    "changed": false, 
    "failed": true, 
    "parsed": false
}
```
