### PR TITLE
Set the argument type for ec2_vol's encrypted parameter

### DIFF
--- a/cloud/amazon/ec2_vol.py
+++ b/cloud/amazon/ec2_vol.py
@@ -379,7 +379,7 @@ def main():
             volume_size = dict(),
             volume_type = dict(choices=['standard', 'gp2', 'io1'], default='standard'),
             iops = dict(),
-            encrypted = dict(),
+            encrypted = dict(type='bool', default=False),
             device_name = dict(),
             zone = dict(aliases=['availability_zone', 'aws_zone', 'ec2_zone']),
             snapshot = dict(),


### PR DESCRIPTION
If this is not set, Ansible parses the parameter as a string.
This is fine if the parameter is not provided by the caller, but
if it is set to False or True explicitly, ec2_vol receives this as
the string 'False' or the string 'True', both of which are truthy.

Thus, without this fix, setting the parameter results in encryption
always enabled.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ansible/ansible-modules-core/2655)

<!-- Reviewable:end -->
