### PR TITLE
total_seconds not present on timedelta on python2.6

### DIFF
--- a/utilities/logic/wait_for.py
+++ b/utilities/logic/wait_for.py
@@ -103,7 +103,7 @@ options:
 notes:
   - The ability to use search_regex with a port connection was added in 1.7.
 requirements: []
-author: 
+author:
     - "Jeroen Hoekx (@jhoekx)"
     - "John Jarvis (@jarv)"
     - "Andrii Radyk (@AnderEnder)"
@@ -127,7 +127,7 @@ EXAMPLES = '''
 - wait_for: path=/tmp/foo search_regex=completed
 
 # wait until the lock file is removed
-- wait_for: path=/var/lock/file.lock state=absent 
+- wait_for: path=/var/lock/file.lock state=absent
 
 # wait until the process is finished and pid was destroyed
 - wait_for: path=/proc/3466/status state=absent
@@ -322,6 +322,11 @@ def _create_connection( (host, port), connect_timeout):
         connect_socket = socket.create_connection( (host, port), connect_timeout)
     return connect_socket
 
+def _timedelta_total_seconds(timedelta):
+    return (
+        timedelta.microseconds + 0.0 +
+        (timedelta.seconds + timedelta.days * 24 * 3600) * 10 ** 6) / 10 ** 6
+
 def main():
 
     module = AnsibleModule(
@@ -432,7 +437,7 @@ def main():
                     except IOError:
                         pass
             elif port:
-                alt_connect_timeout = math.ceil((end - datetime.datetime.now()).total_seconds())
+                alt_connect_timeout = math.ceil(_timedelta_total_seconds(end - datetime.datetime.now()))
                 try:
                     s = _create_connection((host, port), min(connect_timeout, alt_connect_timeout))
                 except:
@@ -444,7 +449,7 @@ def main():
                         data = ''
                         matched = False
                         while datetime.datetime.now() < end:
-                            max_timeout = math.ceil((end - datetime.datetime.now()).total_seconds())
+                            max_timeout = math.ceil(_timedelta_total_seconds(end - datetime.datetime.now()))
                             (readable, w, e) = select.select([s], [], [], max_timeout)
                             if not readable:
                                 # No new data.  Probably means our timeout


### PR DESCRIPTION
wait_for with timeout doesn't work on python 2.6 with ansible 2.0 since timedelta doesn't have total_seconds.
this patch will make it compatible with python 2.6.
