### PR TITLE
Fix error on ec2 status change

### DIFF
--- a/cloud/amazon/ec2.py
+++ b/cloud/amazon/ec2.py
@@ -1228,6 +1228,8 @@ def startstop_instances(module, ec2, instance_ids, state, instance_tags):
     wait_timeout = int(module.params.get('wait_timeout'))
     changed = False
     instance_dict_array = []
+    source_dest_check = module.params.get('source_dest_check')
+    termination_protection = module.params.get('termination_protection')
 
     if not isinstance(instance_ids, list) or len(instance_ids) < 1:
         # Fail unless the user defined instance tags


### PR DESCRIPTION
Fixes #2205 

Both `source_dest_check` and `termination_protection` variables are not available within the scope of the startstop_instances method. This just pulls them from module.params.
