### PR TITLE
Make the docker volumes binds a list instead of a dict

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -120,7 +120,7 @@ options:
     version_added: "2.0"
   log_opt:
     description:
-      - Additional options to pass to the logging driver selected above. See Docker `log-driver 
+      - Additional options to pass to the logging driver selected above. See Docker `log-driver
         <https://docs.docker.com/reference/logging/overview/>` documentation for more information.
         Requires docker >=1.7.0.
     required: false
@@ -625,7 +625,7 @@ class DockerManager(object):
         self.binds = None
         self.volumes = None
         if self.module.params.get('volumes'):
-            self.binds = {}
+            self.binds = []
             self.volumes = []
             vols = self.module.params.get('volumes')
             for vol in vols:
@@ -643,7 +643,7 @@ class DockerManager(object):
                             self.module.fail_json(msg='invalid bind mode ' + parts[2])
                         else:
                             mode = parts[2]
-                    self.binds[parts[0]] = {'bind': parts[1], 'mode': mode }
+                    self.binds.append((parts[0], {'bind': parts[1], 'mode': mode}))
                 else:
                     self.module.fail_json(msg='volumes support 1 to 3 arguments')
 
@@ -1220,7 +1220,7 @@ class DockerManager(object):
 
             expected_binds = set()
             if self.binds:
-                for host_path, config in self.binds.iteritems():
+                for host_path, config in self.binds:
                     if isinstance(config, dict):
                         container_path = config['bind']
                         mode = config['mode']


### PR DESCRIPTION
This will prevent overwriting configurations when copying the same file to two places.

I just noticed this issue on one of my server builds, only the second one works, the first one just ends up as an empty directory for some reason. This is similar to the configuration I am using to reproduce the problem:

``` yml
docker_storage_volumes:
      - "{{ docker_storage_conf_dir }}local.py:/code/thing/local.py:ro"
      - "{{ docker_storage_conf_dir }}local.py:/code/totally/different/thing/local.py:ro"
```
