### PR TITLE
return information about created subnet

### DIFF
--- a/cloud/openstack/os_subnet.py
+++ b/cloud/openstack/os_subnet.py
@@ -302,7 +302,9 @@ def main():
                     changed = True
                 else:
                     changed = False
-            module.exit_json(changed=changed)
+            module.exit_json(changed=changed,
+                             subnet=subnet,
+                             id=subnet['id'])
 
         elif state == 'absent':
             if not subnet:


### PR DESCRIPTION
make os_subnet behave like os_network in terms of returning information
about the created resource.  With this commit, os_subnet will return the
created subnet in `subnet` and the subnet id in `id`.
