### PR TITLE
vsphere_guest: support putting a guest into a nested folder

### DIFF
--- a/cloud/vmware/vsphere_guest.py
+++ b/cloud/vmware/vsphere_guest.py
@@ -175,6 +175,10 @@ EXAMPLES = '''
         size_gb: 10
         type: thin
         datastore: storage001
+        # VMs can be put into folders. The value given here is either the full path
+        # to the folder (e.g. production/customerA/lamp) or just the last component
+        # of the path (e.g. lamp):
+        folder: production/customerA/lamp
     vm_nic:
       nic1:
         type: vmxnet3
@@ -915,6 +919,48 @@ def reconfigure_net(vsphere_client, vm, module, esxi, resource_pool, guest, vm_n
         elif len(nics) == 0:
             return(False)
 
+
+def _build_folder_tree(nodes, parent):
+    tree = {}
+
+    for node in nodes:
+        if node['parent'] == parent:
+            tree[node['name']] = dict.copy(node)
+            tree[node['name']]['subfolders'] = _build_folder_tree(nodes, node['id'])
+            del tree[node['name']]['parent']
+
+    return tree
+
+
+def _find_path_in_tree(tree, path):
+    for name, o in tree.iteritems():
+        if name == path[0]:
+            if len(path) == 1:
+                return o
+            else:
+                return _find_path_in_tree(o['subfolders'], path[1:])
+
+    return None
+
+
+def _get_folderid_for_path(vsphere_client, datacenter, path):
+    content = vsphere_client._retrieve_properties_traversal(property_names=['name', 'parent'], obj_type=MORTypes.Folder)
+    if not content: return {}
+
+    node_list = [
+        {
+            'id': o.Obj,
+            'name': o.PropSet[0].Val,
+            'parent': (o.PropSet[1].Val if len(o.PropSet) > 1 else None)
+        } for o in content
+    ]
+
+    tree = _build_folder_tree(node_list, datacenter)
+    tree = _find_path_in_tree(tree, ['vm'])['subfolders']
+    folder = _find_path_in_tree(tree, path.split('/'))
+    return folder['id'] if folder else None
+
+
 def create_vm(vsphere_client, module, esxi, resource_pool, cluster_name, guest, vm_extra_config, vm_hardware, vm_disk, vm_nic, vm_hw_version, state):
 
     datacenter = esxi['datacenter']
@@ -935,13 +981,19 @@ def create_vm(vsphere_client, module, esxi, resource_pool, cluster_name, guest, 
 
     # virtualmachineFolder managed object reference
     if vm_extra_config.get('folder'):
-        if vm_extra_config['folder'] not in vsphere_client._get_managed_objects(MORTypes.Folder).values():
+        # try to find the folder by its full path, e.g. 'production/customerA/lamp'
+        vmfmor = _get_folderid_for_path(vsphere_client, dcmor, vm_extra_config.get('folder'))
+
+        # try the legacy behaviour of just matching the folder name, so 'lamp' alone matches 'production/customerA/lamp'
+        if vmfmor is None:
+            for mor, name in vsphere_client._get_managed_objects(MORTypes.Folder).iteritems():
+                if name == vm_extra_config['folder']:
+                    vmfmor = mor
+
+        # if neither of strategies worked, bail out
+        if vmfmor is None:
             vsphere_client.disconnect()
             module.fail_json(msg="Cannot find folder named: %s" % vm_extra_config['folder'])
-
-        for mor, name in vsphere_client._get_managed_objects(MORTypes.Folder).iteritems():
-            if name == vm_extra_config['folder']:
-                vmfmor = mor
     else:
         vmfmor = dcprops.vmFolder._obj
 


### PR DESCRIPTION
## current situation

Assume the following folder structure:
- test
  - developer1
    - productC
- prod
  - customerA
  - customerB

Currently the `vm_extra_config.folder` parameter does the following:
1. vsphere_guest constructs a flat list like this: `test, developer1, productC, prod, customerA, customerB`.
2. the last entry matching `vm_extra_config.folder` in this list is used as folder

It is not possible to give a nested path like `prod/customerA`. Instead you'd give `customerA` and hope, that this name is never duplicated.
## this PR

This PR allows to give a full path to the folder, like `prod/customerB`. This is done by reconstructing the whole folder-tree in the background, then finding the proper folder, according to the path and using that.

Please consider that this is a breaking change, since just supplying `customerB` won't yield the same result as before, but an error. Supplying a top-level folder like `prod` will still work like before. Since I wasn't able to find anything in the [contributor guidelines](http://docs.ansible.com/ansible/community.html) regarding breaking changes, I guess we have the following ways to go about this:
- just merge it and let it break
- fallback to the old behavior, when the folder could not be found, then error
- add a 2nd parameter, `folder_path`, which uses the new behavior. The current parameter `folder` would behave the same, as to does now.

Just tell me which you'd prefer and I'll update this PR accordingly.

Please also note that the current behavior doesn't seem to be documented anywhere. Once you decided how we will go about this, I'll add the documentation.
