### PR TITLE
Allow nics to be a string in os_server

### DIFF
--- a/cloud/openstack/os_server.py
+++ b/cloud/openstack/os_server.py
@@ -461,7 +461,7 @@ def main():
         flavor_include                  = dict(default=None),
         key_name                        = dict(default=None),
         security_groups                 = dict(default=['default'], type='list'),
-        nics                            = dict(default=[], type='list'),
+        nics                            = dict(default=None),
         meta                            = dict(default=None),
         userdata                        = dict(default=None),
         config_drive                    = dict(default=False, type='bool'),


### PR DESCRIPTION
The module docs and code handle comma separated strings as well as
actual lists. Making the argument a list type turns the string into a
single entry list which is undesireable.

Resolves #2231
