### PR TITLE
Also show stdout when validation fails. This fixes #2498

### DIFF
--- a/files/copy.py
+++ b/files/copy.py
@@ -279,7 +279,7 @@ def main():
                 # os.path.exists() can return false in some
                 # circumstances where the directory does not have
                 # the execute bit for the current user set, in
-                # which case the stat() call will raise an OSError 
+                # which case the stat() call will raise an OSError
                 os.stat(os.path.dirname(dest))
             except OSError, e:
                 if "permission denied" in str(e).lower():
@@ -308,7 +308,7 @@ def main():
                     module.fail_json(msg="validate must contain %%s: %s" % (validate))
                 (rc,out,err) = module.run_command(validate % src)
                 if rc != 0:
-                    module.fail_json(msg="failed to validate: rc:%s error:%s" % (rc,err))
+                    module.fail_json(msg="failed to validate", exit_status=rc, stdout=out, stderr=err)
             if remote_src:
                 _, tmpdest = tempfile.mkstemp(dir=os.path.dirname(dest))
                 shutil.copy2(src, tmpdest)


### PR DESCRIPTION
I created a PR for this issue previously (#1238), but it was based on an older version of the source and created a merge conflict. This PR will fix #2498.

With this change, exit status, standard output and standard error is shown when validation fails. Instead of a single string `msg`, they are now included separately in the JSON response, as per @bcoca 's [suggestion](https://github.com/ansible/ansible-modules-core/pull/1238#discussion_r33889810).

Example (from https://github.com/bertvv/ansible-role-bind):

``` Yaml
- name: Main BIND config file (master)
  template:
    src: master_etc_named.conf.j2
    dest: /etc/named.conf
    owner: root
    group: named
    mode: '0640'
    setype: named_conf_t
    validate: 'named-checkconf %s'
  notify: restart bind
  tags: bind
```

with an error introduced into the template file yields:

``` JSON
fatal: [testbindmaster]: FAILED! => {"changed": true, "exit_status": 1, "failed": true, "msg": "failed to validate", "stderr": "", "stdout": "/home/vagrant/.ansible/tmp/ansible-tmp-1449577420.8-70744375518285/source:29: unknown option 'this'\n", "stdout_lines": ["/home/vagrant/.ansible/tmp/ansible-tmp-1449577420.8-70744375518285/source:29: unknown option 'this'"]}
```
