### PR TITLE
Google Cloud Storage doc fix

### DIFF
--- a/cloud/google/gc_storage.py
+++ b/cloud/google/gc_storage.py
@@ -69,14 +69,14 @@ options:
     required: true
     default: null
     choices: [ 'get', 'put', 'get_url', 'get_str', 'delete', 'create' ]
-  gcs_secret_key:
+  gs_secret_key:
     description:
-      - GCS secret key. If not set then the value of the GCS_SECRET_KEY environment variable is used.
+      - GCS secret key. If not set then the value of the GS_SECRET_KEY environment variable is used.
     required: true
     default: null
-  gcs_access_key:
+  gs_access_key:
     description:
-      - GCS access key. If not set then the value of the GCS_ACCESS_KEY environment variable is used.
+      - GCS access key. If not set then the value of the GS_ACCESS_KEY environment variable is used.
     required: true
     default: null
 


### PR DESCRIPTION
Fix documentation for 'gcs' for access and secret variables
