### PR TITLE
default asg properties 'instances' to an empty list

### DIFF
--- a/cloud/amazon/ec2_asg.py
+++ b/cloud/amazon/ec2_asg.py
@@ -254,6 +254,7 @@ def get_properties(autoscaling_group):
     properties['pending_instances'] = 0
     properties['viable_instances'] = 0
     properties['terminating_instances'] = 0
+    properties['instances'] = []
 
     instance_facts = {}
 


### PR DESCRIPTION
This will avoid KeyError exceptions as described in #2638.
