### PR TITLE
Py2.4: SystemExit in async_wrapper is not an error - compatibility fix

### DIFF
--- a/utilities/logic/async_wrapper.py
+++ b/utilities/logic/async_wrapper.py
@@ -199,6 +199,11 @@ if __name__ == '__main__':
                 notice("Module complete (%s)"%os.getpid())
                 sys.exit(0)
 
+    except SystemExit:
+        e = get_exception()
+        if e.code != 0:
+            raise
+
     except Exception:
         e = get_exception()
         notice("error: %s"%(e))


### PR DESCRIPTION
#### Symptoms

Integration tests are failing on Py2.4 with..

```
fatal: [testhost]: FAILED! => {"changed": false, "failed": true, "msg": "The async task did not return valid JSON: Extra data: line 2 column 1 - line 5 column 1 (char 109 - 229)"}
```

If you execute the module manually..

```
# python2.4 /root/.ansible/tmp/ansible-tmp-1448009570.28-345403177685/async_wrapper 724759715815 60 /root/.ansible/tmp/ansible-tmp-1448009570.28-345403177685/command /root/.ansible/tmp/ansible-tmp-1448009570.28-345403177685/arguments
{"started":1, "results_file":"/root/.ansible_async/724759715815.3299", "ansible_job_id":"724759715815.3299"}
{"msg":"FATAL ERROR: 0", "failed":true}
{"msg":"FATAL ERROR: 0", "failed":true}
{"msg":"FATAL ERROR: 0", "failed":true}
```

Whereas on Python 2.5+

```
# python2.5 /root/.ansible/tmp/ansible-tmp-1448009570.28-345403177685/async_wrapper 724759715815 60 /root/.ansible/tmp/ansible-tmp-1448009570.28-345403177685/command /root/.ansible/tmp/ansible-tmp-1448009570.28-345403177685/arguments
{"started": 1, "results_file": "/root/.ansible_async/724759715815.3307", "ansible_job_id": "724759715815.3307"}
```
#### Root cause

```
$ python2.4 -c 'print(issubclass(SystemExit, Exception))'
True
$ python2.5 -c 'print(issubclass(SystemExit, Exception))'
False
```
#### Fix

Exclude SystemExit from try/catch-all
#### Note for the reviewer

Potentially,

```
try:
    sys.exit(1)
except SystemExit:
    pass
```

would turn retcode 1 into 0. Re-raise is there for the (unlikely) case when daemonizing fails on fork(), for example. Re-raise would preserve the return code.
