### PR TITLE
Update ec2.py remove state tag

### DIFF
--- a/cloud/amazon/ec2.py
+++ b/cloud/amazon/ec2.py
@@ -488,7 +488,6 @@ EXAMPLES = '''
 #
 
 - ec2:
-    state: running
     key_name: mykey
     instance_type: c1.medium
     image: ami-40603AD1
@@ -506,7 +505,6 @@ EXAMPLES = '''
 #
 
 - ec2:
-    state: running
     key_name: mykey
     instance_type: c1.medium
     image: ami-40603AD1


### PR DESCRIPTION
 'exact_count' and 'state' are mutually exclusive options they should not be in the following examples:
- # Enforce that 5 running instances named "database" with a "dbtype" of "postgres" example and 
- # Enforce that 5 instances with a tag "foo" are running
