### PR TITLE
Remove a unneeded use of use_unsafe_shell

### DIFF
--- a/system/hostname.py
+++ b/system/hostname.py
@@ -260,8 +260,8 @@ class SystemdStrategy(GenericStrategy):
                 (rc, out, err))
 
     def get_permanent_hostname(self):
-        cmd = 'hostnamectl --static status'
-        rc, out, err = self.module.run_command(cmd, use_unsafe_shell=True)
+        cmd = ['hostnamectl', '--static', 'status']
+        rc, out, err = self.module.run_command(cmd)
         if rc != 0:
             self.module.fail_json(msg="Command failed rc=%d, out=%s, err=%s" %
                 (rc, out, err))


### PR DESCRIPTION
Since use_unsafe_shell is suspicious from a security point
of view (or it wouldn't be unsafe), the less we have, the less
code we have to toroughly inspect for a security audit.
