### PR TITLE
hg: discard changes without changing the current revision

### DIFF
--- a/source_control/hg.py
+++ b/source_control/hg.py
@@ -137,9 +137,7 @@ class Hg(object):
         if not before:
             return False
 
-        args = ['update', '-C', '-R', self.dest]
-        if self.revision is not None:
-            args = args + ['-r', self.revision]
+        args = ['update', '-C', '-R', self.dest, '-r', '.']
         (rc, out, err) = self._command(args)
         if rc != 0:
             self.module.fail_json(msg=err)


### PR DESCRIPTION
hg: discard changes without changing the current revision

The command `hg up -C` by default moves to the latest revision on the
current branch. The `discard` function was trying to update to a
different branch, in case it was provided, by passing a `-r REVISION`
argument. Not only is this not the intended effect of the `discard`
function, but this also could update to a different branch that hasn't
been pulled yet, which is how we were experiencing trouble.

Instead, we unconditionally do `hg up -C -r .` to "update" to the
current revision (i.e. to "."), while `-C/--clean`ing the current
directory. This is similar to `hg revert --all`, except that it also
undoes the merge state of the working directory, in case there was
any.
