### PR TITLE
apt: export env vars before run dpkg

### DIFF
--- a/packaging/os/apt.py
+++ b/packaging/os/apt.py
@@ -443,6 +443,9 @@ def install_deb(m, debs, cache, force, install_recommends, dpkg_options):
         if force:
             options += " --force-all"
 
+        for (k,v) in APT_ENV_VARS.iteritems():
+            os.environ[k] = v
+
         cmd = "dpkg %s -i %s" % (options, " ".join(pkgs_to_install))
         rc, out, err = m.run_command(cmd)
         if "stdout" in retvals:


### PR DESCRIPTION
Without this change, some trouble may occur when "deb" parameter
is used as env vars controlling dpkg are not set. For example,
installing a package that requires user input will never end since
DEBIAN_FRONTEND=noninteractive is not set.

So export env vars in APT_ENV_VARS before run dpkg, like in cases
using apt-get/aptitude.
