### PR TITLE
ec2_ami.py - Added improvements and documented return structure

### DIFF
--- a/cloud/amazon/ec2_ami.py
+++ b/cloud/amazon/ec2_ami.py
@@ -72,12 +72,13 @@ options:
     default: null
   delete_snapshot:
     description:
-      - Whether or not to delete an AMI while deregistering it.
+      - Whether or not to delete snapshots when deregistering AMI.
     required: false
-    default: null
+    default: "no"
+    choices: [ "yes", "no" ]
   tags:
     description:
-      - a hash/dictionary of tags to add to the new image; '{"key":"value"}' and '{"key":"value","key":"value"}'
+      - a dictionary of tags to add to the new image; '{"key":"value"}' and '{"key":"value","key":"value"}'
     required: false
     default: null
     version_added: "2.0"
@@ -87,7 +88,9 @@ options:
     required: false
     default: null
     version_added: "2.0"
-author: "Evan Duffield (@scicoin-project) <eduffield@iacquire.com>"
+author:
+    - "Evan Duffield (@scicoin-project) <eduffield@iacquire.com>"
+    - "Constantin Bugneac (@Constantin07) <constantin.bugneac@endava.com>"
 extends_documentation_fragment:
     - aws
     - ec2
@@ -150,22 +153,22 @@ EXAMPLES = '''
           no_device: yes
   register: instance
 
-# Deregister/Delete AMI
-- ec2_ami:
-    aws_access_key: xxxxxxxxxxxxxxxxxxxxxxx
-    aws_secret_key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-    region: xxxxxx
-    image_id: "{{ instance.image_id }}"
-    delete_snapshot: True
-    state: absent
-
-# Deregister AMI
+# Deregister/Delete AMI (keep associated snapshots)
 - ec2_ami:
     aws_access_key: xxxxxxxxxxxxxxxxxxxxxxx
     aws_secret_key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
     region: xxxxxx
     image_id: "{{ instance.image_id }}"
     delete_snapshot: False
+    state: absent
+
+# Deregister AMI (delete associated snapshots too)
+- ec2_ami:
+    aws_access_key: xxxxxxxxxxxxxxxxxxxxxxx
+    aws_secret_key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    region: xxxxxx
+    image_id: "{{ instance.image_id }}"
+    delete_snapshot: True
     state: absent
 
 # Update AMI Launch Permissions, making it public
@@ -189,6 +192,102 @@ EXAMPLES = '''
       user_ids: ['123456789012']
 '''
 
+RETURN = '''
+architecture:
+    description: architecture of image
+    returned: when AMI is created or already exists
+    type: string
+    sample: "x86_64"
+block_device_mapping:
+    description: block device mapping associated with image
+    returned: when AMI is created or already exists
+    type: a dictionary of block devices
+    sample: {
+        "/dev/sda1": {
+        "delete_on_termination": true,
+        "encrypted": false,
+        "size": 10,
+        "snapshot_id": "snap-1a03b80e7",
+        "volume_type": "standard"
+    }
+creationDate:
+    description: creation date of image
+    returned: when AMI is created or already exists
+    type: string
+    sample: "2015-10-15T22:43:44.000Z"
+description:
+    description: description of image
+    returned: when AMI is created or already exists
+    type: string
+    sample: "nat-server"
+hypervisor:
+    description: type of hypervisor
+    returned: when AMI is created or already exists
+    type: string
+    sample: "xen"
+is_public:
+    description: whether image is public
+    returned: when AMI is created or already exists
+    type: bool
+    sample: false
+location:
+    description: location of image
+    returned: when AMI is created or already exists
+    type: string
+    sample: "315210894379/nat-server"
+name:
+    description: ami name of image
+    returned: when AMI is created or already exists
+    type: string
+    sample: "nat-server"
+owner_id:
+    description: owner of image
+    returned: when AMI is created or already exists
+    type: string
+    sample: "435210894375"
+platform:
+    description: plaform of image
+    returned: when AMI is created or already exists
+    type: string
+    sample: null
+root_device_name:
+    description: root device name of image
+    returned: when AMI is created or already exists
+    type: string
+    sample: "/dev/sda1"
+root_device_type:
+    description: root device type of image
+    returned: when AMI is created or already exists
+    type: string
+    sample: "ebs"
+state:
+    description: state of image
+    returned: when AMI is created or already exists
+    type: string
+    sample: "available"
+tags:
+    description: a dictionary of tags assigned to image
+    returned: when AMI is created or already exists
+    type: dictionary of tags
+    sample: {
+        "Env": "devel",
+        "Name": "nat-server"
+    }
+virtualization_type:
+    description: image virtualization type
+    returned: when AMI is created or already exists
+    type: string
+    sample: "hvm"
+snapshots_deleted:
+    description: a list of snapshot ids deleted after deregistering image
+    returned: after AMI is deregistered, if 'delete_snapshot' is set to 'yes'
+    type: list
+    sample: [
+        "snap-fbcccb8f",
+        "snap-cfe7cdb4"
+    ]
+'''
+
 import sys
 import time
 
@@ -199,6 +298,47 @@ try:
     HAS_BOTO = True
 except ImportError:
     HAS_BOTO = False
+
+
+def get_block_device_mapping(image):
+    """
+    Retrieves block device mapping from AMI
+    """
+
+    bdm_dict = dict()
+
+    if image is not None and hasattr(image, 'block_device_mapping'):
+        bdm = getattr(image,'block_device_mapping')
+        for device_name in bdm.keys():
+            bdm_dict[device_name] = {
+                'size': bdm[device_name].size,
+                'snapshot_id': bdm[device_name].snapshot_id,
+                'volume_type': bdm[device_name].volume_type,
+                'encrypted': bdm[device_name].encrypted,
+                'delete_on_termination': bdm[device_name].delete_on_termination
+            }
+
+    return bdm_dict
+
+
+def get_ami_info(image):
+
+    return dict(
+        image_id=image.id,
+        state=image.state,
+        architecture=image.architecture,
+        block_device_mapping=get_block_device_mapping(image),
+        creationDate=image.creationDate,
+        description=image.description,
+        hypervisor=image.hypervisor,
+        is_public=image.is_public,
+        location=image.location,
+        ownerId=image.ownerId,
+        root_device_name=image.root_device_name,
+        root_device_type=image.root_device_type,
+        tags=image.tags,
+        virtualization_type = image.virtualization_type
+    )
 
 
 def create_image(module, ec2):
@@ -281,7 +421,7 @@ def create_image(module, ec2):
         except boto.exception.BotoServerError, e:
             module.fail_json(msg="%s: %s" % (e.error_code, e.error_message), image_id=image_id)
 
-    module.exit_json(msg="AMI creation operation complete", image_id=image_id, state=img.state, changed=True)
+    module.exit_json(msg="AMI creation operation complete", changed=True, **get_ami_info(img))
 
 
 def deregister_image(module, ec2):
@@ -298,13 +438,23 @@ def deregister_image(module, ec2):
     if img == None:
         module.fail_json(msg = "Image %s does not exist" % image_id, changed=False)
 
-    try:
-        params = {'image_id': image_id,
-                  'delete_snapshot': delete_snapshot}
+    # Get all associated snapshot ids before deregistering image otherwise this information becomes unavailable
+    snapshots = []
+    if hasattr(img, 'block_device_mapping'):
+        for key in img.block_device_mapping:
+            snapshots.append(img.block_device_mapping[key].snapshot_id)
 
-        res = ec2.deregister_image(**params)
-    except boto.exception.BotoServerError, e:
-        module.fail_json(msg = "%s: %s" % (e.error_code, e.error_message))
+    # When trying to re-delete already deleted image it doesn't raise an exception
+    # It just returns an object without image attributes
+    if hasattr(img, 'id'):
+        try:
+            params = {'image_id': image_id,
+                      'delete_snapshot': delete_snapshot}
+            res = ec2.deregister_image(**params)
+        except boto.exception.BotoServerError, e:
+            module.fail_json(msg = "%s: %s" % (e.error_code, e.error_message))
+    else:
+        module.exit_json(msg = "Image %s has already been deleted" % image_id, changed=False)
 
     # wait here until the image is gone
     img = ec2.get_image(image_id)
@@ -314,9 +464,21 @@ def deregister_image(module, ec2):
         time.sleep(3)
     if wait and wait_timeout <= time.time():
         # waiting took too long
-        module.fail_json(msg = "timed out waiting for image to be reregistered/deleted")
+        module.fail_json(msg = "timed out waiting for image to be deregistered/deleted")
 
-    module.exit_json(msg="AMI deregister/delete operation complete", changed=True)
+    # Boto library has hardcoded the deletion of the snapshot for the root volume mounted as '/dev/sda1' only
+    # Make it possible to delete all snapshots which belong to image, including root block device mapped as '/dev/xvda'
+    if delete_snapshot:
+        try:
+            for snapshot_id in snapshots:
+                ec2.delete_snapshot(snapshot_id)
+        except boto.exception.BotoServerError, e:
+            if e.error_code == 'InvalidSnapshot.NotFound':
+                # Don't error out if root volume snapshot was already deleted as part of deregister_image
+                pass
+        module.exit_json(msg="AMI deregister/delete operation complete", changed=True, snapshots_deleted=snapshots)
+    else:
+        module.exit_json(msg="AMI deregister/delete operation complete", changed=True)
 
 
 def update_image(module, ec2):
@@ -354,12 +516,12 @@ def main():
     argument_spec.update(dict(
             instance_id = dict(),
             image_id = dict(),
-            delete_snapshot = dict(),
+            delete_snapshot = dict(default=False, type='bool'),
             name = dict(),
-            wait = dict(type="bool", default=False),
+            wait = dict(type='bool', default=False),
             wait_timeout = dict(default=900),
             description = dict(default=""),
-            no_reboot = dict(default=False, type="bool"),
+            no_reboot = dict(default=False, type='bool'),
             state = dict(default='present'),
             device_mapping = dict(type='list'),
             tags = dict(type='dict'),
@@ -399,4 +561,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR improves the existing module as follows:
1. Added missing documentation for return structure.
2. 'delete_snapshot=yes' option now takes care of snapshots which have root volume as '/dev/xvda' and additionally deletes all snapshots associated with image. Now there is no need to worry about cleaning up orphaned snapshots anymore after de-registering image (a real pain).
3. After deleting image (with 'delete_snapshot=yes') the output returns the ids of deleted snapshots.
4. The output of state=present now includes more complete list of image attributes.
5. Removed sys.exit() statements.
6. Minor corrections in DOCUMENTATION and EXAMPLES sections.
7. Caught and handled the situation when it's attempted to re-delete already deleted image.

Note: Long and repeatable module.exit_json(...) statements left for compatibility with the current return format - I didn't want to move them under new key as probably many rely on existing format.

_If image with similar name exists just print out details_

```
ec2_ami instance_id=i-18c5a9a7 name=proj-dev state=present region=us-east-1 wait=yes no_reboot=yes owners=self
127.0.0.1 | success >> {
    "architecture": "x86_64",
    "block_device_mapping": {
        "/dev/sdf": {
            "delete_on_termination": false,
            "encrypted": false,
            "size": 1,
            "snapshot_id": "snap-e8eda79d",
            "volume_type": "standard"
        },
        "/dev/xvda": {
            "delete_on_termination": true,
            "encrypted": false,
            "size": 8,
            "snapshot_id": "snap-05d82366",
            "volume_type": "gp2"
        }
    },
    "changed": true,
    "creationDate": "2015-10-20T18:59:28.000Z",
    "description": null,
    "hypervisor": "xen",
    "image_id": "ami-73762416",
    "is_public": false,
    "location": "196076420568/proj-dev",
    "msg": "AMI creation operation complete",
    "ownerId": "196076420568",
    "root_device_name": "/dev/xvda",
    "root_device_type": "ebs",
    "state": "available",
    "tags": {},
    "virtualization_type": "hvm"
}
```

_If de-registering image with delete of associated snapshots:_

```
ansible localhost -m ec2_ami -a "image_id=ami-73762416 state=absent region=us-east-1 delete_snapshot=yes" -vv                     <127.0.0.1> REMOTE_MODULE ec2_ami image_id=ami-73762416 state=absent region=us-east-1 delete_snapshot=yes
127.0.0.1 | success >> {
    "changed": true,
    "msg": "AMI deregister/delete operation complete",
    "snapshots_deleted": [
        "snap-e8eda79d",
        "snap-05d82366"
    ]
}
```

_If deleting with delete_snapshot=no:_

```
ansible localhost -m ec2_ami -a "image_id=ami-bb782ade state=absent region=us-east-1 delete_snapshot=no" -vv                      <127.0.0.1> REMOTE_MODULE ec2_ami image_id=ami-bb782ade state=absent region=us-east-1 delete_snapshot=no
127.0.0.1 | success >> {
    "changed": true,
    "msg": "AMI deregister/delete operation complete"
}
```

_If trying to re-delete already deleted image - don't error out:_

```
ansible localhost -m ec2_ami -a "image_id=ami-357a2850 state=absent region=us-east-1 delete_snapshot=yes" -vv
<127.0.0.1> REMOTE_MODULE ec2_ami image_id=ami-357a2850 state=absent region=us-east-1 delete_snapshot=yes
127.0.0.1 | success >> {
    "changed": false,
    "msg": "Image ami-357a2850 has already been deleted"
}
```
