### PR TITLE
win_feature: source option

### DIFF
--- a/windows/win_feature.ps1
+++ b/windows/win_feature.ps1
@@ -60,26 +60,26 @@ If ($state -eq "present") {
     
     if ($IncludeManagementTools -eq $true)
     {
-        $InstallParams.add("IncludeManagementTools";$includemanagementtools)
+        $InstallParams.add("IncludeManagementTools",$includemanagementtools)
     }
     
     if ($source -ne $null)
     {
-        $InstallParams.add("Source";$source)
+        $InstallParams.add("Source",$source)
     }
     
     
     
     try {
         If (Get-Command "Install-WindowsFeature" -ErrorAction SilentlyContinue) {
-            $featureresult = Install-WindowsFeature @Params
+            $featureresult = Install-WindowsFeature @InstallParams
         }
         ElseIf (Get-Command "Add-WindowsFeature" -ErrorAction SilentlyContinue) {
             if ($IncludeManagementTools)
             {
                 $Params.Remove("IncludeManagementTools")
             }
-            $featureresult = Add-WindowsFeature @Params
+            $featureresult = Add-WindowsFeature @InstallParams
         }
         Else {
             Fail-Json $result "Not supported on this version of Windows"

--- a/windows/win_feature.py
+++ b/windows/win_feature.py
@@ -34,7 +34,6 @@ options:
       - Names of roles or features to install as a single feature or a comma-separated list of features
     required: true
     default: null
-    aliases: []
   state:
     description:
       - State of the features or roles on the system
@@ -43,7 +42,6 @@ options:
       - present
       - absent
     default: present
-    aliases: []
   restart:
     description:
       - Restarts the computer automatically when installation is complete, if restarting is required by the roles or features installed.
@@ -51,7 +49,6 @@ options:
       - yes
       - no
     default: null
-    aliases: []
   include_sub_features:
     description:
       - Adds all subfeatures of the specified feature
@@ -59,7 +56,6 @@ options:
       - yes
       - no
     default: null
-    aliases: []
   include_management_tools:
     description:
       - Adds the corresponding management tools to the specified feature
@@ -67,7 +63,13 @@ options:
       - yes
       - no
     default: null
-    aliases: []
+  source:
+    description:
+      - Specify a source to install the feature from
+    required: false
+    choices: 
+      - {driveletter}:\sources\sxs
+      - \\{IP}\Share\sources\sxs
 author: 
     - "Paul Durivage (@angstwad)"
     - "Trond Hindenes (@trondhindenes)"

--- a/windows/win_feature.py
+++ b/windows/win_feature.py
@@ -81,6 +81,7 @@ EXAMPLES = '''
 # PS C:\Users\Administrator> Import-Module ServerManager; Get-WindowsFeature
 $ ansible -i hosts -m win_feature -a "name=Web-Server" all
 $ ansible -i hosts -m win_feature -a "name=Web-Server,Web-Common-Http" all
+ansible -m "win_feature" -a "name=NET-Framework-Core source=C:/Temp/iso/sources/sxs" windows
 
 
 # Playbook example


### PR DESCRIPTION
This non-required option allows win_feature to specify the install source when adding features. Usually used with "Net-Framework-Core" since that package isn't included with Windows.

`ansible -m "win_feature" -a "name=NET-Framework-Core source=C:/Temp/iso/sources/sxs" windows -vv`
