### PR TITLE
user: Fix adding a user who's group exists for SLES11

### DIFF
--- a/system/user.py
+++ b/system/user.py
@@ -339,6 +339,11 @@ class User(object):
                     cmd.append('-n')
                 else:
                     cmd.append('-N')
+            elif os.path.exists('/etc/SuSE-release'):
+                dist = platform.dist()
+                major_release = int(dist[1].split('.')[0])
+                if major_release >= 12:
+                    cmd.append('-N')
             else:
                 cmd.append('-N')
 


### PR DESCRIPTION
SLES11 doesn't know about -N or -n so skip it there but pass it in for newer
versions that know about -N.
