### PR TITLE
ec2_tag - minor doc fix

### DIFF
--- a/cloud/amazon/ec2_tag.py
+++ b/cloud/amazon/ec2_tag.py
@@ -73,7 +73,7 @@ tasks:
       Env: production
     exact_count: 1
     group: "{{ security_group }}" 
-    keypair: ""{{ keypair }}" 
+    keypair: "{{ keypair }}" 
     image: "{{ image_id }}" 
     instance_tags:
       Name: dbserver


### PR DESCRIPTION
Fixes double quotes causing syntax highlight errors in http://docs.ansible.com/ansible/ec2_tag_module.html. 
