### PR TITLE
Fixed error message: TypeError: fail_json() takes exactly 1 argument …

### DIFF
--- a/cloud/amazon/iam_policy.py
+++ b/cloud/amazon/iam_policy.py
@@ -188,7 +188,7 @@ def role_action(module, iam, name, policy_name, skip, pdoc, state):
       # Role doesn't exist so it's safe to assume the policy doesn't either
       module.exit_json(changed=False)
     else:
-      module.fail_json(e.message)
+      module.fail_json(msg=e.message)
       
   try:    
     for pol in current_policies:


### PR DESCRIPTION
Missing msg=xxxxx argument causing the following error:

task path: /home/ec2-user/jenkins/bill/fabric_ansible/roles/log_subscriptions/tasks/main.yml:20
ESTABLISH LOCAL CONNECTION FOR USER: root
localhost EXEC (umask 22 && mkdir -p "`echo $HOME/.ansible/tmp/ansible-tmp-1447875684.38-192970896958776`" && echo "`echo $HOME/.ansible/tmp/ansible-tmp-1447875684.38-192970896958776`")
localhost PUT /tmp/tmpaWIbSU TO /root/.ansible/tmp/ansible-tmp-1447875684.38-192970896958776/iam_policy
localhost EXEC LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/python /root/.ansible/tmp/ansible-tmp-1447875684.38-192970896958776/iam_policy
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-tmp-1447875684.38-192970896958776/iam_policy", line 2479, in <module>
    main()
  File "/root/.ansible/tmp/ansible-tmp-1447875684.38-192970896958776/iam_policy", line 336, in main
    state)
  File "/root/.ansible/tmp/ansible-tmp-1447875684.38-192970896958776/iam_policy", line 192, in role_action
    module.fail_json(e.message)
TypeError: fail_json() takes exactly 1 argument (2 given)

fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "invocation": {"module_args": {"iam_name": "LambdaSubscriptionFilter", "iam_type": "role", "policy_name": "LambdaSubscriptionFilter", "state": "absent"}, "module_name": "iam_policy"}, "parsed": false}
