### PR TITLE
Fix 'stat' module document

### DIFF
--- a/files/stat.py
+++ b/files/stat.py
@@ -111,7 +111,7 @@ stat:
         path:
             description: The full path of the file/object to get the facts of
             returned: success and if path exists
-            type: boolean
+            type: string
             sample: '/path/to/file'
         mode:
             description: Unix permissions of the file in octal


### PR DESCRIPTION
'path' field returned by 'stat' is a 'string' type.
