### PR TITLE
Set default of dimensions parameter to be empty dict

### DIFF
--- a/cloud/amazon/ec2_metric_alarm.py
+++ b/cloud/amazon/ec2_metric_alarm.py
@@ -115,9 +115,6 @@ EXAMPLES = '''
 
 import sys
 
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
-
 try:
     import boto.ec2.cloudwatch
     from boto.ec2.cloudwatch import CloudWatchConnection, MetricAlarm
@@ -281,5 +278,9 @@ def main():
         create_metric_alarm(connection, module)
     elif state == 'absent':
         delete_metric_alarm(connection, module)
+
+
+from ansible.module_utils.basic import *
+from ansible.module_utils.ec2 import *
 
 main()

--- a/cloud/amazon/ec2_metric_alarm.py
+++ b/cloud/amazon/ec2_metric_alarm.py
@@ -184,7 +184,7 @@ def create_metric_alarm(connection, module):
         comparisons = {'<=' : 'LessThanOrEqualToThreshold', '<' : 'LessThanThreshold', '>=' : 'GreaterThanOrEqualToThreshold', '>' : 'GreaterThanThreshold'}
         alarm.comparison = comparisons[comparison]
 
-        dim1 = module.params.get('dimensions', {})
+        dim1 = module.params.get('dimensions')
         dim2 = alarm.dimensions
 
         for keys in dim1:
@@ -255,7 +255,7 @@ def main():
             unit=dict(type='str', choices=['Seconds', 'Microseconds', 'Milliseconds', 'Bytes', 'Kilobytes', 'Megabytes', 'Gigabytes', 'Terabytes', 'Bits', 'Kilobits', 'Megabits', 'Gigabits', 'Terabits', 'Percent', 'Count', 'Bytes/Second', 'Kilobytes/Second', 'Megabytes/Second', 'Gigabytes/Second', 'Terabytes/Second', 'Bits/Second', 'Kilobits/Second', 'Megabits/Second', 'Gigabits/Second', 'Terabits/Second', 'Count/Second', 'None']),
             evaluation_periods=dict(type='int'),
             description=dict(type='str'),
-            dimensions=dict(type='dict'),
+            dimensions=dict(type='dict', default={}),
             alarm_actions=dict(type='list'),
             insufficient_data_actions=dict(type='list'),
             ok_actions=dict(type='list'),


### PR DESCRIPTION
https://github.com/ansible/ansible-modules-core/pull/1906 was merged to fix issue https://github.com/ansible/ansible-modules-core/issues/1611 but it doesn't work because it would only set a default of {} if the key didn't exist.  The key always exists because it is a module parameter with a default of None.

Instead, this PR changes the default of the parameter to be an empty dict.
