### PR TITLE
Fix v2 breakage: Add missing variable initializations

### DIFF
--- a/cloud/amazon/ec2.py
+++ b/cloud/amazon/ec2.py
@@ -1226,6 +1226,8 @@ def startstop_instances(module, ec2, instance_ids, state, instance_tags):
 
     wait = module.params.get('wait')
     wait_timeout = int(module.params.get('wait_timeout'))
+    source_dest_check = module.params.get('source_dest_check')
+    termination_protection = module.params.get('termination_protection')
     changed = False
     instance_dict_array = []
 


### PR DESCRIPTION
Without this, «ec2: state=stopped instance_ids=…» would fail with a
traceback like this:

```
if inst.get_attribute('sourceDestCheck')['sourceDestCheck'] != source_dest_check:
```

NameError: global name 'source_dest_check' is not defined
