### PR TITLE
Update the documentation of the 'apt' action for the 'name'.

### DIFF
--- a/packaging/os/apt.py
+++ b/packaging/os/apt.py
@@ -32,6 +32,7 @@ options:
       - A package name, like C(foo), or package specifier with version, like C(foo=1.0). Name wildcards (fnmatch) like C(apt*) and version wildcards like C(foo=1.0*) are also supported.  Note that the apt-get commandline supports implicit regex matches here but we do not because it can let typos through easier (If you typo C(foo) as C(fo) apt-get would install packages that have "fo" in their name with a warning and a prompt for the user.  Since we don't have warnings and prompts before installing we disallow this.  Use an explicit fnmatch pattern if you want wildcarding)
     required: false
     default: null
+    aliases: [ 'pkg', 'package' ]
   state:
     description:
       - Indicates the desired package state. C(latest) ensures that the latest version is installed. C(build-dep) ensures the package build dependencies are installed.


### PR DESCRIPTION
The package name has two aliases, 'package' and 'pkg'. Add them to the
documentation.
