### PR TITLE
Add ansible_date_time to windows facts

### DIFF
--- a/windows/setup.ps1
+++ b/windows/setup.ps1
@@ -65,6 +65,9 @@ Set-Attr $result.ansible_facts "ansible_distribution" $osversion.VersionString
 Set-Attr $result.ansible_facts "ansible_distribution_version" $osversion.Version.ToString()
 
 $date = New-Object psobject
+Set-Attr $date "date" (Get-Date -format d)
+Set-Attr $date "year" (Get-Date -format yyyy)
+Set-Attr $date "month" (Get-Date -format MM)
 Set-Attr $date "day" (Get-Date -format dd)
 Set-Attr $date "hour" (Get-Date -format HH)
 Set-Attr $date "iso8601" (Get-Date -format s)

--- a/windows/setup.ps1
+++ b/windows/setup.ps1
@@ -64,6 +64,12 @@ Set-Attr $result.ansible_facts "ansible_os_name" ($win32_os.Name.Split('|')[0]).
 Set-Attr $result.ansible_facts "ansible_distribution" $osversion.VersionString
 Set-Attr $result.ansible_facts "ansible_distribution_version" $osversion.Version.ToString()
 
+$date = New-Object psobject
+Set-Attr $date "day" (Get-Date -format dd)
+Set-Attr $date "hour" (Get-Date -format HH)
+Set-Attr $date "iso8601" (Get-Date -format s)
+Set-Attr $result.ansible_facts "ansible_date_time" $date
+
 Set-Attr $result.ansible_facts "ansible_totalmem" $capacity
 
 Set-Attr $result.ansible_facts "ansible_lastboot" $win32_os.lastbootuptime.ToString("u")


### PR DESCRIPTION
Added a fact called ansible_date_time that includes day, hour and iso8601 to mirror the available linux facts.  This has been tested on powershell version 4 but it appears it works down to powershell version 3 although I don't have any test machines running that.
