### PR TITLE
make os_network correctly report changed status

### DIFF
--- a/cloud/openstack/os_network.py
+++ b/cloud/openstack/os_network.py
@@ -146,7 +146,10 @@ def main():
         if state == 'present':
             if not net:
                 net = cloud.create_network(name, shared, admin_state_up, external)
-            module.exit_json(changed=False, network=net, id=net['id'])
+                changed = True
+            else:
+                changed = False
+            module.exit_json(changed=changed, network=net, id=net['id'])
 
         elif state == 'absent':
             if not net:


### PR DESCRIPTION
The `os_network` module was incorrectly returning changed=False whether
or not the network was created.  This commit makes the changed return
value useful.
