### PR TITLE
GCE: Use the Python installation from the env

### DIFF
--- a/cloud/google/gc_storage.py
+++ b/cloud/google/gc_storage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/cloud/google/gce.py
+++ b/cloud/google/gce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2013 Google Inc.
 #
 # This file is part of Ansible

--- a/cloud/google/gce_lb.py
+++ b/cloud/google/gce_lb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2013 Google Inc.
 #
 # This file is part of Ansible

--- a/cloud/google/gce_net.py
+++ b/cloud/google/gce_net.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2013 Google Inc.
 #
 # This file is part of Ansible

--- a/cloud/google/gce_pd.py
+++ b/cloud/google/gce_pd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright 2013 Google Inc.
 #
 # This file is part of Ansible


### PR DESCRIPTION
I am using virtualenvs to develop and the GCE modules are not picking up libcloud from the virtualenv. This fix uses the virtualenv's Python for the modules to use the proper paths and such for their dependencies.
