### PR TITLE
Add support for legacy registries to pull_image().

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -117,7 +117,7 @@ options:
     version_added: "2.0"
   log_opt:
     description:
-      - Additional options to pass to the logging driver selected above. See Docker `log-driver 
+      - Additional options to pass to the logging driver selected above. See Docker `log-driver
         <https://docs.docker.com/reference/logging/overview/>` documentation for more information.
         Requires docker >=1.7.0.
     required: false
@@ -1390,24 +1390,20 @@ class DockerManager(object):
                 self.module.fail_json(msg="failed to login to the remote registry, check your username/password.", error=repr(e))
         try:
             changes = list(self.client.pull(image, tag=tag, stream=True, **extra_params))
-            try:
-                last = changes[-1]
-                # seems Docker 1.8 puts an empty dict at the end of the
-                # stream; catch that and get the previous instead
-                # https://github.com/ansible/ansible-modules-core/issues/2043
-                if last.strip() == '{}':
-                    last = changes[-2]
-            except IndexError:
-                last = '{}'
-            status = json.loads(last).get('status', '')
-            if status.startswith('Status: Image is up to date for'):
-                # Image is already up to date. Don't increment the counter.
-                pass
-            elif (status.startswith('Status: Downloaded newer image for') or
-                    status.startswith('Download complete')):
-                # Image was updated. Increment the pull counter.
-                self.increment_counter('pulled')
-            else:
+            pull_success = False
+            for change in changes:
+                status = json.loads(change).get('status', '')
+                if status.startswith('Status: Image is up to date for'):
+                    # Image is already up to date. Don't increment the counter.
+                    pull_success = True
+                    break
+                elif (status.startswith('Status: Downloaded newer image for') or
+                        status.startswith('Download complete')):
+                    # Image was updated. Increment the pull counter.
+                    self.increment_counter('pulled')
+                    pull_success = True
+                    break
+            if not pull_success:
                 # Unrecognized status string.
                 self.module.fail_json(msg="Unrecognized status from pull.", status=status, changes=changes)
         except Exception as e:


### PR DESCRIPTION
This PR aims to fix #2351:

> Docker: 1.8.3
> Ansible: 1.9.4-1
> Docker-py: 1.5.0
> 
> When trying to pull images from a legacy docker registry (quay.io), I get this error:
> 
> Status: Image is up to date for quay.io/mycompany/jenkins:latest\"}\r\n", "{\"status\":\"quay.io/3dsim/jenkins: this image was pulled from a legacy registry.  Important: This registry version will not be supported in future versions of docker.\"}\r\n"], "failed": true, "status": "quay.io/mycompany/jenkins: this image was pulled from a legacy registry.  Important: This registry version will not be supported in future versions of docker."}
> msg: Unrecognized status from pull.

I've tested the fix on both 1.9.4-1 and devel (2.0.0).

Since we now have several exceptions to the assumption that the
result of the pull would be on the last status line returned by
docker-py's pull(), I've changed the function so that it looks
through the status lines and returns what if finds on it.
Despite the repeated `break`s, the code seems simpler and a little
more coherent like this. From what I've checked using
https://github.com/jlafon/ansible-profile, the execution time is
mostly the same.
