### PR TITLE
fix docker random port assignments when not explicitly setting it

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -1267,8 +1267,8 @@ class DockerManager(object):
 
             # NETWORK MODE
 
-            expected_netmode = self.module.params.get('net') or 'bridge'
-            actual_netmode = container['HostConfig']['NetworkMode'] or 'bridge'
+            expected_netmode = self.module.params.get('net') or 'default'
+            actual_netmode = container['HostConfig']['NetworkMode'] or 'default'
             if actual_netmode != expected_netmode:
                 self.reload_reasons.append('net ({0} => {1})'.format(actual_netmode, expected_netmode))
                 differing.append(container)


### PR DESCRIPTION
This fixes #1185 and fixes #1885 in a similar way to #2215 but on devel.

`docker inspect` reports `default` not `bridge` as network mode when the `net` parameter is omitted when running a container.

I think this patch is good enough for now (it fixes the bug the same way it has been fixed in 1.9), but note that the correct behavior here is not clear. If a user omits the net parameter docker will use the `default` mode which currently is the same as if a user specified `bridge`. So if a user is more explicit in the future and actually sets `net` to `bridge` while `state` is set to `reloaded`, the container will be restarted even though the new container will have essentially the same state. One idea could be to track what the default network mode is in docker and use that as the default value to `net`.
