### PR TITLE
Use JSON credentials for GCE modules

### DIFF
--- a/cloud/google/gce.py
+++ b/cloud/google/gce.py
@@ -63,9 +63,15 @@ options:
   pem_file:
     version_added: "1.5.1"
     description:
-      - path to the pem file associated with the service account email
+      - (deprecated) path to the pem file associated with the service account email
     required: false
     default: null
+  credentials_file:
+    version_added: 2.1.0
+    description:
+      - path to the JSON file associated with the service account email
+    default: null
+    required: false
   project_id:
     version_added: "1.5.1"
     description:
@@ -129,7 +135,7 @@ options:
 
 requirements:
     - "python >= 2.6"
-    - "apache-libcloud >= 0.13.3"
+    - "apache-libcloud >= 0.17.0"
 notes:
   - Either I(name) or I(instance_names) is required.
 author: "Eric Johnson (@erjohnso) <erjohnso@google.com>"
@@ -162,13 +168,13 @@ EXAMPLES = '''
     image: debian-6
     zone: us-central1-a
     service_account_email: unique-email@developer.gserviceaccount.com
-    pem_file: /path/to/pem_file
+    credentials_file: /path/to/json_file
     project_id: project-id
   tasks:
     - name: Launch instances
       local_action: gce instance_names={{names}} machine_type={{machine_type}}
                     image={{image}} zone={{zone}} service_account_email={{ service_account_email }}
-                    pem_file={{ pem_file }} project_id={{ project_id }}
+                    credentials_file={{ credentials_file }} project_id={{ project_id }}
       register: gce
     - name: Wait for SSH to come up
       local_action: wait_for host={{item.public_ip}} port=22 delay=10
@@ -445,6 +451,7 @@ def main():
             service_account_email = dict(),
             service_account_permissions = dict(type='list'),
             pem_file = dict(),
+            credentials_file = dict(),
             project_id = dict(),
             ip_forward = dict(type='bool', default=False),
             external_ip = dict(choices=['ephemeral', 'none'],
@@ -456,7 +463,7 @@ def main():
     if not HAS_PYTHON26:
         module.fail_json(msg="GCE module requires python's 'ast' module, python v2.6+")
     if not HAS_LIBCLOUD:
-        module.fail_json(msg='libcloud with GCE support (0.13.3+) required for this module')
+        module.fail_json(msg='libcloud with GCE support (0.17.0+) required for this module')
 
     gce = gce_connect(module)
 

--- a/cloud/google/gce.py
+++ b/cloud/google/gce.py
@@ -71,11 +71,12 @@ options:
   pem_file:
     version_added: "1.5.1"
     description:
-      - (deprecated) path to the pem file associated with the service account email
+      - path to the pem file associated with the service account email
+        This option is deprecated. Use 'credentials_file'.
     required: false
     default: null
   credentials_file:
-    version_added: 2.1.0
+    version_added: "2.1.0"
     description:
       - path to the JSON file associated with the service account email
     default: null
@@ -147,7 +148,7 @@ options:
 
 requirements:
     - "python >= 2.6"
-    - "apache-libcloud >= 0.17.0"
+    - "apache-libcloud >= 0.13.3, >= 0.17.0 if using JSON credentials"
 notes:
   - Either I(name) or I(instance_names) is required.
 author: "Eric Johnson (@erjohnso) <erjohnso@google.com>"
@@ -172,6 +173,9 @@ EXAMPLES = '''
 
 # Launch instances from a control node, runs some tasks on the new instances,
 # and then terminate them
+# This example uses JSON credentials with the credentials_file parameter
+# rather than the deprecated pem_file option with PEM formatted credentials.
+
 - name: Create a sandbox instance
   hosts: localhost
   vars:
@@ -211,6 +215,30 @@ EXAMPLES = '''
         module: gce
         state: 'absent'
         instance_names: {{gce.instance_names}}
+
+# The deprecated PEM file credentials can be used as follows
+- name: Create a sandbox instance with PEM credentials
+  hosts: localhost
+  vars:
+    names: foo,bar
+    machine_type: n1-standard-1
+    image: debian-6
+    zone: us-central1-a
+    service_account_email: unique-email@developer.gserviceaccount.com
+    pem_file: /path/to/pem_file
+    project_id: project-id
+  tasks:
+    - name: Launch instances
+      local_action: gce instance_names={{names}} machine_type={{machine_type}}
+                    image={{image}} zone={{zone}}
+                    service_account_email={{ service_account_email }}
+                    pem_file={{ pem_file }}
+                    project_id={{ project_id }}
+      register: gce
+    - name: Wait for SSH to come up
+      local_action: wait_for host={{item.public_ip}} port=22 delay=10
+                    timeout=60 state=started
+      with_items: {{gce.instance_data}}
 
 '''
 

--- a/cloud/google/gce_lb.py
+++ b/cloud/google/gce_lb.py
@@ -119,10 +119,16 @@ options:
   pem_file:
     version_added: "1.6"
     description:
-      - path to the pem file associated with the service account email
+      - (deprecated) path to the pem file associated with the service account email
     required: false
     default: null
     aliases: []
+  credentials_file:
+    version_added: 2.1.0
+    description:
+      - path to the JSON file associated with the service account email
+    default: null
+    required: false
   project_id:
     version_added: "1.6"
     description:
@@ -133,7 +139,7 @@ options:
 
 requirements:
     - "python >= 2.6"
