### PR TITLE
Add wait option to route53 module

### DIFF
--- a/cloud/amazon/route53.py
+++ b/cloud/amazon/route53.py
@@ -137,6 +137,12 @@ options:
     required: false
     default: null
     version_added: "2.0"
+  wait:
+    description:
+      - Wait until the changes have been replicated to all Amazon Route 53 DNS servers.
+    required: false
+    default: no
+    version_added: "2.0"
 author: 
   - "Bruce Pennypacker (@bpennypacker)"
   - "Mike Buzzetti <mike.buzzetti@gmail.com>"
@@ -146,7 +152,7 @@ extends_documentation_fragment: aws
 # FIXME: the command stuff should have a more state like configuration alias -- MPD
 
 EXAMPLES = '''
-# Add new.foo.com as an A record with 3 IPs
+# Add new.foo.com as an A record with 3 IPs and wait until the changes have been replicated
 - route53:
       command: create
       zone: foo.com
@@ -154,6 +160,7 @@ EXAMPLES = '''
       type: A
       ttl: 7200
       value: 1.1.1.1,2.2.2.2,3.3.3.3
+      wait: yes
 
 # Retrieve the details for new.foo.com
 - route53:
@@ -223,7 +230,7 @@ EXAMPLES = '''
       type: "AAAA"
       ttl: "7200"
       value: "::1"
-      
+
 # Add an AAAA record with Hosted Zone ID.  Note that because there are colons in the value
 # that the entire parameter list must be quoted:
 - route53:
@@ -234,7 +241,7 @@ EXAMPLES = '''
       type: "AAAA"
       ttl: "7200"
       value: "::1"
-      
+
 # Use a routing policy to distribute traffic:
 - route53:
       command: "create"
@@ -250,6 +257,8 @@ EXAMPLES = '''
 
 '''
 
+WAIT_RETRY_SLEEP = 5  # how many seconds to wait between propagation status polls
+
 import time
 
 try:
@@ -258,6 +267,7 @@ try:
     from boto import route53
     from boto.route53 import Route53Connection
     from boto.route53.record import Record, ResourceRecordSets
+    from boto.route53.status import Status
     HAS_BOTO = True
 except ImportError:
     HAS_BOTO = False
@@ -285,19 +295,30 @@ def get_zone_by_name(conn, module, zone_name, want_private, zone_id, want_vpc_id
     return None
 
 
-def commit(changes, retry_interval):
+def commit(changes, retry_interval, wait):
     """Commit changes, but retry PriorRequestNotComplete errors."""
+    result = None
     retry = 10
     while True:
         try:
             retry -= 1
-            return changes.commit()
+            result = changes.commit()
+            break
         except boto.route53.exception.DNSServerError, e:
             code = e.body.split("<Code>")[1]
             code = code.split("</Code>")[0]
             if code != 'PriorRequestNotComplete' or retry < 0:
                 raise e
             time.sleep(float(retry_interval))
+
+    if wait:
+      connection = changes.connection
+      change = result['ChangeResourceRecordSetsResponse']['ChangeInfo']
+      status = Status(connection, change)
+      while status.status != 'INSYNC':
+        time.sleep(WAIT_RETRY_SLEEP)
+        status.update()
+    return result
 
 def main():
     argument_spec = ec2_argument_spec()
@@ -321,6 +342,7 @@ def main():
             health_check                 = dict(required=False),
             failover                    = dict(required=False),
             vpc_id                      = dict(required=False),
+            wait                        = dict(required=False, type='bool'),
         )
     )
     module = AnsibleModule(argument_spec=argument_spec)
@@ -346,6 +368,7 @@ def main():
     health_check_in                 = module.params.get('health_check')
     failover_in                     = module.params.get('failover')
     vpc_id_in                       = module.params.get('vpc_id')
+    wait_in                         = module.params.get('wait')
 
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module)
 
@@ -377,7 +400,7 @@ def main():
             " 'vpc_id'")
 
 
-    # connect to the route53 endpoint 
+    # connect to the route53 endpoint
     try:
         conn = Route53Connection(**aws_connect_kwargs)
     except boto.exception.BotoServerError, e:
@@ -392,7 +415,7 @@ def main():
         module.fail_json(msg = errmsg)
 
     record = {}
