### PR TITLE
[cron] Add missing documentation: cron_file requires user to be set

### DIFF
--- a/system/cron.py
+++ b/system/cron.py
@@ -67,6 +67,7 @@ options:
   cron_file:
     description:
       - If specified, uses this file in cron.d instead of an individual user's crontab.
+        To use the C(cron_file) parameter you must specify the C(user) as well.
     required: false
     default: null
   backup:


### PR DESCRIPTION
This is written as an error message, but not documented properly.

https://github.com/ansible/ansible-modules-core/blob/a15aa09251487a4cb3448182acec370d8259cb2c/system/cron.py#L464
