### PR TITLE
Fixing issue with subversion module whereby the module was reporting local modifications being present when externals were being used

### DIFF
--- a/source_control/subversion.py
+++ b/source_control/subversion.py
@@ -171,9 +171,10 @@ class Subversion(object):
         '''True if revisioned files have been added or modified. Unrevisioned files are ignored.'''
         lines = self._exec(["status", "--quiet", "--ignore-externals",  self.dest])
         # The --quiet option will return only modified files.
-
+        # Match only revisioned files, i.e. ignore status '?'.
+        regex = re.compile(r'^[^?X]')
         # Has local mods if more than 0 modifed revisioned files.
-        return len(filter(len, lines)) > 0
+        return len(filter(regex.match, lines)) > 0
 
     def needs_update(self):
         curr, url = self.get_revision()


### PR DESCRIPTION
I was having issues with the subversion module erroneously reporting that there had been local modifications where in fact, it was getting confused with externals being present. I'd seen a couple of solutions, but they didn't seem to work for me. The fix I made in this pull request works for me, so I'm happy to share it across the community.

In my situation, Subversion was still returning a line prefixed with an "X" even if --quiet and --ignore-externals was set. So, I put the regular expression back, included "X" at the start, and I've had no problems since.
