### PR TITLE
fixes #12831 by updating the boto iam connection method

### DIFF
--- a/cloud/amazon/iam.py
+++ b/cloud/amazon/iam.py
@@ -565,7 +565,7 @@ def main():
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module)
 
     try:
-        iam = boto.iam.connection.IAMConnection(**aws_connect_kwargs)
+        iam = boto.iam.connect_to_region(region, **aws_connect_kwargs)
     except boto.exception.NoAuthHandlerFound, e:
         module.fail_json(msg=str(e))
 

--- a/cloud/amazon/iam.py
+++ b/cloud/amazon/iam.py
@@ -565,7 +565,10 @@ def main():
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module)
 
     try:
-        iam = boto.iam.connect_to_region(region, **aws_connect_kwargs)
+        if region:
+            iam = boto.iam.connect_to_region(region, **aws_connect_kwargs)
+        else:
+            iam = boto.iam.connection.IAMConnection(**aws_connect_kwargs)
     except boto.exception.NoAuthHandlerFound, e:
         module.fail_json(msg=str(e))
 

--- a/cloud/amazon/iam_cert.py
+++ b/cloud/amazon/iam_cert.py
@@ -107,6 +107,7 @@ import sys
 try:
     import boto
     import boto.iam
+    import boto.ec2
     HAS_BOTO = True
 except ImportError:
     HAS_BOTO = False
@@ -246,7 +247,7 @@ def main():
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module)
 
     try:
-        iam = boto.iam.connection.IAMConnection(**aws_connect_kwargs)
+        iam = boto.iam.connect_to_region(region, **aws_connect_kwargs)
     except boto.exception.NoAuthHandlerFound, e:
         module.fail_json(msg=str(e))
 

--- a/cloud/amazon/iam_cert.py
+++ b/cloud/amazon/iam_cert.py
@@ -247,7 +247,10 @@ def main():
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module)
 
     try:
-        iam = boto.iam.connect_to_region(region, **aws_connect_kwargs)
+        if region:
+            iam = boto.iam.connect_to_region(region, **aws_connect_kwargs)
+        else:
+            iam = boto.iam.connection.IAMConnection(**aws_connect_kwargs)
     except boto.exception.NoAuthHandlerFound, e:
         module.fail_json(msg=str(e))
 

--- a/cloud/amazon/iam_policy.py
+++ b/cloud/amazon/iam_policy.py
@@ -307,7 +307,7 @@ def main():
   region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module)
 
   try:
-      iam = boto.iam.connection.IAMConnection(**aws_connect_kwargs)
+      iam = boto.iam.connect_to_region(region, **aws_connect_kwargs)
   except boto.exception.NoAuthHandlerFound, e:
       module.fail_json(msg=str(e))
 

--- a/cloud/amazon/iam_policy.py
+++ b/cloud/amazon/iam_policy.py
@@ -307,7 +307,10 @@ def main():
   region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module)
 
   try:
-      iam = boto.iam.connect_to_region(region, **aws_connect_kwargs)
+    if region:
+        iam = boto.iam.connect_to_region(region, **aws_connect_kwargs)
+    else:
+        iam = boto.iam.connection.IAMConnection(**aws_connect_kwargs)
   except boto.exception.NoAuthHandlerFound, e:
       module.fail_json(msg=str(e))
 


### PR DESCRIPTION
fixes #12831 by updating the boto iam connection method to utilise connect_to_region which AWS China region supports.
