### PR TITLE
Fixes: User module on SunOS always returns changed in check mode

### DIFF
--- a/system/user.py
+++ b/system/user.py
@@ -1352,7 +1352,10 @@ class SunOS(User):
             cmd.append('-s')
             cmd.append(self.shell)
 
-        if self.module.check_mode:
+        # skip if no changes to be made
+        if len(cmd) == 1:
+            return (None, '', '')
+        elif self.module.check_mode:
             return (0, '', '')
         else:
             # modify the user if cmd will do anything


### PR DESCRIPTION
Fixes Issue #2296 : User module on SunOS always returns changed in check mode 
