### PR TITLE
Mark this as a string so it is rendered in the docs

### DIFF
--- a/cloud/amazon/ec2.py
+++ b/cloud/amazon/ec2.py
@@ -225,7 +225,7 @@ options:
     description:
       - whether instance is using optimized EBS volumes, see U(http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSOptimized.html)
     required: false
-    default: false
+    default: 'false'
   exact_count:
     version_added: "1.5"
     description:


### PR DESCRIPTION
When this was treated as a boolean, sphinx was leaving the Default
column on http://docs.ansible.com/ansible/ec2_module.html blank,
implying it would use AWS's default.  In reality, it passes False, which
overrides the defaults at AWS (it's possible to boot an instance which
AWS claims will always have EBS optimization without it because of this
silently passed False).

Tested by running make webdocs in a local checkout and looking at ec2_module.html
Note that other docs use default: true which don't have this problem.  I have not looked into the doc building process in depth.
