### PR TITLE
Making cluster parameter optional

### DIFF
--- a/cloud/vmware/vsphere_guest.py
+++ b/cloud/vmware/vsphere_guest.py
@@ -656,7 +656,7 @@ def deploy_template(vsphere_client, guest, resource_pool, template_src, esxi, mo
     elif resource_pool:
         try:
             cluster = [k for k,
-                       v in vsphere_client.get_clusters().items() if v == cluster_name][0]
+                       v in vsphere_client.get_clusters().items() if v == cluster_name][0] if cluster_name else None
         except IndexError, e:
             vsphere_client.disconnect()
             module.fail_json(msg="Cannot find Cluster named: %s" %
@@ -1059,7 +1059,7 @@ def create_vm(vsphere_client, module, esxi, resource_pool, cluster_name, guest, 
     if resource_pool:
         try:
             cluster = [k for k,
-                       v in vsphere_client.get_clusters().items() if v == cluster_name][0]
+                       v in vsphere_client.get_clusters().items() if v == cluster_name][0] if cluster_name else None
         except IndexError, e:
             vsphere_client.disconnect()
             module.fail_json(msg="Cannot find Cluster named: %s" %


### PR DESCRIPTION
Parameter _cluster_ should not be required as Hosts within vCenter does not have to assigned to clusters. 

Task passes variable _cluster_ later to _VIServer.get_resource_pools()_ which supports None:

``` python
        try:
            rpmor = [k for k, v in vsphere_client.get_resource_pools(
                from_mor=cluster).items()
                if v == resource_pool][0]
        except IndexError, e:
            vsphere_client.disconnect()
            module.fail_json(msg="Cannot find Resource Pool named: %s" %
                             resource_pool)
```
