### PR TITLE
Add state=running on some ec2 examples

### DIFF
--- a/cloud/amazon/ec2.py
+++ b/cloud/amazon/ec2.py
@@ -481,6 +481,7 @@ EXAMPLES = '''
 #
 
 - ec2:
+    state: running
     key_name: mykey
     instance_type: c1.medium
     image: ami-40603AD1
@@ -498,6 +499,7 @@ EXAMPLES = '''
 #
 
 - ec2:
+    state: running
     key_name: mykey
     instance_type: c1.medium
     image: ami-40603AD1


### PR DESCRIPTION
`state=running` was missing in some of the ec2 module examples
