### PR TITLE
Fix for 13315 - minute now included in ansible_date_time on windows hosts

### DIFF
--- a/windows/setup.ps1
+++ b/windows/setup.ps1
@@ -68,6 +68,7 @@ Set-Attr $date "year" (Get-Date -format yyyy)
 Set-Attr $date "month" (Get-Date -format MM)
 Set-Attr $date "day" (Get-Date -format dd)
 Set-Attr $date "hour" (Get-Date -format HH)
+Set-Attr $date "minute" (Get-Date -format mm)
 Set-Attr $date "iso8601" (Get-Date -format s)
 Set-Attr $result.ansible_facts "ansible_date_time" $date
 


### PR DESCRIPTION
Ran the test_win_setup integration tests against windows server 2008 r2 and windows server 2012 r2 succesfully.
