### PR TITLE
Neutron should manage router ports and not addresses

### DIFF
--- a/cloud/openstack/quantum_floating_ip.py
+++ b/cloud/openstack/quantum_floating_ip.py
@@ -171,9 +171,9 @@ def _get_port_info(neutron, module, instance_id, internal_network_name=None):
         return None, None
     return fixed_ip_address, port_id
 
-def _get_floating_ip(module, neutron, fixed_ip_address):
+def _get_floating_ip(module, neutron, port_id):
     kwargs = {
-            'fixed_ip_address': fixed_ip_address
+            'port_id': port_id
     }
     try:
         ips = neutron.list_floatingips(**kwargs)
@@ -181,6 +181,9 @@ def _get_floating_ip(module, neutron, fixed_ip_address):
         module.fail_json(msg = "error in fetching the floatingips's %s" % e.message)
     if not ips['floatingips']:
         return None, None
+    if len(ips['floatingips']) > 1:
+        module.fail_json(msg = "Multiple floatingips found",
+                         floatingips = ips['floatingips'])
     return ips['floatingips'][0]['id'], ips['floatingips'][0]['floating_ip_address']
 
 def _create_floating_ip(neutron, module, port_id, net_id, fixed_ip):
@@ -217,6 +220,12 @@ def _update_floating_ip(neutron, module, port_id, floating_ip_id):
         module.fail_json(msg="There was an error in updating the floating ip address: %s" % e.message)
     module.exit_json(changed=True, result=result)
 
+def _delete_floatingip(neutron, module, floating_ip_id):
+    try:
+        neutron.delete_floatingip(floating_ip_id)
+    except Exception, e:
+        module.fail_json(msg="There was an error in deleting the floating ip address: %s" % e.message)
+    module.exit_json(changed=True, msg = "Floating IP %s deleted" % floating_ip_id)
 
 def main():
 
@@ -244,7 +253,7 @@ def main():
     if not port_id:
         module.fail_json(msg="Cannot find a port for this instance, maybe fixed ip is not assigned")
 
-    floating_id, floating_ip = _get_floating_ip(module, neutron, fixed_ip)
+    floating_id, floating_ip = _get_floating_ip(module, neutron, port_id)
 
     if module.params['state'] == 'present':
         if floating_ip:
@@ -256,8 +265,9 @@ def main():
 
     if module.params['state'] == 'absent':
         if floating_ip:
-            _update_floating_ip(neutron, module, None, floating_id)
-        module.exit_json(changed=False)
+            _delete_floatingip(neutron, module, floating_id)
+        module.exit_json(changed=False, msg="Flaoting IP %s not found for "
+                                            "fixed IP" % fixed_ip)
 
 # this is magic, see lib/ansible/module.params['common.py
 from ansible.module_utils.basic import *


### PR DESCRIPTION
Fails to remove gateway or detected existing one when not
admin.
Otherwise fails with overlapping private ips

Instead of searching gw ports (visible to admin only) search router
gw info.
Also - make network_name redundant for "absent" mode.
