### PR TITLE
Update documentation for 'file' module to include 'diff_peek'.

### DIFF
--- a/files/file.py
+++ b/files/file.py
@@ -87,6 +87,12 @@ options:
       - 'force the creation of the symlinks in two cases: the source file does
         not exist (but will appear later); the destination exists and is a file (so, we need to unlink the
         "path" file and create symlink to the "src" file in place of it).'
+  diff_peek:
+    required: false
+    description:
+      - "Only check whether the file looks like binary. Returns with the parameter
+         'appears_binary' set to True or False depending on the initial content of the
+         file. This option is enabled when the option is set (to any value)."
 '''
 
 EXAMPLES = '''
@@ -158,7 +164,6 @@ def main():
             recurse  = dict(default=False, type='bool'),
             force = dict(required=False, default=False, type='bool'),
             diff_peek = dict(default=None),
-            validate = dict(required=False, default=None),
             src = dict(required=False, default=None),
         ),
         add_file_common_args=True,

--- a/files/file.py
+++ b/files/file.py
@@ -87,12 +87,6 @@ options:
       - 'force the creation of the symlinks in two cases: the source file does
         not exist (but will appear later); the destination exists and is a file (so, we need to unlink the
         "path" file and create symlink to the "src" file in place of it).'
-  diff_peek:
-    required: false
-    description:
-      - "Only check whether the file looks like binary. Returns with the parameter
-         'appears_binary' set to True or False depending on the initial content of the
-         file. This option is enabled when the option is set (to any value)."
 '''
 
 EXAMPLES = '''
@@ -163,7 +157,8 @@ def main():
             original_basename = dict(required=False), # Internal use only, for recursive ops
             recurse  = dict(default=False, type='bool'),
             force = dict(required=False, default=False, type='bool'),
-            diff_peek = dict(default=None),
+            diff_peek = dict(default=None), # Internal use only, for internal checks in the action plugins
+            validate = dict(required=False, default=None), # Internal use only, for template and copy
             src = dict(required=False, default=None),
         ),
         add_file_common_args=True,


### PR DESCRIPTION
diff_peek and validate are options that are for internal use - they shouldn't be used by end users.
So we document them in the code as such.
