### PR TITLE
Removing Type for 'nics' parameter

### DIFF
--- a/cloud/openstack/os_server.py
+++ b/cloud/openstack/os_server.py
@@ -435,7 +435,7 @@ def main():
         flavor_include                  = dict(default=None),
         key_name                        = dict(default=None),
         security_groups                 = dict(default='default'),
-        nics                            = dict(default=[], type='list'),
+        nics                            = dict(default=[]),
         meta                            = dict(default=None),
         userdata                        = dict(default=None),
         config_drive                    = dict(default=False, type='bool'),


### PR DESCRIPTION
Since 'nics' is a complex parameter, supporting both list input and
string input, the type should not be 'List'.

closes #2231
