### PR TITLE
docker: Fix state=reloaded to detect default LoggingDriver for docker

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -1017,6 +1017,7 @@ class DockerManager(object):
 
         running = self.get_running_containers()
         current = self.get_inspect_containers(running)
+        defaults = self.client.info()
 
         #Get API version
         api_version = self.client.version()['ApiVersion']
@@ -1288,7 +1289,7 @@ class DockerManager(object):
             # LOG_DRIVER
 
             if self.ensure_capability('log_driver', False):
-                expected_log_driver = self.module.params.get('log_driver') or 'json-file'
+                expected_log_driver = self.module.params.get('log_driver') or defaults['LoggingDriver']
                 actual_log_driver = container['HostConfig']['LogConfig']['Type']
                 if actual_log_driver != expected_log_driver:
                     self.reload_reasons.append('log_driver ({0} => {1})'.format(actual_log_driver, expected_log_driver))


### PR DESCRIPTION
Previously the logging module hard coded the default logging driver. This means if the docker daemon is started with a different logging driver, the ansible module would continually restart it when run.

This fix adds a call to docker.Client.info(), which is inspected if a logging driver is not supplied in the playbook, and the container only restarted if the logging driver applied differs from the configured default.

In usage, this has solved issues with using alternative logging drivers.

Closes #2479.
