### PR TITLE
ec2_elb_lb - required option for listeners should be true in docs

### DIFF
--- a/cloud/amazon/ec2_elb_lb.py
+++ b/cloud/amazon/ec2_elb_lb.py
@@ -38,7 +38,7 @@ options:
   listeners:
     description:
       - List of ports/protocols for this ELB to listen on (see example)
-    required: false
+    required: true
   purge_listeners:
     description:
       - Purge existing listeners on ELB that are not found in listeners
@@ -882,7 +882,7 @@ def main():
     argument_spec.update(dict(
             state={'required': True, 'choices': ['present', 'absent']},
             name={'required': True},
-            listeners={'default': None, 'required': False, 'type': 'list'},
+            listeners={'default': None, 'required': True, 'type': 'list'},
             purge_listeners={'default': True, 'required': False, 'type': 'bool'},
             zones={'default': None, 'required': False, 'type': 'list'},
             purge_zones={'default': False, 'required': False, 'type': 'bool'},


### PR DESCRIPTION
##### Issue Type:
- Docs Pull Request
##### Summary:

The documentation section from module states that 'listeners' option is optional, e.g. required: false but when I try to create ELB without 'listeners' I get:

```
failed: [127.0.0.1] => {"failed": true}
msg: At least one port is required for ELB creation

FATAL: all hosts have already failed -- aborting
```

Changed required option to true to make it consistent with actual code.
