### PR TITLE
Add DigitalOcean API v2 support for SSH keys and Domains with fixes

### DIFF
--- a/cloud/digital_ocean/digital_ocean_domain.py
+++ b/cloud/digital_ocean/digital_ocean_domain.py
@@ -126,7 +126,7 @@ class Domain(JsonfyMixIn):
         self.__dict__.update(domain_json)
 
     def destroy(self):
-        self.manager.destroy_domain(self.id)
+        self.manager.destroy_domain(self.name)
 
     def records(self):
         json = self.manager.all_domain_records(self.name)

--- a/cloud/digital_ocean/digital_ocean_domain.py
+++ b/cloud/digital_ocean/digital_ocean_domain.py
@@ -28,12 +28,9 @@ options:
      - Indicate desired state of the target.
     default: present
     choices: ['present', 'absent']
-  client_id:
-     description:
-     - DigitalOcean manager id.
-  api_key:
+  api_token:
     description:
-     - DigitalOcean api key.
+     - DigitalOcean api token.
   id:
     description:
      - Numeric, the droplet id you want to operate on.
@@ -45,9 +42,9 @@ options:
      - The IP address to point a domain at.
 
 notes:
-  - Two environment variables can be used, DO_CLIENT_ID and DO_API_KEY.
-  - Version 1 of DigitalOcean API is used.
-
+  - Two environment variables can be used, DO_API_KEY and DO_API_TOKEN. They both refer to the v2 token.
+  - As of Ansible 2.0, Version 2 of the DigitalOcean API is used.
+  - As of Ansible 2.0, the above parameters were changed significantly. If you are running 1.9.x or earlier, please use C(ansible-doc digital_ocean_v2) to view the correct parameters for your version. Dedicated web docs will be available in the near future for the stable branch.
 requirements:
   - "python >= 2.6"
   - dopy
@@ -61,15 +58,17 @@ EXAMPLES = '''
       state=present
       name=my.digitalocean.domain
       ip=127.0.0.1
+      api_token=XXX
 
 # Create a droplet and a corresponding domain record
 
 - digital_ocean: >
       state=present
       name=test_droplet
-      size_id=1
-      region_id=2
-      image_id=3
+      size_id=2gb
+      region_id=ams2
+      image_id=fedora-19-x64
+      api_token=XXX
   register: test_droplet
 
 - digital_ocean_domain: >
@@ -80,10 +79,14 @@ EXAMPLES = '''
 
 import os
 import time
+from distutils.version import LooseVersion
 
+HAS_DOPY = True
 try:
+    import dopy
     from dopy.manager import DoError, DoManager
-    HAS_DOPY = True
+    if LooseVersion(dopy.__version__) < LooseVersion('0.3.2'):
+        HAS_DOPY = False
 except ImportError as e:
     HAS_DOPY = False
 
@@ -134,8 +137,8 @@ class Domain(JsonfyMixIn):
         return cls(json)
 
     @classmethod
-    def setup(cls, client_id, api_key):
-        cls.manager = DoManager(client_id, api_key)
+    def setup(cls, api_token):
+        cls.manager = DoManager(None, api_token, api_version=2)
         DomainRecord.manager = cls.manager
 
     @classmethod
@@ -170,16 +173,14 @@ def core(module):
         return v
 
     try:
-        # params['client_id'] will be None even if client_id is not passed in
-        client_id = module.params['client_id'] or os.environ['DO_CLIENT_ID']
-        api_key = module.params['api_key'] or os.environ['DO_API_KEY']
+        api_token = module.params['api_token'] or os.environ['DO_API_TOKEN'] or os.environ['DO_API_KEY']
     except KeyError, e:
         module.fail_json(msg='Unable to load %s' % e.message)
 
     changed = True
     state = module.params['state']
 
-    Domain.setup(client_id, api_key)
+    Domain.setup(api_token)
     if state in ('present'):
         domain = Domain.find(id=module.params["id"])
 
