### PR TITLE
mark failed async_status as finished

### DIFF
--- a/utilities/logic/async_status.py
+++ b/utilities/logic/async_status.py
@@ -66,7 +66,7 @@ def main():
     log_path = os.path.join(logdir, jid)
 
     if not os.path.exists(log_path):
-        module.fail_json(msg="could not find job", ansible_job_id=jid)
+        module.fail_json(msg="could not find job", ansible_job_id=jid, started=1, finished=1)
 
     if mode == 'cleanup':
         os.unlink(log_path)
@@ -85,7 +85,7 @@ def main():
             module.exit_json(results_file=log_path, ansible_job_id=jid, started=1, finished=0)
         else:
             module.fail_json(ansible_job_id=jid, results_file=log_path,
-                msg="Could not parse job output: %s" % data)
+                msg="Could not parse job output: %s" % data, started=1, finished=1)
 
     if not 'started' in data:
         data['finished'] = 1


### PR DESCRIPTION
Running async_status in an "until: result.finished" loop will mask a module failure (eg, traceback) with a
template failure, because the fail dict doesn't include "finished" (eg, you'll see "ERROR! The conditional check 'bogus_out.finished' failed. The error was: ERROR! error while evaluating conditional: bogus_out.finished ({% if bogus_out.finished %} True {% else %} False {% endif %}") instead of the traceback from the module. Because the failure dict still includes "failed: true",
this change has no effect on stoppage/failure reporting, it just prevents the common usage pattern from masking the underlying error message.
