### PR TITLE
fix: don't set scopes' account to service account used for gce instance creation

### DIFF
--- a/cloud/google/gce.py
+++ b/cloud/google/gce.py
@@ -64,7 +64,7 @@ options:
     default: null
     choices: [
       "bigquery", "cloud-platform", "compute-ro", "compute-rw",
-      "computeaccounts-ro", "computeaccounts-rw", "datastore", "logging-write",
+      "useraccounts-ro", "useraccounts-rw", "datastore", "logging-write",
       "monitoring", "sql", "sql-admin", "storage-full", "storage-ro",
       "storage-rw", "taskqueue", "userinfo-email"
     ]
@@ -351,10 +351,7 @@ def create_instances(module, gce, instance_names):
                 bad_perms.append(perm)
         if len(bad_perms) > 0:
             module.fail_json(msg='bad permissions: %s' % str(bad_perms))
-        if service_account_email:
-            ex_sa_perms.append({'email': service_account_email})
-        else:
-            ex_sa_perms.append({'email': "default"})
+        ex_sa_perms.append({'email': "default"})
         ex_sa_perms[0]['scopes'] = service_account_permissions
 
     # These variables all have default values but check just in case


### PR DESCRIPTION
Hello, this is a fix for [issue 2595](https://github.com/ansible/ansible-modules-core/issues/2595) I reported earlier this week.

To be honest I am not comfortable with this pull request since I have neither python nor libcloud experience.
I can only say that it works for me on a clean environment.

Thus I open this PR in hope it will make easier for the maintainers to have a look at the issue.
