### PR TITLE
vsphere_guest: add power status to facts

### DIFF
--- a/cloud/vmware/vsphere_guest.py
+++ b/cloud/vmware/vsphere_guest.py
@@ -266,8 +266,22 @@ EXAMPLES = '''
   hw_guest_id: "rhel6_64Guest"
   hw_memtotal_mb: 2048
   hw_name: "centos64Guest"
+  hw_power_status: "POWERED ON",
   hw_processor_count: 2
   hw_product_uuid: "ef50bac8-2845-40ff-81d9-675315501dac"
+
+hw_power_status will be one of the following values:
+  - POWERED ON
+  - POWERED OFF
+  - SUSPENDED
+  - POWERING ON
+  - POWERING OFF
+  - SUSPENDING
+  - RESETTING
+  - BLOCKED ON MSG
+  - REVERTING TO SNAPSHOT
+  - UNKNOWN
+as seen in the VMPowerState-Class of PySphere: http://git.io/vlwOq
 
 # Remove a vm from vSphere
 # The VM must be powered_off or you need to use force to force a shutdown
@@ -1175,6 +1189,7 @@ def gather_facts(vm):
     facts = {
         'module_hw': True,
         'hw_name': vm.properties.name,
+        'hw_power_status': vm.get_status(),
         'hw_guest_full_name':  vm.properties.config.guestFullName,
         'hw_guest_id': vm.properties.config.guestId,
         'hw_product_uuid': vm.properties.config.uuid,

--- a/cloud/vmware/vsphere_guest.py
+++ b/cloud/vmware/vsphere_guest.py
@@ -1093,9 +1093,10 @@ def create_vm(vsphere_client, module, esxi, resource_pool, cluster_name, guest, 
         # Power on the VM if it was requested
         power_state(vm, state, True)
 
+        vmfacts=gather_facts(vm)
         vsphere_client.disconnect()
         module.exit_json(
-            ansible_facts=gather_facts(vm),
+            ansible_facts=vmfacts,
             changed=True,
             changes="Created VM %s" % guest)
 


### PR DESCRIPTION
This adds the power status (e.g. `POWERED ON`, `SUSPENDED`, etc.) to the facts gathered by `vmware_guest_facts`:

``` yaml
"ansible_facts": {
    "hw_guest_full_name": "CentOS 4/5/6 (64-Bit)", 
    "hw_guest_id": "centos64Guest", 
    "hw_memtotal_mb": 1024, 
    "hw_name": "ml_test_vm", 
    "hw_power_status": "POWERED ON",  # <<< added
    "hw_processor_count": 1, 
    "hw_product_uuid": "4206c105-70ce-8545-4513-3fcb2ffedc6e", 
    "module_hw": true
}, 
```

See the [documentation](https://github.com/luto/ansible-modules-core/blob/d5ed8381b66cba47cf3f7f45e30b0da04c26dac5/cloud/vmware/vsphere_guest.py#L269-L284) for details.

I agree to the [license agreement](http://docs.ansible.com/ansible/community.html#contributors-license-agreement) in the contributor guidelines.
