### PR TITLE
Remove 'cache_table' from required params

### DIFF
--- a/web_infrastructure/django_manage.py
+++ b/web_infrastructure/django_manage.py
@@ -183,7 +183,6 @@ def main():
 
     command_required_param_map = dict(
         loaddata=('fixtures', ),
-        createcachetable=('cache_table', ),
         )
 
     # forces --noinput on every command that needs it


### PR DESCRIPTION
Starting in Django 1.7, the createcachetable command looks for cache
table names in the CACHES settings dictionary, so cache_table is no
longer required, but is still allowed.
