### PR TITLE
fix problem with file content and high cpu/out of memory errors

### DIFF
--- a/windows/win_msi.ps1
+++ b/windows/win_msi.ps1
@@ -47,7 +47,7 @@ Else
 
 Set-Attr $result "changed" $true;
 
-$logcontents = Get-Content $logfile;
+$logcontents = Get-Content $logfile | Out-String;
 Remove-Item $logfile;
 
 Set-Attr $result "log" $logcontents;


### PR DESCRIPTION
fix problem with file content and high cpu/out of memory errors. i took a look and the reason is some weird stuff with ConvertTo-Json and the depth of 99. the user can still fetch the file and examine it. fixxes https://github.com/ansible/ansible-modules-core/issues/2330
