### PR TITLE
Split a shell snippet in 2 to avoid using use_unsafe_shell=True

### DIFF
--- a/packaging/os/apt_repository.py
+++ b/packaging/os/apt_repository.py
@@ -106,7 +106,10 @@ def install_python_apt(module):
     if not module.check_mode:
         apt_get_path = module.get_bin_path('apt-get')
         if apt_get_path:
-            rc, so, se = module.run_command('%s update && %s install python-apt -y -q' % (apt_get_path, apt_get_path), use_unsafe_shell=True)
+            rc, so, se = module.run_command([apt_get_path, 'update'])
+            if rc != 0:
+                module.fail_json(msg="Failed to auto-install python-apt. Error was: '%s'" % se.strip())
+            rc, so, se = module.run_command([apt_get_path, 'install', 'python-apt', '-y', '-q'])
             if rc == 0:
                 global apt, apt_pkg, aptsources_distro, distro, HAVE_PYTHON_APT
                 import apt


### PR DESCRIPTION
Since use_unsafe_shell is suspicious from a security point
of view (or it wouldn't be unsafe), the less we have, the less
code we have to toroughly inspect for a security audit.

In this case, the '&&' can be replaced by doing 2 calls to run_command.
