### PR TITLE
allow empty description attribute for os_security_group

### DIFF
--- a/cloud/openstack/os_security_group.py
+++ b/cloud/openstack/os_security_group.py
@@ -91,7 +91,7 @@ def _system_state_change(module, secgroup):
 def main():
     argument_spec = openstack_full_argument_spec(
         name=dict(required=True),
-        description=dict(default=None),
+        description=dict(default=''),
         state=dict(default='present', choices=['absent', 'present']),
     )
 


### PR DESCRIPTION
The `os_security_group` module would fail if there was no `description:`
attribute:

```
localhost | FAILED! => {
    "changed": false,
    "failed": true,
"msg": "Error creating security group larstest: Invalid input for
description. Reason: 'None' is not a valid string."
}
```

This commit makes the default description `''` rather than `None`.
