### PR TITLE
Allow RPMs to be downgraded within Ansible

### DIFF
--- a/packaging/os/yum.py
+++ b/packaging/os/yum.py
@@ -544,7 +544,7 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
                     f.close()
                     pkg = package
                 except Exception, e:
-                    shutil.rmtree(tempdir)
+                    delete_temporary_directory(tempdir)
                     module.fail_json(msg="Failure downloading %s, %s" % (spec, e))
 
         #groups :(
@@ -611,11 +611,7 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
 
         if module.check_mode:
             # Remove rpms downloaded for EL5 via url
-            try:
-                shutil.rmtree(tempdir)
-            except Exception, e:
-                module.fail_json(msg="Failure deleting temp directory %s, %s" % (tempdir, e))
-
+            delete_temporary_directory(tempdir)
             module.exit_json(changed=True, results=res['results'], changes=dict(installed=pkgs))
 
         changed = True
@@ -650,10 +646,7 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
         res['changed'] = changed
 
     # Remove rpms downloaded for EL5 via url
-    try:
-        shutil.rmtree(tempdir)
-    except Exception, e:
-        module.fail_json(msg="Failure deleting temp directory %s, %s" % (tempdir, e))
+    delete_temporary_directory(tempdir)
 
     return res
 
@@ -915,6 +908,12 @@ def ensure(module, state, pkgs, conf_file, enablerepo, disablerepo,
                 " failed", changed=False, results='', errors='unepected state')
 
     return res
+
+def delete_temporary_directory(tempdir):
+    try:
+        shutil.rmtree(tempdir)
+    except Exception, e:
+        module.fail_json(msg="Failure deleting temp directory %s, %s" % (tempdir, e))
 
 def main():
 


### PR DESCRIPTION
## Overview

Ansible is not currently able to install an older version of an RPM (if this older version was previously installed on the system) because of the way yum handles downgrading RPMs.

In order to downgrade to an older version of an RPM, one needs to use the `yum downgrade` plugin, since the intuitive `yum install <older version>` does not work in a CentOS world.

As of now, yum downgrading _will not_ work on lists of packages. This is a necessary workaround since building the logic for this will take a larger refactoring effort.
## References

This work builds on the work done in previous PRs:
- https://github.com/ansible/ansible/pull/6033
- https://github.com/ansible/ansible/pull/6333
## Testing

I decided to use a CentOS 6 Docker image to do my testing since that seemed like the easiest thing to build + have someone else verify. All the files are available here https://gist.github.com/marvinpinto/326f3f3750fac1121cf4

Running that sample playbook should demonstrate the RPM upgrading and downgrading process (a full sample output is available there)

Looks something like:

```
PLAY RECAP ********************************************************************
localhost                  : ok=44   changed=21   unreachable=0    failed=0
```
## Feedback

I would love to hear your feedback on how we could improve this module!
