### PR TITLE
IAM doc fix

### DIFF
--- a/cloud/amazon/iam.py
+++ b/cloud/amazon/iam.py
@@ -83,26 +83,12 @@ options:
     choices: ['always', 'on_create']
     description:
      - C(always) will update passwords if they differ.  C(on_create) will only set the password for newly created users.
-  aws_secret_key:
-    description:
-      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used.
-    required: false
-    default: null
-    aliases: [ 'ec2_secret_key', 'secret_key' ]
-  aws_access_key:
-    description:
-      - AWS access key. If not set then the value of the AWS_ACCESS_KEY environment variable is used.
-    required: false
-    default: null
-    aliases: [ 'ec2_access_key', 'access_key' ]
 notes:
   - 'Currently boto does not support the removal of Managed Policies, the module will error out if your user/group/role has managed policies when you try to do state=absent. They will need to be removed manually.'
 author:
     - "Jonathan I. Davila (@defionscode)"
     - "Paul Seiffert (@seiffert)"
-extends_documentation_fragment:
-    - aws
-    - ec2
+extends_documentation_fragment: aws
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
Remove access_key and secret_key as these are provided by aws doc fragment

Remove ec2 doc fragment as region is not required for IAM
