### PR TITLE
Fix iam_policy pdoc variable assignment

### DIFF
--- a/cloud/amazon/iam_policy.py
+++ b/cloud/amazon/iam_policy.py
@@ -300,10 +300,11 @@ def main():
           pdoc = json.dumps(json.load(json_data))
           json_data.close()
   elif module.params.get('policy_json') != None:
+      pdoc = module.params.get('policy_json')
       # if its a string, assume it is already JSON
       if not isinstance(pdoc, basestring):
         try:
-          pdoc = json.dumps(module.params.get('policy_json'))
+          pdoc = json.dumps(pdoc)
         except Exception as e:
           module.fail_json(msg='Failed to convert the policy into valid JSON: %s' % str(e))
   else:


### PR DESCRIPTION
Changes about pdoc variable at " 1fe64796179a73510718ef38ad361e6bafc3febe be smarter when dealing with policy_json input  " causes UnboundLocalError. 

```
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/home/ubuntu/.ansible/tmp/ansible-tmp-1452225166.33-45917374755705/iam_policy", line 2503, in <module>
    main()
  File "/home/ubuntu/.ansible/tmp/ansible-tmp-1452225166.33-45917374755705/iam_policy", line 305, in main
    if not isinstance(pdoc, basestring):
UnboundLocalError: local variable 'pdoc' referenced before assignment
```

This pull request fix this error.
