### PR TITLE
Get new server object after adding floating IP

### DIFF
--- a/cloud/openstack/os_floating_ip.py
+++ b/cloud/openstack/os_floating_ip.py
@@ -154,7 +154,7 @@ def main():
                 msg="server {0} not found".format(server_name_or_id))
 
         if state == 'present':
-            cloud.add_ips_to_server(
+            server = cloud.add_ips_to_server(
                 server=server, ips=floating_ip_address, reuse=reuse,
                 fixed_address=fixed_address, wait=wait, timeout=timeout)
             fip_address = cloud.get_server_public_ip(server)


### PR DESCRIPTION
We need a new server object once we add the floating ip, otherwise we will be operating with the older server object pre-floating-ip assignment.
