### PR TITLE
Fix yum module failing to initalize yum plugins

### DIFF
--- a/packaging/os/yum.py
+++ b/packaging/os/yum.py
@@ -195,6 +195,7 @@ def yum_base(conf_file=None):
     my = yum.YumBase()
     my.preconf.debuglevel=0
     my.preconf.errorlevel=0
+    my.preconf.plugins = True
     if conf_file and os.path.exists(conf_file):
         my.preconf.fn = conf_file
     if os.geteuid() != 0:


### PR DESCRIPTION
##### Bugfix Pull Request
##### Ansible Version:

```
ansible 1.9.4
```
##### Ansible Configuration:

N/A
##### Environment:

CentOS 6, likely all systems using Spacewalk or requiring yum plugins.
##### Summary:

When using disablerepo/enablerepo with Spacewalk/RHN channels one will get the incorrect error message: `Error setting/accessing repos: Error getting repository data for ..., repository not found`. This is caused by the module not correctly initializing the required rhn plugin.

See [YumBase object initialization](https://github.com/ansible/ansible-modules-core/blob/52321e35ef765b6988ac7f3258d03e4401724da8/packaging/os/yum.py#L178).

This was also reported in [ansible#10245](https://github.com/ansible/ansible/issues/10245). However, the developer was unable to replicate
because they did not test using channels only found in Spacewalk/RHN.
##### Steps To Reproduce:

```
$ ansible --sudo -i localhost, -v -m yum -a "disablerepo=* enablerepo=foo state=latest name=monkey" localhost
```
##### Expected Results:

```
<localhost> REMOTE_MODULE yum disablerepo=* enablerepo=foo state=latest name=monkey
localhost | FAILED >> {
    "changed": false,
    "failed": true,
    "msg": "No Package matching 'monkey' found available, installed or updated",
    "rc": 0,
    "results": []
}
```
##### Actual Results:

```
<localhost> REMOTE_MODULE yum disablerepo=* enablerepo=foo state=latest name=monkey
localhost | FAILED >> {
    "failed": true,
    "msg": "Error setting/accessing repos: Error getting repository data for foo, repository not found"
}
```
