### PR TITLE
Fix detached head detection in is_not_a_branch()

### DIFF
--- a/source_control/git.py
+++ b/source_control/git.py
@@ -453,7 +453,7 @@ def is_local_branch(git_path, module, dest, branch):
 def is_not_a_branch(git_path, module, dest):
     branches = get_branches(git_path, module, dest)
     for b in branches:
-        if b.startswith('* ') and 'no branch' in b:
+        if b.startswith('* ') and ('no branch' in b or 'detached from' in b):
             return True
     return False
 


### PR DESCRIPTION
Detached head detection seems to have broken somewhere a long the way
because git decided to change how that situation looks when doing a 'git
branch -a' which is performed by `get_branches()`.

This is how git 1.7.1 displays this situation (which works):

```
shell> git branch -a
* (no branch)
  master
```

This is the output from git 1.8.3.1 (which does not work):

```
shell> git branch -a
* (detached from e132711)
  master
```

It looks like this same wording is used in the most recent version of
git (2.6.1 as of writing this).
