### PR TITLE
apt-key: convert ids to the 'short' format

### DIFF
--- a/packaging/os/apt_key.py
+++ b/packaging/os/apt_key.py
@@ -220,19 +220,22 @@ def main():
     keyserver       = module.params['keyserver']
     changed         = False
 
+    # we use the "short" id: key_id[-8:], short_format=True
+    # it's a workaround for https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1481871
+
     if key_id:
         try:
             _ = int(key_id, 16)
             if key_id.startswith('0x'):
                 key_id = key_id[2:]
-            key_id = key_id.upper()
+            key_id = key_id.upper()[-8:]
         except ValueError:
             module.fail_json(msg="Invalid key_id", id=key_id)
 
     # FIXME: I think we have a common facility for this, if not, want
     check_missing_binaries(module)
 
-    short_format = (key_id is not None and len(key_id) == 8)
+    short_format = True
     keys = all_keys(module, keyring, short_format)
     return_values = {}
 
@@ -257,7 +260,7 @@ def main():
                 keys2 = all_keys(module, keyring, short_format)
                 if len(keys) != len(keys2):
                     changed=True
-                if key_id and not key_id[-16:] in keys2:
+                if key_id and not key_id in keys2:
                     module.fail_json(msg="key does not seem to have been added", id=key_id)
                 module.exit_json(changed=changed)
     elif state == 'absent':


### PR DESCRIPTION
**Issue Type:** Bugfix Pull Request (security)
See https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1481871

**Ansible Version:**

```
$ ansible --version
ansible 2.1.0 (devel cacc22abbb) last updated 2016/01/12 00:03:48 (GMT +000)
  lib/ansible/modules/core: (fix-apt-key-del-long-id d441cb176c) last updated 2016/01/12 01:12:32 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD 82a4cf84be) last updated 2016/01/12 00:04:01 (GMT +000)
```

**Environment**:

```
$ hostnamectl
   Static hostname: hola-bro
         Icon name: computer-vm
           Chassis: vm
        Machine ID: db79307cf0a7419589c900a3e6d84be0
           Boot ID: 958a82e507074d21b62a7530484ca805
    Virtualization: oracle
  Operating System: Ubuntu 15.10
            Kernel: Linux 4.2.0-18-generic
      Architecture: x86-64
```

**Steps To Reproduce**:

```
$ ansible all -m apt_key -a 'state=present id=7A82B743B9B8E46F12C733FA4759FA960E27C0A6 keyserver=hkp://keyserver.ubuntu.com:80' --sudo
127.0.0.1 | SUCCESS => {
    "changed": true
}

$ ansible all -m apt_key -a 'state=absent id=7A82B743B9B8E46F12C733FA4759FA960E27C0A6' --sudo
127.0.0.1 | SUCCESS => {
    "changed": false
}

$ apt-key export 7A82B743B9B8E46F12C733FA4759FA960E27C0A6
-----BEGIN PGP PUBLIC KEY BLOCK-----
Version: GnuPG v1
...
```
