### PR TITLE
Pass network argument to add_ips_to_server

### DIFF
--- a/cloud/openstack/os_floating_ip.py
+++ b/cloud/openstack/os_floating_ip.py
@@ -155,8 +155,9 @@ def main():
 
         if state == 'present':
             server = cloud.add_ips_to_server(
-                server=server, ips=floating_ip_address, reuse=reuse,
-                fixed_address=fixed_address, wait=wait, timeout=timeout)
+                server=server, ips=floating_ip_address, ip_pool=network,
+                reuse=reuse, fixed_address=fixed_address, wait=wait,
+                timeout=timeout)
             fip_address = cloud.get_server_public_ip(server)
             # Update the floating IP status
             f_ip = _get_floating_ip(cloud, fip_address)


### PR DESCRIPTION
The `network` argument needs to be passed through add_ips_to_server so that the default value can be properly overridden from ansible.