-    
+
     found_record = False
     wanted_rset = Record(name=record_in, type=type_in, ttl=ttl_in,
         identifier=identifier_in, weight=weight_in, region=region_in,
@@ -467,7 +490,7 @@ def main():
         changes.add_change_record(command, wanted_rset)
 
     try:
-        result = commit(changes, retry_interval_in)
+        result = commit(changes, retry_interval_in, wait_in)
     except boto.route53.exception.DNSServerError, e:
         txt = e.body.split("<Message>")[1]
         txt = txt.split("</Message>")[0]

--- a/cloud/amazon/route53.py
+++ b/cloud/amazon/route53.py
@@ -143,6 +143,13 @@ options:
     required: false
     default: no
     version_added: "2.0"
+  wait_timeout:
+    description:
+      - How long to wait for the changes to be replicated, in seconds.
+    required: false
+    default: 300
+    version_added: "2.0"
+author: "Bruce Pennypacker (@bpennypacker)"
 author: 
   - "Bruce Pennypacker (@bpennypacker)"
   - "Mike Buzzetti <mike.buzzetti@gmail.com>"
@@ -259,6 +266,7 @@ EXAMPLES = '''
 
 WAIT_RETRY_SLEEP = 5  # how many seconds to wait between propagation status polls
 
+
 import time
 
 try:
@@ -271,6 +279,11 @@ try:
     HAS_BOTO = True
 except ImportError:
     HAS_BOTO = False
+
+
+class TimeoutError(Exception):
+    pass
+
 
 def get_zone_by_name(conn, module, zone_name, want_private, zone_id, want_vpc_id):
     """Finds a zone by name or zone_id"""
@@ -295,7 +308,7 @@ def get_zone_by_name(conn, module, zone_name, want_private, zone_id, want_vpc_id
     return None
 
 
-def commit(changes, retry_interval, wait):
+def commit(changes, retry_interval, wait, wait_timeout):
     """Commit changes, but retry PriorRequestNotComplete errors."""
     result = None
     retry = 10
@@ -312,12 +325,15 @@ def commit(changes, retry_interval, wait):
             time.sleep(float(retry_interval))
 
     if wait:
+      timeout_time = time.time() + wait_timeout
       connection = changes.connection
       change = result['ChangeResourceRecordSetsResponse']['ChangeInfo']
       status = Status(connection, change)
-      while status.status != 'INSYNC':
+      while status.status != 'INSYNC' and time.time() < timeout_time:
         time.sleep(WAIT_RETRY_SLEEP)
         status.update()
+      if time.time() >= timeout_time:
+        raise TimeoutError()
     return result
 
 def main():
@@ -340,9 +356,10 @@ def main():
             weight                       = dict(required=False, type='int'),
             region                       = dict(required=False),
             health_check                 = dict(required=False),
-            failover                    = dict(required=False),
-            vpc_id                      = dict(required=False),
-            wait                        = dict(required=False, type='bool'),
+            failover                     = dict(required=False),
+            vpc_id                       = dict(required=False),
+            wait                         = dict(required=False, type='bool', default=False),
+            wait_timeout                 = dict(required=False, type='int', default=300),
         )
     )
     module = AnsibleModule(argument_spec=argument_spec)
@@ -369,6 +386,7 @@ def main():
     failover_in                     = module.params.get('failover')
     vpc_id_in                       = module.params.get('vpc_id')
     wait_in                         = module.params.get('wait')
+    wait_timeout_in                 = module.params.get('wait_timeout')
 
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module)
 
@@ -490,11 +508,13 @@ def main():
         changes.add_change_record(command, wanted_rset)
 
     try:
-        result = commit(changes, retry_interval_in, wait_in)
+        result = commit(changes, retry_interval_in, wait_in, wait_timeout_in)
     except boto.route53.exception.DNSServerError, e:
         txt = e.body.split("<Message>")[1]
         txt = txt.split("</Message>")[0]
         module.fail_json(msg = txt)
+    except TimeoutError:
+        module.fail_json(msg='Timeout waiting for changes to replicate')
 
     module.exit_json(changed=True)
 


### PR DESCRIPTION
The new `wait` option (disabled by default) makes the module wait for the changes to replicate to all Amazon DNS servers. This is useful if you want to make sure DNS queries work in subsequent tasks.

@bpennypacker As the original author, could you take a look at the proposed changes?
