### PR TITLE
Improved the expires option in the system/user module

### DIFF
--- a/system/user.py
+++ b/system/user.py
@@ -679,6 +679,18 @@ class User(object):
         except OSError, e:
             self.module.exit_json(failed=True, msg="%s" % e)
 
+    def check_expires(self):
+
+        expires = None
+        if os.path.exists(self.SHADOWFILE) and os.access(self.SHADOWFILE, os.R_OK):
+            for line in open(self.SHADOWFILE).readlines():
+                if line.startswith('%s:' % self.name):
+                    expires = line.split(':')[7]
+
+        if not expires:
+            expires = 'never'
+
+        return expires
 
 # ===========================================
 
@@ -2168,6 +2180,10 @@ def main():
                 result['ssh_fingerprint'] = err.strip()
             result['ssh_key_file'] = user.get_ssh_key_path()
             result['ssh_public_key'] = user.get_ssh_public_key()
+
+        expires = user.check_expires()
+        if expires:
+            result['expires'] = expires
 
     module.exit_json(**result)
 

--- a/system/user.py
+++ b/system/user.py
@@ -687,7 +687,9 @@ class User(object):
                 if line.startswith('%s:' % self.name):
                     expires = line.split(':')[7]
 
-        if not expires:
+        if expires:
+            expires = int(expires) * 86400
+        else:
             expires = 'never'
 
         return expires


### PR DESCRIPTION
I have made two changes to the system/user module, specifically for the expires option.
1. Currently you cannot set the expires option to never. As many systems use the account expiry as a quick way to disable and enable accounts on demand this is a problem. I have changed it so you can pass the string `never` to the expires option and it will unset any existing expiry date.
2. The expires value isn't currently returned during fact checking, so if you set the expires option it always registers as a changed action. I have fixed this by returning the epoch value which is converted from whole days, due to how linux deals with account expiry dates in the system shadow file. Obviously this means the user has to provide an epoch value that is the exact date only (excluding time) if they want it to match the fact checking, but this won't break any existing use of the feature.

I have tested my changes on Fedora 23 & CentOS 6. It should work fine on BSD systems, but I haven't been able to test it on these yet.
