### PR TITLE
Included 'block_device_mapping' in the output of module and other mis…

### DIFF
--- a/cloud/amazon/ec2_ami_find.py
+++ b/cloud/amazon/ec2_ami_find.py
@@ -165,11 +165,31 @@ EXAMPLES = '''
 
 try:
     import boto.ec2
+    from boto.ec2.blockdevicemapping import BlockDeviceType, BlockDeviceMapping
     HAS_BOTO=True
 except ImportError:
     HAS_BOTO=False
 
 import json
+
+def get_block_device_mapping(image):
+    """
+    Retrieves block device mapping from AMI
+    """
+
+    bdm_dict = dict()
+    bdm = getattr(image,'block_device_mapping')
+    for device_name in bdm.keys():
+        bdm_dict[device_name] = {
+            'size': bdm[device_name].size,
+            'snapshot_id': bdm[device_name].snapshot_id,
+            'volume_type': bdm[device_name].volume_type,
+            'encrypted': bdm[device_name].encrypted,
+            'delete_on_termination': bdm[device_name].delete_on_termination
+        }
+
+    return bdm_dict
+
 
 def main():
     argument_spec = ec2_argument_spec()
@@ -255,8 +275,12 @@ def main():
         data = {
             'ami_id': image.id,
             'architecture': image.architecture,
+            'block_device_mapping': get_block_device_mapping(image),
+            'creationDate': image.creationDate,
             'description': image.description,
+            'hypervisor': image.hypervisor,
             'is_public': image.is_public,
+            'location': image.location,
             'name': image.name,
             'owner_id': image.owner_id,
             'platform': image.platform,

--- a/cloud/amazon/ec2_ami_find.py
+++ b/cloud/amazon/ec2_ami_find.py
@@ -163,6 +163,105 @@ EXAMPLES = '''
     wait: yes
 '''
 
+RETURN = '''
+ami_id:
+    description: id of found amazon image
+    returned: when AMI found
+    type: string
+    sample: "ami-e9095e8c"
+architecture:
+    description: architecture of image
+    returned: when AMI found
+    type: string
+    sample: "x86_64"
+architecture:
+    description: architecture of image
+    returned: when AMI found
+    type: string
+    sample: "x86_64"
+block_device_mapping:
+    description: block device mapping associated with image
+    returned: when AMI found
+    type: dictionary of block devices
+    sample: {
+	"/dev/xvda": {
+    	    "delete_on_termination": true,
+            "encrypted": false,
+            "size": 8,
+            "snapshot_id": "snap-ca0330b8",
+            "volume_type": "gp2"
+    }
+creationDate:
+    description: creation date of image
+    returned: when AMI found
+    type: string
+    sample: "2015-10-15T22:43:44.000Z"
+description:
+    description: description of image
+    returned: when AMI found
+    type: string
+    sample: "test-server01"
+hypervisor:
+    description: type of hypervisor
+    returned: when AMI found
+    type: string
+    sample: "xen"
+is_public:
+    description: whether image is public
+    returned: when AMI found
+    type: bool
+    sample: false
+location:
+    description: location of image
+    returned: when AMI found
+    type: string
+    sample: "435210894375/test-server01-20151015-234343"
+name:
+    description: ami name of image
+    returned: when AMI found
+    type: string
+    sample: "test-server01-20151015-234343"
+owner_id:
+    description: owner of image
+    returned: when AMI found
+    type: string
+    sample: "435210894375"
+platform:
+    description: plaform of image
+    returned: when AMI found
+    type: string
+    sample: null
+root_device_name:
+    description: rood device name of image
+    returned: when AMI found
+    type: string
+    sample: "/dev/xvda"
+root_device_type:
+    description: rood device type of image
+    returned: when AMI found
+    type: string
+    sample: "ebs"
+state:
+    description: state of image
+    returned: when AMI found
+    type: string
+    sample: "available"
+tags:
+    description: tags assigned to image
+    returned: when AMI found
+    type: dictionary of tags
+    sample: {
+	"Environment": "devel",
+	"Name": "test-server01",
+        "Role": "web"
+    }
+virtualization_type:
+    description: image virtualization type
+    returned: when AMI found
+    type: string
+    sample: "hvm"
+'''
+
 try:
     import boto.ec2
     from boto.ec2.blockdevicemapping import BlockDeviceType, BlockDeviceMapping
@@ -323,4 +422,3 @@ from ansible.module_utils.ec2 import *
 
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
This PR just adds useful information about the AMI e.g. allows to see how many snapshots it contains and their attributes.

```
TASK: [debug var=images_res] **************************************************
ok: [127.0.0.1] => {
    "var": {
        "images_res": {
            "changed": false,
            "invocation": {
                "module_args": "",
                "module_name": "ec2_ami_find"
            },
            "results": [
                {
                    "ami_id": "ami-e9095e8c",
                    "architecture": "x86_64",
                    "block_device_mapping": {
                        "/dev/xvda": {
                            "delete_on_termination": true,
                            "encrypted": false,
                            "size": 8,
                            "snapshot_id": "snap-ca0330b8",
                            "volume_type": "gp2"
                        }
                    },
                    "creationDate": "2015-10-15T22:43:44.000Z",
                    "description": null,
                    "hypervisor": "xen",
                    "is_public": false,
                    "location": "XXXXXXXXXX/proj-dev-web01-20151015-234343",
                    "name": "test",
                    "owner_id": "XXXXXXXXXX",
                    "platform": null,
                    "root_device_name": "/dev/xvda",
                    "root_device_type": "ebs",
                    "state": "available",
                    "tags": {
                        "Env": "dev",
                        "Name": "proj-dev-web01",
                        "Project": "GRPIT022W01",
                        "Role": "web"
                    },
                    "virtualization_type": "hvm"
                }
            ]
        }
    }
}

```
