### PR TITLE
Fix of adding existing ssh key on DigitalOcean

### DIFF
--- a/cloud/digital_ocean/digital_ocean.py
+++ b/cloud/digital_ocean/digital_ocean.py
@@ -174,8 +174,14 @@ import base64
 import hashlib
 from distutils.version import LooseVersion
 
+def decode_base64(data):
+    missing_padding = 4 - len(data) % 4
+    if missing_padding:
+        data += b'='* missing_padding
+    return base64.decodestring(data)
+
 def get_fingerprint(str):
-    key = base64.b64decode(str.strip().split()[1].encode('ascii'))
+    key = decode_base64(str.strip().split()[1].encode('ascii'))
     fp_plain = hashlib.md5(key).hexdigest()
     return ':'.join(a+b for a,b in zip(fp_plain[::2], fp_plain[1::2]))
 


### PR DESCRIPTION
Check ssh keys list by fingerprint and if exists - return it
If not exists - create new ssh key
