### PR TITLE
Use connect_to_aws where possible

### DIFF
--- a/cloud/amazon/cloudformation.py
+++ b/cloud/amazon/cloudformation.py
@@ -305,10 +305,7 @@ def main():
     stack_outputs = {}
 
     try:
-        cfn = boto.cloudformation.connect_to_region(
-                  region,
-                  **aws_connect_kwargs
-              )
+        cfn = connect_to_aws(boto.cloudformation, region, **aws_connect_kwargs)
     except boto.exception.NoAuthHandlerFound, e:
         module.fail_json(msg=str(e))
     update = False

--- a/cloud/amazon/ec2.py
+++ b/cloud/amazon/ec2.py
@@ -1361,7 +1361,7 @@ def main():
 
     if region:
         try:
-            vpc = boto.vpc.connect_to_region(region, **aws_connect_kwargs)
+            vpc = connect_to_aws(boto.vpc, region, **aws_connect_kwargs)
         except boto.exception.NoAuthHandlerFound, e:
             module.fail_json(msg = str(e))
     else:

--- a/cloud/amazon/ec2_vpc.py
+++ b/cloud/amazon/ec2_vpc.py
@@ -688,10 +688,7 @@ def main():
     # If we have a region specified, connect to its endpoint.
     if region:
         try:
-            vpc_conn = boto.vpc.connect_to_region(
-                region,
-                **aws_connect_kwargs
-            )
+            vpc_conn = connect_to_aws(boto.vpc, region, **aws_connect_kwargs)
         except boto.exception.NoAuthHandlerFound, e:
             module.fail_json(msg = str(e))
     else:

--- a/cloud/amazon/iam.py
+++ b/cloud/amazon/iam.py
@@ -566,7 +566,7 @@ def main():
 
     try:
         if region:
-            iam = boto.iam.connect_to_region(region, **aws_connect_kwargs)
+            iam = connect_to_aws(boto.iam, region, **aws_connect_kwargs)
         else:
             iam = boto.iam.connection.IAMConnection(**aws_connect_kwargs)
     except boto.exception.NoAuthHandlerFound, e:

--- a/cloud/amazon/iam_cert.py
+++ b/cloud/amazon/iam_cert.py
@@ -248,7 +248,7 @@ def main():
 
     try:
         if region:
-            iam = boto.iam.connect_to_region(region, **aws_connect_kwargs)
+            iam = connect_to_aws(boto.iam, region, **aws_connect_kwargs)
         else:
             iam = boto.iam.connection.IAMConnection(**aws_connect_kwargs)
     except boto.exception.NoAuthHandlerFound, e:

--- a/cloud/amazon/iam_policy.py
+++ b/cloud/amazon/iam_policy.py
@@ -316,7 +316,7 @@ def main():
 
   try:
     if region:
-        iam = boto.iam.connect_to_region(region, **aws_connect_kwargs)
+        iam = connect_to_aws(boto.iam, region, **aws_connect_kwargs)
     else:
         iam = boto.iam.connection.IAMConnection(**aws_connect_kwargs)
   except boto.exception.NoAuthHandlerFound, e:

--- a/cloud/amazon/rds_param_group.py
+++ b/cloud/amazon/rds_param_group.py
@@ -240,7 +240,7 @@ def main():
         module.fail_json(msg = str("Either region or AWS_REGION or EC2_REGION environment variable or boto config aws_region or ec2_region must be set."))
 
     try:
-        conn = boto.rds.connect_to_region(region, **aws_connect_kwargs)
+        conn = connect_to_aws(boto.rds, region, **aws_connect_kwargs)
     except boto.exception.BotoServerError, e:
         module.fail_json(msg = e.error_message)
 

--- a/cloud/amazon/rds_subnet_group.py
+++ b/cloud/amazon/rds_subnet_group.py
@@ -112,7 +112,7 @@ def main():
         module.fail_json(msg = str("Either region or AWS_REGION or EC2_REGION environment variable or boto config aws_region or ec2_region must be set."))
 
     try:
-        conn = boto.rds.connect_to_region(region, **aws_connect_kwargs)
+        conn = connect_to_aws(boto.rds, region, **aws_connect_kwargs)
     except boto.exception.BotoServerError, e:
         module.fail_json(msg = e.error_message)
 

--- a/cloud/amazon/s3.py
+++ b/cloud/amazon/s3.py
@@ -460,7 +460,8 @@ def main():
             walrus = urlparse.urlparse(s3_url).hostname
             s3 = boto.connect_walrus(walrus, **aws_connect_kwargs)
         else:
-            s3 = boto.s3.connect_to_region(location, is_secure=True, **aws_connect_kwargs)
+            aws_connect_args['is_secure'] = True
+            s3 = connect_to_aws(boto.s3, location, **aws_connect_args)
             # use this as fallback because connect_to_region seems to fail in boto + non 'classic' aws accounts in some cases
             if s3 is None:
                 s3 = boto.connect_s3(**aws_connect_kwargs)


### PR DESCRIPTION
`connect_to_aws` fixes a bug with security tokens in AWS.
Modules should use that rather than calling
`boto.x.connect_to_region`

Addresses #2389 

Needs testing by people with security tokens, but I'm confident that `connect_to_aws` is widely tested across the board.
