### PR TITLE
added a reference to the template module for clarity

### DIFF
--- a/files/copy.py
+++ b/files/copy.py
@@ -27,7 +27,7 @@ module: copy
 version_added: "historical"
 short_description: Copies files to remote locations.
 description:
-     - The M(copy) module copies a file on the local box to remote locations. Use the M(fetch) module to copy files from remote locations to the local box.
+     - The M(copy) module copies a file on the local box to remote locations. Use the M(fetch) module to copy files from remote locations to the local box. If you need variable interpolation in copied files, use the M(template) module.
 options:
   src:
     description:


### PR DESCRIPTION
The current documentation for the copy module does not include any reference to the template module, and it should.
