### PR TITLE
Change always convert identifier_in to string

### DIFF
--- a/cloud/amazon/route53.py
+++ b/cloud/amazon/route53.py
@@ -391,7 +391,10 @@ def main():
         #Need to save this changes in rset, because of comparing rset.to_xml() == wanted_rset.to_xml() in next block
 	rset.name = decoded_name
 
-        if rset.type == type_in and decoded_name.lower() == record_in.lower() and rset.identifier == str(identifier_in):
+	if identifier_in is not None:
+            identifier_in = str(identifier_in)
+	
+        if rset.type == type_in and decoded_name.lower() == record_in.lower() and rset.identifier == identifier_in:
             found_record = True
             record['zone'] = zone_in
             record['type'] = rset.type


### PR DESCRIPTION
Because it breaks behaviour for all tasks without identifier_in. 
In this cases obviously `None !=str(None)`, but we want to match already existing DNS records with unset identifier with requests without identifier.
