### PR TITLE
fixed ansible_totalmem fact returning 0

### DIFF
--- a/windows/setup.ps1
+++ b/windows/setup.ps1
@@ -26,11 +26,9 @@ $result = New-Object psobject @{
 };
 
 $win32_os = Get-CimInstance Win32_OperatingSystem
+$win32_cs = Get-CimInstance Win32_ComputerSystem
 $osversion = [Environment]::OSVersion
-$memory = @()
-$memory += Get-WmiObject win32_Physicalmemory
-$capacity = 0
-$memory | foreach {$capacity += $_.Capacity}
+$capacity = $win32_cs.TotalPhysicalMemory # Win32_PhysicalMemory is empty on some virtual platforms
 $netcfg = Get-WmiObject win32_NetworkAdapterConfiguration
 
 $ActiveNetcfg = @(); $ActiveNetcfg+= $netcfg | where {$_.ipaddress -ne $null}


### PR DESCRIPTION
Win32_PhysicalMemory CIM object is busted on some virtual environments, switched
to Win32_ComputerSystem.TotalPhysicalMemory. Fixes setup integration test failure
on virtualbox 4.x Windows Server 2008R2.
