### PR TITLE
make os_flavor return a top-level 'id' key

### DIFF
--- a/cloud/openstack/os_nova_flavor.py
+++ b/cloud/openstack/os_nova_flavor.py
@@ -217,8 +217,13 @@ def main():
                     rxtx_factor=module.params['rxtx_factor'],
                     is_public=module.params['is_public']
                 )
-                module.exit_json(changed=True, flavor=flavor)
-            module.exit_json(changed=False, flavor=flavor)
+                changed=True
+            else:
+                changed=False
+
+            module.exit_json(changed=changed,
+                             flavor=flavor,
+                             id=flavor['id'])
 
         elif state == 'absent':
             if flavor:


### PR DESCRIPTION
make os_flavor return a top-level 'id' key, much like other os_*
resources.
