### PR TITLE
win_service module present/absent

### DIFF
--- a/windows/win_service.ps1
+++ b/windows/win_service.ps1
@@ -52,16 +52,20 @@ If (-not $svc) {
         If (-not $path) {
             Fail-Json $result "path must be specified when state is '$state'"
         }
-        $svc = New-Service -Name $svcName -DisplayName $display_name -BinaryPathName -Description $description
+        New-Service -Name $svcName -DisplayName $display_name -BinaryPathName $path -Description $description
+        $svc = Get-Service -Name $svcName -ErrorAction SilentlyContinue
         
         Set-Attr $result "changed" $true
         Set-Attr $result "state" $state
+    } ElseIf ($state -eq "absent") {
+	Exit-Json $result
+    } Else {
+	Fail-Json $result "Service '$svcName' not installed"
     }
-    Fail-Json $result "Service '$svcName' not installed"
 } Else {
     If ($state -eq "absent") {
         Stop-Service -Name $svcName
-        $svc.delete()
+        (Get-WmiObject Win32_Service -filter "name='$svcName'").Delete()
         
         Set-Attr $result "changed" $true
         Set-Attr $result "state" $state

--- a/windows/win_service.py
+++ b/windows/win_service.py
@@ -35,6 +35,24 @@ options:
     required: true
     default: null
     aliases: []
+  display_name:
+    description:
+      - The Display Name of the service - Used during service creation
+    required: false
+    default: null
+    aliases: []
+  description:
+    description:
+      - Set the description of the service - Used during service creation
+    required: false
+    default: null
+    aliases: []
+  path:
+    description:
+      - The path to the executable file - Used during service creation
+    required: false
+    default: null
+    aliases: []
   start_mode:
     description:
       - Set the startup type for the service
@@ -45,11 +63,13 @@ options:
       - disabled
   state:
     description:
-      - C(started)/C(stopped) are idempotent actions that will not run
+      - C(present)/C(absent)/C(started)/C(stopped) are idempotent actions that will not run
         commands unless necessary.  C(restarted) will always bounce the
         service.
     required: false
     choices:
+      - present
+      - absent
       - started
       - stopped
       - restarted

--- a/windows/win_service.py
+++ b/windows/win_service.py
@@ -34,25 +34,24 @@ options:
       - Name of the service
     required: true
     default: null
-    aliases: []
   display_name:
     description:
       - The Display Name of the service - Used during service creation
+    version_added: "2.1"
     required: false
     default: null
-    aliases: []
   description:
     description:
       - Set the description of the service - Used during service creation
+    version_added: "2.1"
     required: false
     default: null
-    aliases: []
   path:
     description:
       - The path to the executable file - Used during service creation
+    version_added: "2.1"
     required: false
     default: null
-    aliases: []
   start_mode:
     description:
       - Set the startup type for the service
@@ -64,8 +63,8 @@ options:
   state:
     description:
       - C(present)/C(absent)/C(started)/C(stopped) are idempotent actions that will not run
-        commands unless necessary.  C(restarted) will always bounce the
-        service.
+        commands unless necessary. C(restarted) will always bounce the service.
+        Note that the present and absent actions are available from version 2.1.
     required: false
     choices:
       - present
@@ -74,7 +73,6 @@ options:
       - stopped
       - restarted
     default: null
-    aliases: []
 author: "Chris Hoffman (@chrishoffman)"
 '''
 


### PR DESCRIPTION
It's now possible to install/uninstall a windows service using the "present" and the "absent" states. Obviously, to install the service the path to the executable file is mandatory. Also added the optional parameters "display_name" and "description", which are used only when the state is "present".
