### PR TITLE
Add optional 'spot_launch_group' parameter to ec2 module

### DIFF
--- a/cloud/amazon/ec2.py
+++ b/cloud/amazon/ec2.py
@@ -247,6 +247,13 @@ options:
     required: false
     default: null
     aliases: ['network_interface']
+  spot_launch_group:
+    version_added: "2.0"
+    description:
+      - Launch group for spot request, see U(http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/how-spot-instances-work.html#spot-launch-group)
+    required: false
+    default: null
+    aliases: []
 
 author:
     - "Tim Gerla (@tgerla)"
@@ -358,6 +365,7 @@ EXAMPLES = '''
     wait: yes
     vpc_subnet_id: subnet-29e63245
     assign_public_ip: yes
+    spot_launch_group: report_generators
 
 # Examples using pre-existing network interfaces
 - ec2:
@@ -860,6 +868,7 @@ def create_instances(module, ec2, vpc, override_count=None):
     source_dest_check = module.boolean(module.params.get('source_dest_check'))
     termination_protection = module.boolean(module.params.get('termination_protection'))
     network_interfaces = module.params.get('network_interfaces')
+    spot_launch_group = module.params.get('spot_launch_group')
 
     # group_id and group_name are exclusive of each other
     if group_id and group_name:
@@ -1041,6 +1050,9 @@ def create_instances(module, ec2, vpc, override_count=None):
                 elif placement_group :
                         module.fail_json(
                             msg="placement_group parameter requires Boto version 2.3.0 or higher.")
+
+                if spot_launch_group and isinstance(spot_launch_group, basestring):
+                    params['launch_group'] = spot_launch_group
 
                 params.update(dict(
                     count = count_remaining,
@@ -1310,6 +1322,7 @@ def main():
             instance_type = dict(aliases=['type']),
             spot_price = dict(),
             spot_type = dict(default='one-time', choices=["one-time", "persistent"]),
+            spot_launch_group = dict(),
             image = dict(),
             kernel = dict(),
             count = dict(type='int', default='1'),


### PR DESCRIPTION
This allows instances to be placed into a specific launch group:

```
«Specify a launch group in your Spot instance request to tell Amazon
EC2 to launch a set of Spot instances only if it can launch them
all. In addition, if the Spot service must terminate one of the
instances in a launch group (for example, if the Spot price rises
above your bid price), it must terminate them all.»
```

Patch by Pavan Deolasee (@pavanvd).
