### PR TITLE
Elasticache Module: changing default cache_security_group to none

### DIFF
--- a/cloud/amazon/elasticache.py
+++ b/cloud/amazon/elasticache.py
@@ -43,7 +43,7 @@ options:
     description:
       - The version number of the cache engine
     required: false
-    default: none
+    default: None
   node_type:
     description:
       - The compute and memory capacity of the nodes in the cache cluster
@@ -57,7 +57,7 @@ options:
     description:
       - The port number on which each of the cache nodes will accept connections
     required: false
-    default: none
+    default: None
   cache_parameter_group:
     description:
       - The name of the cache parameter group to associate with this cache cluster. If this argument is omitted, the default cache parameter group for the specified engine will be used.
@@ -75,13 +75,13 @@ options:
     description:
       - A list of vpc security group names to associate with this cache cluster. Only use if inside a vpc
     required: false
-    default: ['default']
+    default: None
     version_added: "1.6"
   cache_security_groups:
     description:
       - A list of cache security group names to associate with this cache cluster. Must be an empty list if inside a vpc
     required: false
-    default: ['default']
+    default: None
   zone:
     description:
       - The EC2 Availability Zone in which the cache cluster will be created
@@ -477,28 +477,24 @@ class ElastiCacheManager(object):
         return cache_node_ids[-num_nodes_to_remove:]
 
 
-
 def main():
     argument_spec = ec2_argument_spec()
-    default = object()
     argument_spec.update(dict(
-            state={'required': True, 'choices': ['present', 'absent', 'rebooted']},
-            name={'required': True},
-            engine={'required': False, 'choices': ['redis', 'memcached'], 'default': 'memcached'},
-            cache_engine_version={'required': False},
-            node_type={'required': False, 'default': 'cache.m1.small'},
-            num_nodes={'required': False, 'default': None, 'type': 'int'},
+            state                 ={'required': True, 'choices': ['present', 'absent', 'rebooted']},
+            name                  ={'required': True},
+            engine                ={'required': False, 'default': 'memcached'},
+            cache_engine_version  ={'required': False},
+            node_type             ={'required': False, 'default': 'cache.m1.small'},
+            num_nodes             ={'required': False, 'default': None, 'type': 'int'},
             # alias for compat with the original PR 1950
-            cache_parameter_group={'required': False, 'default': None, 'aliases': ['parameter_group']},
-            cache_port={'required': False, 'type': 'int'},
-            cache_subnet_group={'required': False, 'default': None},
-            cache_security_groups={'required': False, 'default': [default],
-                                'type': 'list'},
-            security_group_ids={'required': False, 'default': [],
-                                'type': 'list'},
-            zone={'required': False, 'default': None},
-            wait={'required': False, 'type' : 'bool', 'default': True},
-            hard_modify={'required': False, 'type': 'bool', 'default': False}
+            cache_parameter_group ={'required': False, 'default': None, 'aliases': ['parameter_group']},
+            cache_port            ={'required': False, 'type': 'int'},
+            cache_subnet_group    ={'required': False, 'default': None},
+            cache_security_groups ={'required': False, 'default': [], 'type': 'list'},
+            security_group_ids    ={'required': False, 'default': [], 'type': 'list'},
+            zone                  ={'required': False, 'default': None},
+            wait                  ={'required': False, 'type' : 'bool', 'default': True},
+            hard_modify           ={'required': False, 'type': 'bool', 'default': False}
         )
     )
 
@@ -526,13 +522,8 @@ def main():
     hard_modify = module.params['hard_modify']
     cache_parameter_group = module.params['cache_parameter_group']
 
-    if cache_subnet_group and cache_security_groups == [default]:
-        cache_security_groups = []
     if cache_subnet_group and cache_security_groups:
         module.fail_json(msg="Can't specify both cache_subnet_group and cache_security_groups")
-
-    if cache_security_groups == [default]:
-        cache_security_groups = ['default']
 
     if state == 'present' and not num_nodes:
         module.fail_json(msg="'num_nodes' is a required parameter. Please specify num_nodes > 0")


### PR DESCRIPTION
I have been running into an error with the elasticache module, that I believe is tied to the `cache_security_groups` default value not being valid.

Here is the output

```
***********************************
RAW OUTPUT

Traceback (most recent call last):
  File "/Users/benvisser/.ansible_module_generated", line 2719, in <module>
    main()
  File "/Users/benvisser/.ansible_module_generated", line 505, in main
    argument_spec=argument_spec,
  File "/Users/benvisser/.ansible_module_generated", line 1128, in __init__
    self._check_required_arguments()
  File "/Users/benvisser/.ansible_module_generated", line 1709, in _check_required_arguments
    self.fail_json(msg="missing required arguments: %s" % ",".join(missing))
  File "/Users/benvisser/.ansible_module_generated", line 2103, in fail_json
    kwargs = remove_values(kwargs, self.no_log_values)
  File "/Users/benvisser/.ansible_module_generated", line 981, in remove_values
    return dict((k, remove_values(v, no_log_strings)) for k, v in value.items())
  File "/Users/benvisser/.ansible_module_generated", line 981, in <genexpr>
    return dict((k, remove_values(v, no_log_strings)) for k, v in value.items())
  File "/Users/benvisser/.ansible_module_generated", line 981, in remove_values
    return dict((k, remove_values(v, no_log_strings)) for k, v in value.items())
  File "/Users/benvisser/.ansible_module_generated", line 981, in <genexpr>
    return dict((k, remove_values(v, no_log_strings)) for k, v in value.items())
  File "/Users/benvisser/.ansible_module_generated", line 979, in remove_values
    return [remove_values(elem, no_log_strings) for elem in value]
  File "/Users/benvisser/.ansible_module_generated", line 990, in remove_values
    raise TypeError('Value of unknown type: %s, %s' % (type(value), value))
TypeError: Value of unknown type: <type 'object'>, <object object at 0x103e85120>

***********************************
INVALID OUTPUT FORMAT

Traceback (most recent call last):
  File "ansible/hacking/test-module", line 167, in runtest
    results = json.loads(out)
  File "/usr/local/Cellar/python/2.7.10/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/__init__.py", line 338, in loads
    return _default_decoder.decode(s)
  File "/usr/local/Cellar/python/2.7.10/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/decoder.py", line 366, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/local/Cellar/python/2.7.10/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/decoder.py", line 384, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
```

In this pull request, I want to set the default value of `cache_security_groups` to None. 
