### PR TITLE
Fixed typo in uri module example

### DIFF
--- a/network/basics/uri.py
+++ b/network/basics/uri.py
@@ -159,7 +159,7 @@ EXAMPLES = '''
   register: webpage
 
 - action: fail
-  when: "'illustrative' not in webpage.content"
+  when: "'AWESOME' not in webpage.content"
 
 
 # Create a JIRA issue


### PR DESCRIPTION
Example does not function as described
