### PR TITLE
win_lineinfile: acl fix

### DIFF
--- a/windows/win_lineinfile.ps1
+++ b/windows/win_lineinfile.ps1
@@ -96,7 +96,8 @@ function WriteLines($outlines, $dest, $linesep, $encodingobj, $validate) {
 	
 	# Commit changes to the destination file
 	$cleandest = $dest.Replace("/", "\");
-	Move-Item $temppath $cleandest -force;	
+	Copy-Item $temppath $cleandest -force;	
+	Remove-Item $temppath -force;
 }
 
 


### PR DESCRIPTION
if i'm using win_lineinfile, a temporary file will be created and moved after changes have been detected.
if move is used, the acl wont be kept of the original file. instead use copy
