### PR TITLE
Elasticache Module: Stating that num_nodes is required when state=present

### DIFF
--- a/cloud/amazon/elasticache.py
+++ b/cloud/amazon/elasticache.py
@@ -50,7 +50,7 @@ options:
     default: cache.m1.small
   num_nodes:
     description:
-      - The initial number of cache nodes that the cache cluster will have
+      - The initial number of cache nodes that the cache cluster will have. Required when state=present.
     required: false
   cache_port:
     description:


### PR DESCRIPTION
Trying to make the elasticache documentation a little clearer, like it is in the [rds module](http://docs.ansible.com/ansible/rds_module.html) under the param `instance_name`. 

I was running this module and got a few of these error messages without realizing it.

``` python
module.fail_json(msg="'num_nodes' is a required parameter. Please specify num_nodes > 0")
```

that was being called from [here](https://github.com/ansible/ansible-modules-core/blob/devel/cloud/amazon/elasticache.py#L536-L537)
