### PR TITLE
unarchive: read absolute tempdir path for downloads (fixes #2250)

### DIFF
--- a/files/unarchive.py
+++ b/files/unarchive.py
@@ -278,7 +278,7 @@ def main():
             module.fail_json(msg="Source '%s' failed to transfer" % src)
         # If copy=false, and src= contains ://, try and download the file to a temp directory.
         elif '://' in src:
-            tempdir = os.path.dirname(__file__)
+            tempdir = os.path.dirname(os.path.abspath(__file__))
             package = os.path.join(tempdir, str(src.rsplit('/', 1)[1]))
             try:
                 rsp, info = fetch_url(module, src)


### PR DESCRIPTION
The tempdir variable for unarchive downloads needs to be determined absolutely.
Fixes bug #2250
