### PR TITLE
return allocation id for address created in vpc

### DIFF
--- a/cloud/amazon/ec2_eip.py
+++ b/cloud/amazon/ec2_eip.py
@@ -279,7 +279,7 @@ def ensure_present(ec2, domain, address, device_id,
 
         changed = changed or assoc_result['changed']
 
-    return {'changed': changed, 'public_ip': address.public_ip}
+    return {'changed': changed, 'public_ip': address.public_ip, 'allocation_id': address.allocation_id}
 
 
 def ensure_absent(ec2, domain, address, device_id, check_mode, isinstance=True):
@@ -355,7 +355,7 @@ def main():
                                     module.check_mode, isinstance=is_instance)
             else:
                 address = allocate_address(ec2, domain, reuse_existing_ip_allowed)
-                result = {'changed': True, 'public_ip': address.public_ip}
+                result = {'changed': True, 'public_ip': address.public_ip, 'allocation_id': address.allocation_id}
         else:
             if device_id:
                 disassociated = ensure_absent(ec2, domain, address, device_id, module.check_mode, isinstance=is_instance)


### PR DESCRIPTION
The boto3 API for adding a Managed NAT Gateway takes an allocation id as the canonical identifier of the address. This PR adds the allocation id to the result so that the result can be registered and used as input for a new module:

Example output. With address created in VPC:

```
ok: [localhost] => {
    "eip_response": {
        "allocation_id": "eipalloc-fef3749b",
        "changed": true,
        "public_ip": "52.31.253.59"
    }
} 
```

With address created in classic:

```
ok: [localhost] => {
    "eip_response": {
        "allocation_id": null,
        "changed": true,
        "public_ip": "54.228.191.37"
    }
}
```