-    - "apache-libcloud >= 0.13.3"
+    - "apache-libcloud >= 0.17.0"
 author: "Eric Johnson (@erjohnso) <erjohnso@google.com>"
 '''
 
@@ -182,6 +188,7 @@ def main():
             state = dict(default='present'),
             service_account_email = dict(),
             pem_file = dict(),
+            credentials_file = dict(),
             project_id = dict(),
         )
     )

--- a/cloud/google/gce_lb.py
+++ b/cloud/google/gce_lb.py
@@ -119,12 +119,13 @@ options:
   pem_file:
     version_added: "1.6"
     description:
-      - (deprecated) path to the pem file associated with the service account email
+      - path to the pem file associated with the service account email
+        This option is deprecated. Use 'credentials_file'.
     required: false
     default: null
     aliases: []
   credentials_file:
-    version_added: 2.1.0
+    version_added: "2.1.0"
     description:
       - path to the JSON file associated with the service account email
     default: null
@@ -139,7 +140,7 @@ options:
 
 requirements:
     - "python >= 2.6"
-    - "apache-libcloud >= 0.17.0"
+    - "apache-libcloud >= 0.13.3, >= 0.17.0 if using JSON credentials"
 author: "Eric Johnson (@erjohnso) <erjohnso@google.com>"
 '''
 

--- a/cloud/google/gce_net.py
+++ b/cloud/google/gce_net.py
@@ -91,7 +91,8 @@ options:
   pem_file:
     version_added: "1.6"
     description:
-      - (deprecated) path to the pem file associated with the service account email
+      - path to the pem file associated with the service account email
+        This option is deprecated. Use 'credentials_file'.
     required: false
     default: null
     aliases: []
@@ -112,7 +113,7 @@ options:
 
 requirements:
     - "python >= 2.6"
-    - "apache-libcloud >= 0.17.0"
+    - "apache-libcloud >= 0.13.3, >= 0.17.0 if using JSON credentials"
 author: "Eric Johnson (@erjohnso) <erjohnso@google.com>"
 '''
 

--- a/cloud/google/gce_net.py
+++ b/cloud/google/gce_net.py
@@ -90,7 +90,14 @@ options:
   pem_file:
     version_added: "1.6"
     description:
-      - path to the pem file associated with the service account email
+      - (deprecated) path to the pem file associated with the service account email
+    required: false
+    default: null
+    aliases: []
+  credentials_file:
+    version_added: "2.1.0"
+    description:
+      - path to the JSON file associated with the service account email
     required: false
     default: null
     aliases: []
@@ -104,7 +111,7 @@ options:
 
 requirements:
     - "python >= 2.6"
-    - "apache-libcloud >= 0.13.3"
+    - "apache-libcloud >= 0.17.0"
 author: "Eric Johnson (@erjohnso) <erjohnso@google.com>"
 '''
 
@@ -177,12 +184,13 @@ def main():
             state = dict(default='present'),
             service_account_email = dict(),
             pem_file = dict(),
+            credentials_file = dict(),
             project_id = dict(),
         )
     )
 
     if not HAS_LIBCLOUD:
-        module.exit_json(msg='libcloud with GCE support (0.13.3+) required for this module')
+        module.exit_json(msg='libcloud with GCE support (0.17.0+) required for this module')
 
     gce = gce_connect(module)
 

--- a/cloud/google/gce_pd.py
+++ b/cloud/google/gce_pd.py
@@ -97,7 +97,8 @@ options:
   pem_file:
     version_added: "1.6"
     description:
-      - (deprecated) path to the pem file associated with the service account email
+      - path to the pem file associated with the service account email
+        This option is deprecated. Use 'credentials_file'.
     required: false
     default: null
     aliases: []
@@ -126,7 +127,7 @@ options:
 
 requirements:
     - "python >= 2.6"
-    - "apache-libcloud >= 0.17.0"
+    - "apache-libcloud >= 0.13.3, >= 0.17.0 if using JSON credentials"
 author: "Eric Johnson (@erjohnso) <erjohnso@google.com>"
 '''
 

--- a/cloud/google/gce_pd.py
+++ b/cloud/google/gce_pd.py
@@ -97,7 +97,14 @@ options:
   pem_file:
     version_added: "1.6"
     description:
-      - path to the pem file associated with the service account email
+      - (deprecated) path to the pem file associated with the service account email
+    required: false
+    default: null
+    aliases: []
+  credentials_file:
+    version_added: "2.1.0"
+    description:
+      - path to the JSON file associated with the service account email
     required: false
     default: null
     aliases: []
@@ -119,7 +126,7 @@ options:
 
 requirements:
     - "python >= 2.6"
-    - "apache-libcloud >= 0.13.3"
+    - "apache-libcloud >= 0.17.0"
 author: "Eric Johnson (@erjohnso) <erjohnso@google.com>"
 '''
 
@@ -158,11 +165,12 @@ def main():
             zone = dict(default='us-central1-b'),
             service_account_email = dict(),
             pem_file = dict(),
+            credentials_file = dict(),
             project_id = dict(),
         )
     )
     if not HAS_LIBCLOUD:
-        module.fail_json(msg='libcloud with GCE support (0.13.3+) is required for this module')
+        module.fail_json(msg='libcloud with GCE support (0.17.0+) is required for this module')
 
     gce = gce_connect(module)
 


### PR DESCRIPTION
This PR enables the use of JSON credentials for the GCE modules. It is part of the fix for https://github.com/ansible/ansible/issues/13515 and is paired with https://github.com/ansible/ansible/pull/13623. 

cc @erjohnso
