### PR TITLE
ec2_vol: added deleteOnTermination in the output of list option

### DIFF
--- a/cloud/amazon/ec2_vol.py
+++ b/cloud/amazon/ec2_vol.py
@@ -400,7 +400,8 @@ def main():
                 'attachment_set': {
                     'attach_time': attachment.attach_time,
                     'device': attachment.device,
-                    'status': attachment.status
+                    'status': attachment.status,
+                    'deleteOnTermination': attachment.deleteOnTermination
                 }
             })
 


### PR DESCRIPTION
This change just adds in the output of the list option the "deleteOnTermination" attribute.
It's useful to know whether the volume has this set in some situations or not.

```
127.0.0.1 | success >> {
    "changed": false,
    "volumes": [
        {
            "attachment_set": {
                "attach_time": "2015-10-12T08:15:18.000Z",
                "deleteOnTermination": "true",
                "device": "/dev/xvda",
                "status": "attached"
            },
            "create_time": "2015-10-12T08:15:18.718Z",
            "id": "vol-3ed51fd2",
            "iops": 24,
            "size": 8,
            "snapshot_id": "snap-b772aec8",
            "status": "in-use",
            "type": "gp2",
            "zone": "us-east-1b"
        }
    ]
}
```
