### PR TITLE
Fix ec2_snapshot documentation

### DIFF
--- a/cloud/amazon/ec2_snapshot.py
+++ b/cloud/amazon/ec2_snapshot.py
@@ -74,7 +74,7 @@ options:
       - If the volume's most recent snapshot has started less than `last_snapshot_min_age' minutes ago, a new snapshot will not be created.
     required: false
     default: 0
-    version_added: "1.9"
+    version_added: "2.0"
 
 author: "Will Thames (@willthames)"
 extends_documentation_fragment:


### PR DESCRIPTION
last_snapshot_min_age is added in 2.0, not 1.9

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ansible/ansible-modules-core/2546)

<!-- Reviewable:end -->
