### PR TITLE
make os_router return a top level 'id' key

### DIFF
--- a/cloud/openstack/os_router.py
+++ b/cloud/openstack/os_router.py
@@ -335,7 +335,9 @@ def main():
 
                     changed = True
 
-            module.exit_json(changed=changed, router=router)
+            module.exit_json(changed=changed,
+                             router=router,
+                             id=router['id'])
 
         elif state == 'absent':
             if not router:


### PR DESCRIPTION
make os_router return a top-level 'id' key, much like other
os_\* resources.