@@ -222,8 +223,7 @@ def main():
     module = AnsibleModule(
         argument_spec = dict(
             state = dict(choices=['present', 'absent'], default='present'),
-            client_id = dict(aliases=['CLIENT_ID'], no_log=True),
-            api_key = dict(aliases=['API_KEY'], no_log=True),
+            api_token = dict(aliases=['API_TOKEN'], no_log=True),
             name = dict(type='str'),
             id = dict(aliases=['droplet_id'], type='int'),
             ip = dict(type='str'),

--- a/cloud/digital_ocean/digital_ocean_domain.py
+++ b/cloud/digital_ocean/digital_ocean_domain.py
@@ -22,6 +22,7 @@ short_description: Create/delete a DNS record in DigitalOcean
 description:
      - Create/delete a DNS record in DigitalOcean.
 version_added: "1.6"
+author: "Michael Gregson (@mgregson)"
 options:
   state:
     description:
@@ -128,7 +129,7 @@ class Domain(JsonfyMixIn):
         self.manager.destroy_domain(self.id)
 
     def records(self):
-        json = self.manager.all_domain_records(self.id)
+        json = self.manager.all_domain_records(self.name)
         return map(DomainRecord, json)
 
     @classmethod

--- a/cloud/digital_ocean/digital_ocean_sshkey.py
+++ b/cloud/digital_ocean/digital_ocean_sshkey.py
@@ -28,12 +28,9 @@ options:
      - Indicate desired state of the target.
     default: present
     choices: ['present', 'absent']
-  client_id:
-     description:
-     - DigitalOcean manager id.
-  api_key:
+  api_token:
     description:
-     - DigitalOcean api key.
+     - DigitalOcean api token.
   id:
     description:
      - Numeric, the SSH key id you want to operate on.
@@ -45,8 +42,9 @@ options:
      - The public SSH key you want to add to your account.
 
 notes:
-  - Two environment variables can be used, DO_CLIENT_ID and DO_API_KEY.
-  - Version 1 of DigitalOcean API is used.
+  - Two environment variables can be used, DO_API_KEY and DO_API_TOKEN. They both refer to the v2 token.
+  - As of Ansible 2.0, Version 2 of the DigitalOcean API is used.
+  - As of Ansible 2.0, the above parameters were changed significantly. If you are running 1.9.x or earlier, please use C(ansible-doc digital_ocean_v2) to view the correct parameters for your version. Dedicated web docs will be available in the near future for the stable branch.
 requirements:
   - "python >= 2.6"
   - dopy
@@ -62,17 +60,20 @@ EXAMPLES = '''
       state=present
       name=my_ssh_key
       ssh_pub_key='ssh-rsa AAAA...'
-      client_id=XXX
-      api_key=XXX
+      api_token=XXX
 
 '''
 
 import os
 import time
+from distutils.version import LooseVersion
 
+HAS_DOPY = True
 try:
+    import dopy
     from dopy.manager import DoError, DoManager
-    HAS_DOPY = True
+    if LooseVersion(dopy.__version__) < LooseVersion('0.3.2'):
+        HAS_DOPY = False
 except ImportError:
     HAS_DOPY = False
 
@@ -97,8 +98,8 @@ class SSH(JsonfyMixIn):
         return True
 
     @classmethod
-    def setup(cls, client_id, api_key):
-        cls.manager = DoManager(client_id, api_key)
+    def setup(cls, api_token):
+        cls.manager = DoManager(None, api_token, api_version=2)
 
     @classmethod
     def find(cls, name):
@@ -128,16 +129,14 @@ def core(module):
         return v
 
     try:
-        # params['client_id'] will be None even if client_id is not passed in
-        client_id = module.params['client_id'] or os.environ['DO_CLIENT_ID']
-        api_key = module.params['api_key'] or os.environ['DO_API_KEY']
+        api_token = module.params['api_token'] or os.environ['DO_API_TOKEN'] or os.environ['DO_API_KEY']
     except KeyError, e:
         module.fail_json(msg='Unable to load %s' % e.message)
 
     changed = True
     state = module.params['state']
 
-    SSH.setup(client_id, api_key)
+    SSH.setup(api_token)
     name = getkeyordie('name')
     if state in ('present'):
         key = SSH.find(name)
@@ -157,8 +156,7 @@ def main():
     module = AnsibleModule(
         argument_spec = dict(
             state = dict(choices=['present', 'absent'], default='present'),
-            client_id = dict(aliases=['CLIENT_ID'], no_log=True),
-            api_key = dict(aliases=['API_KEY'], no_log=True),
+            api_token = dict(aliases=['API_TOKEN'], no_log=True),
             name = dict(type='str'),
             id = dict(aliases=['droplet_id'], type='int'),
             ssh_pub_key = dict(type='str'),


### PR DESCRIPTION
 @zyegfryed     zyegfryed   Add DigitalOcean API v2 support for SSH keys and Domains management  
b0126fd
Commits on Aug 22, 2015
    @connorfinnerty     connorfinnerty  Digital Ocean APIv2 uses domain name instead of id
