### PR TITLE
Fix copy with the remote_src option

### DIFF
--- a/files/copy.py
+++ b/files/copy.py
@@ -310,7 +310,7 @@ def main():
                 if rc != 0:
                     module.fail_json(msg="failed to validate: rc:%s error:%s" % (rc,err))
             if remote_src:
-                tmpdest = tempfile.mkstemp(dir=os.basedir(dest))
+                _, tmpdest = tempfile.mkstemp(dir=os.path.dirname(dest))
                 shutil.copy2(src, tmpdest)
                 module.atomic_move(tmpdest, dest)
             else:


### PR DESCRIPTION
It was broken in 6e37f1dcef0 when the `remote_src` was added. 
`os.basedir` doesn't seem to exist and `shutil.copy2` expects a path instead of a tuple.

Not sure if this is related to a specific python version? I'm using Python 2.7.10
I'm not a python developer and I'm new to ansible, but this is what I did to get it to work for me.

Otherwise I got this error:

```
AttributeError: 'module' object has no attribute 'basedir'
```
