### PR TITLE
Fix quote on grants of more than one word

### DIFF
--- a/database/mysql/mysql_user.py
+++ b/database/mysql/mysql_user.py
@@ -137,7 +137,7 @@ EXAMPLES = """
 - mysql_user: login_user=root login_password=123456 name=sally state=absent
 
 # Specify grants composed of more than one word
-- mysql_user: name=replication password=12345 priv=*.*:"REPLICATION CLIENT" state=present
+- mysql_user: name=replication password=12345 priv="*.*:REPLICATION CLIENT" state=present
 
 # Revoke all privileges for user 'bob' and password '12345' 
 - mysql_user: name=bob password=12345 priv=*.*:USAGE state=present


### PR DESCRIPTION
Fixed a quote location on the grants composed of more than one word. Current docs will raise an error with a invalid privilege command.
