### PR TITLE
verify both tags and commits

### DIFF
--- a/source_control/git.py
+++ b/source_control/git.py
@@ -635,7 +635,11 @@ def switch_version(git_path, module, dest, remote, version, verify_commit):
 
 
 def verify_commit_sign(git_path, module, dest, version):
-    cmd = "%s verify-commit %s" % (git_path, version)
+    if version in get_tags(git_path, module, dest):
+        git_sub = "verify-tag"
+    else:
+        git_sub = "verify-commit"
+    cmd = "%s %s %s" % (git_path, git_sub, version)
     (rc, out, err) = module.run_command(cmd, cwd=dest)
     if rc != 0:
         module.fail_json(msg='Failed to verify GPG signature of commit/tag "%s"' % version)


### PR DESCRIPTION
This fixes a bug where the module fails to verify tags.  I added a conditional statement in `verify_commit_sign()` that checks if `version` argument is a tag, if so, use `git verify-tag` instead.
