### PR TITLE
Add missing import on cloudformation for boto profile check

### DIFF
--- a/cloud/amazon/cloudformation.py
+++ b/cloud/amazon/cloudformation.py
@@ -105,9 +105,9 @@ EXAMPLES = '''
 tasks:
 - name: launch ansible cloudformation example
   cloudformation:
-    stack_name: "ansible-cloudformation" 
+    stack_name: "ansible-cloudformation"
     state: "present"
-    region: "us-east-1" 
+    region: "us-east-1"
     disable_rollback: true
     template: "files/cloudformation-example.json"
     template_parameters:
@@ -124,6 +124,7 @@ import time
 
 try:
     import boto
+    import boto.ec2
     import boto.cloudformation.connection
     HAS_BOTO = True
 except ImportError:


### PR DESCRIPTION
This is the same issue that affects route53: #1901 #2272

"The  module imports the ec2 utils:
from ansible.module_utils.ec2 import *
Which has a method that checks for boto support calling:
return hasattr(boto.ec2.EC2Connection, 'profile_name')"
