### PR TITLE
Removed unneccessary permission greed

### DIFF
--- a/cloud/openstack/_quantum_network.py
+++ b/cloud/openstack/_quantum_network.py
@@ -164,17 +164,16 @@ def _get_neutron_client(module, kwargs):
 def _set_tenant_id(module):
     global _os_tenant_id
     if not module.params['tenant_name']:
-        tenant_name = module.params['login_tenant_name']
+        _os_tenant_id = _os_keystone.tenant_id
     else:
         tenant_name = module.params['tenant_name']
 
-    for tenant in _os_keystone.tenants.list():
-        if tenant.name == tenant_name:
-            _os_tenant_id = tenant.id
-            break
+        for tenant in _os_keystone.tenants.list():
+            if tenant.name == tenant_name:
+                _os_tenant_id = tenant.id
+                break
     if not _os_tenant_id:
         module.fail_json(msg = "The tenant id cannot be found, please check the parameters")
-
 
 def _get_net_id(neutron, module):
     kwargs = {

--- a/cloud/openstack/_quantum_router.py
+++ b/cloud/openstack/_quantum_router.py
@@ -136,17 +136,16 @@ def _get_neutron_client(module, kwargs):
 def _set_tenant_id(module):
     global _os_tenant_id
     if not module.params['tenant_name']:
-        login_tenant_name = module.params['login_tenant_name']
+        _os_tenant_id = _os_keystone.tenant_id
     else:
-        login_tenant_name = module.params['tenant_name']
+        tenant_name = module.params['tenant_name']
 
-    for tenant in _os_keystone.tenants.list():
-        if tenant.name == login_tenant_name:
-            _os_tenant_id = tenant.id
-            break
+        for tenant in _os_keystone.tenants.list():
+            if tenant.name == tenant_name:
+                _os_tenant_id = tenant.id
+                break
     if not _os_tenant_id:
-            module.fail_json(msg = "The tenant id cannot be found, please check the parameters")
-
+        module.fail_json(msg = "The tenant id cannot be found, please check the parameters")
 
 def _get_router_id(module, neutron):
     kwargs = {

--- a/cloud/openstack/_quantum_router_interface.py
+++ b/cloud/openstack/_quantum_router_interface.py
@@ -138,17 +138,16 @@ def _get_neutron_client(module, kwargs):
 def _set_tenant_id(module):
     global _os_tenant_id
     if not module.params['tenant_name']:
-        login_tenant_name = module.params['login_tenant_name']
+        _os_tenant_id = _os_keystone.tenant_id
     else:
-        login_tenant_name = module.params['tenant_name']
+        tenant_name = module.params['tenant_name']
 
-    for tenant in _os_keystone.tenants.list():
-        if tenant.name == login_tenant_name:
-            _os_tenant_id = tenant.id
-            break
+        for tenant in _os_keystone.tenants.list():
+            if tenant.name == tenant_name:
+                _os_tenant_id = tenant.id
+                break
     if not _os_tenant_id:
         module.fail_json(msg = "The tenant id cannot be found, please check the parameters")
-
 
 def _get_router_id(module, neutron):
     kwargs = {

--- a/cloud/openstack/_quantum_subnet.py
+++ b/cloud/openstack/_quantum_subnet.py
@@ -170,16 +170,16 @@ def _get_neutron_client(module, kwargs):
 def _set_tenant_id(module):
     global _os_tenant_id
     if not module.params['tenant_name']:
-        tenant_name = module.params['login_tenant_name']
+        _os_tenant_id = _os_keystone.tenant_id
     else:
         tenant_name = module.params['tenant_name']
 
-    for tenant in _os_keystone.tenants.list():
-        if tenant.name == tenant_name:
-            _os_tenant_id = tenant.id
-            break
+        for tenant in _os_keystone.tenants.list():
+            if tenant.name == tenant_name:
+                _os_tenant_id = tenant.id
+                break
     if not _os_tenant_id:
-            module.fail_json(msg = "The tenant id cannot be found, please check the parameters")
+        module.fail_json(msg = "The tenant id cannot be found, please check the parameters")
 
 def _get_net_id(neutron, module):
     kwargs = {


### PR DESCRIPTION
Commit message:
"fixed quantum_ modules to work with minimum access rights if greater access rights are not needed"

The quantum modules should not require tenant listing permissions when they do not need to list tenants. This upgrade removes the need for that when target tenant name is not explicitly provided. Instead, tenant id that is already acquired by keystone during authentication is used.
