### PR TITLE
guard main-execution

### DIFF
--- a/cloud/amazon/cloudformation.py
+++ b/cloud/amazon/cloudformation.py
@@ -403,4 +403,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/amazon/ec2.py
+++ b/cloud/amazon/ec2.py
@@ -1431,4 +1431,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/amazon/ec2_ami.py
+++ b/cloud/amazon/ec2_ami.py
@@ -404,4 +404,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/amazon/ec2_facts.py
+++ b/cloud/amazon/ec2_facts.py
@@ -178,4 +178,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
 
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/amazon/ec2_group.py
+++ b/cloud/amazon/ec2_group.py
@@ -469,4 +469,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/amazon/ec2_key.py
+++ b/cloud/amazon/ec2_key.py
@@ -241,4 +241,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/amazon/ec2_lc.py
+++ b/cloud/amazon/ec2_lc.py
@@ -144,9 +144,6 @@ EXAMPLES = '''
 
 '''
 
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
-
 try:
     from boto.ec2.blockdevicemapping import BlockDeviceType, BlockDeviceMapping
     import boto.ec2.autoscale
@@ -321,4 +318,9 @@ def main():
     elif state == 'absent':
         delete_launch_config(connection, module)
 
-main()
+# import module snippets
+from ansible.module_utils.basic import *
+from ansible.module_utils.ec2 import *
+
+if __name__ == '__main__':
+    main()

--- a/cloud/amazon/ec2_tag.py
+++ b/cloud/amazon/ec2_tag.py
@@ -181,4 +181,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/amazon/ec2_vpc.py
+++ b/cloud/amazon/ec2_vpc.py
@@ -713,4 +713,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/amazon/elasticache.py
+++ b/cloud/amazon/elasticache.py
@@ -564,4 +564,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/amazon/elasticache_subnet_group.py
+++ b/cloud/amazon/elasticache_subnet_group.py
@@ -151,4 +151,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/amazon/iam.py
+++ b/cloud/amazon/iam.py
@@ -730,7 +730,9 @@ def main():
                 changed=False, msg='Role update not currently supported by boto.')
         module.exit_json(changed=changed, roles=role_list)
 
+# import module snippets
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/amazon/iam_policy.py
+++ b/cloud/amazon/iam_policy.py
@@ -337,7 +337,9 @@ def main():
                                                        state)
     module.exit_json(changed=changed, group_name=name, policies=current_policies, msg=msg)
 
+# import module snippets
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/amazon/rds.py
+++ b/cloud/amazon/rds.py
@@ -1083,4 +1083,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/amazon/rds_subnet_group.py
+++ b/cloud/amazon/rds_subnet_group.py
@@ -151,4 +151,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/amazon/route53.py
+++ b/cloud/amazon/route53.py
@@ -479,4 +479,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/amazon/s3.py
+++ b/cloud/amazon/s3.py
@@ -660,4 +660,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/openstack/os_client_config.py
+++ b/cloud/openstack/os_client_config.py
@@ -71,4 +71,5 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/openstack/os_image.py
+++ b/cloud/openstack/os_image.py
@@ -188,4 +188,6 @@ def main():
 # this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *
 from ansible.module_utils.openstack import *
-main()
+
+if __name__ == '__main__':
+    main()

--- a/cloud/openstack/os_ironic.py
+++ b/cloud/openstack/os_ironic.py
@@ -344,4 +344,6 @@ def main():
 # this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *
 from ansible.module_utils.openstack import *
-main()
+
+if __name__ == '__main__':
+    main()

--- a/cloud/openstack/os_ironic_node.py
+++ b/cloud/openstack/os_ironic_node.py
@@ -330,4 +330,6 @@ def main():
 # this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *
 from ansible.module_utils.openstack import *
-main()
+
+if __name__ == '__main__':
+    main()

--- a/cloud/openstack/os_object.py
+++ b/cloud/openstack/os_object.py
@@ -122,4 +122,6 @@ def main():
 # this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *
 from ansible.module_utils.openstack import *
-main()
+
+if __name__ == '__main__':
+    main()

--- a/cloud/openstack/os_security_group.py
+++ b/cloud/openstack/os_security_group.py
@@ -139,4 +139,6 @@ def main():
 # this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *
 from ansible.module_utils.openstack import *
-main()
+
+if __name__ == '__main__':
+    main()

--- a/cloud/rackspace/rax.py
+++ b/cloud/rackspace/rax.py
@@ -888,5 +888,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
-# invoke the module
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/rackspace/rax_cbs.py
+++ b/cloud/rackspace/rax_cbs.py
@@ -232,5 +232,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
-# invoke the module
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/rackspace/rax_cbs_attachments.py
+++ b/cloud/rackspace/rax_cbs_attachments.py
@@ -217,5 +217,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
-### invoke the module
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/rackspace/rax_cdb.py
+++ b/cloud/rackspace/rax_cdb.py
@@ -255,5 +255,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
-# invoke the module
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/rackspace/rax_cdb_database.py
+++ b/cloud/rackspace/rax_cdb_database.py
@@ -171,5 +171,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
-# invoke the module
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/rackspace/rax_cdb_user.py
+++ b/cloud/rackspace/rax_cdb_user.py
@@ -216,5 +216,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
-# invoke the module
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/rackspace/rax_clb.py
+++ b/cloud/rackspace/rax_clb.py
@@ -304,5 +304,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
-### invoke the module
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/rackspace/rax_clb_nodes.py
+++ b/cloud/rackspace/rax_clb_nodes.py
@@ -277,5 +277,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
-# invoke the module
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/rackspace/rax_dns.py
+++ b/cloud/rackspace/rax_dns.py
@@ -169,5 +169,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
-### invoke the module
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/rackspace/rax_dns_record.py
+++ b/cloud/rackspace/rax_dns_record.py
@@ -331,5 +331,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
-### invoke the module
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/rackspace/rax_facts.py
+++ b/cloud/rackspace/rax_facts.py
@@ -142,5 +142,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
-### invoke the module
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/rackspace/rax_files.py
+++ b/cloud/rackspace/rax_files.py
@@ -373,7 +373,9 @@ def main():
                private, web_index, web_error)
 
 
+# import module snippets
 from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/rackspace/rax_files_objects.py
+++ b/cloud/rackspace/rax_files_objects.py
@@ -597,7 +597,9 @@ def main():
     cloudfiles(module, container, src, dest, method, typ, meta, clear_meta, structure, expires)
 
 
+# import module snippets
 from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/rackspace/rax_identity.py
+++ b/cloud/rackspace/rax_identity.py
@@ -104,5 +104,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
-# invoke the module
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/rackspace/rax_keypair.py
+++ b/cloud/rackspace/rax_keypair.py
@@ -170,5 +170,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
-### invoke the module
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/rackspace/rax_meta.py
+++ b/cloud/rackspace/rax_meta.py
@@ -174,5 +174,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
-### invoke the module
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/rackspace/rax_network.py
+++ b/cloud/rackspace/rax_network.py
@@ -142,5 +142,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
-### invoke the module
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/rackspace/rax_queue.py
+++ b/cloud/rackspace/rax_queue.py
@@ -143,5 +143,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
-### invoke the module
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/rackspace/rax_scaling_group.py
+++ b/cloud/rackspace/rax_scaling_group.py
@@ -425,5 +425,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
-# invoke the module
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/rackspace/rax_scaling_policy.py
+++ b/cloud/rackspace/rax_scaling_policy.py
@@ -279,5 +279,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.rax import *
 
-# invoke the module
-main()
+if __name__ == '__main__':
+    main()

--- a/commands/command.py
+++ b/commands/command.py
@@ -248,4 +248,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.splitter import *
 
-main()
+if __name__ == '__main__':
+    main()

--- a/database/mysql/mysql_variables.py
+++ b/database/mysql/mysql_variables.py
@@ -184,4 +184,6 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.database import *
 from ansible.module_utils.mysql import *
-main()
+
+if __name__ == '__main__':
+    main()

--- a/database/postgresql/postgresql_user.py
+++ b/database/postgresql/postgresql_user.py
@@ -658,4 +658,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 from ansible.module_utils.database import *
-main()
+
+if __name__ == '__main__':
+    main()

--- a/files/acl.py
+++ b/files/acl.py
@@ -329,4 +329,5 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+if __name__ == '__main__':
+    main()

--- a/files/assemble.py
+++ b/files/assemble.py
@@ -232,5 +232,5 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
-
+if __name__ == '__main__':
+    main()

--- a/files/copy.py
+++ b/files/copy.py
@@ -335,4 +335,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == '__main__':
+    main()

--- a/files/find.py
+++ b/files/find.py
@@ -346,5 +346,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
 
+if __name__ == '__main__':
+    main()

--- a/files/stat.py
+++ b/files/stat.py
@@ -415,4 +415,5 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+if __name__ == '__main__':
+    main()

--- a/files/synchronize.py
+++ b/files/synchronize.py
@@ -390,5 +390,5 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
-
+if __name__ == '__main__':
+    main()

--- a/files/xattr.py
+++ b/files/xattr.py
@@ -203,4 +203,5 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+if __name__ == '__main__':
+    main()

--- a/network/basics/slurp.py
+++ b/network/basics/slurp.py
@@ -73,5 +73,5 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
-
+if __name__ == '__main__':
+    main()

--- a/packaging/language/easy_install.py
+++ b/packaging/language/easy_install.py
@@ -200,4 +200,5 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+if __name__ == '__main__':
+    main()

--- a/packaging/language/gem.py
+++ b/packaging/language/gem.py
@@ -256,4 +256,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == '__main__':
+    main()

--- a/packaging/language/pip.py
+++ b/packaging/language/pip.py
@@ -398,4 +398,5 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+if __name__ == '__main__':
+    main()

--- a/packaging/os/apt_key.py
+++ b/packaging/os/apt_key.py
@@ -277,4 +277,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
-main()
+
+if __name__ == '__main__':
+    main()

--- a/packaging/os/apt_repository.py
+++ b/packaging/os/apt_repository.py
@@ -475,4 +475,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
 
-main()
+if __name__ == '__main__':
+    main()

--- a/packaging/os/apt_rpm.py
+++ b/packaging/os/apt_rpm.py
@@ -168,5 +168,6 @@ def main():
 
 # this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *
-    
-main()        
+
+if __name__ == '__main__':
+    main()

--- a/packaging/os/redhat_subscription.py
+++ b/packaging/os/redhat_subscription.py
@@ -459,4 +459,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == '__main__':
+    main()

--- a/packaging/os/rhn_channel.py
+++ b/packaging/os/rhn_channel.py
@@ -166,5 +166,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
 
+if __name__ == '__main__':
+    main()

--- a/packaging/os/rhn_register.py
+++ b/packaging/os/rhn_register.py
@@ -363,5 +363,5 @@ def main():
 
             module.exit_json(changed=True, msg="System successfully unregistered from %s." % rhn.hostname)
 
-
-main()
+if __name__ == '__main__':
+    main()

--- a/source_control/git.py
+++ b/source_control/git.py
@@ -812,4 +812,5 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.known_hosts import *
 
-main()
+if __name__ == '__main__':
+    main()

--- a/source_control/hg.py
+++ b/source_control/hg.py
@@ -274,4 +274,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == '__main__':
+    main()

--- a/source_control/subversion.py
+++ b/source_control/subversion.py
@@ -257,4 +257,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == '__main__':
+    main()

--- a/system/authorized_key.py
+++ b/system/authorized_key.py
@@ -484,4 +484,6 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
-main()
+
+if __name__ == '__main__':
+    main()

--- a/system/cron.py
+++ b/system/cron.py
@@ -532,5 +532,5 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
-
+if __name__ == '__main__':
+    main()

--- a/system/group.py
+++ b/system/group.py
@@ -439,4 +439,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == '__main__':
+    main()

--- a/system/hostname.py
+++ b/system/hostname.py
@@ -627,4 +627,5 @@ def main():
                                         ansible_fqdn=socket.getfqdn(),
                                         ansible_domain='.'.join(socket.getfqdn().split('.')[1:])))
 
-main()
+if __name__ == '__main__':
+    main()

--- a/system/mount.py
+++ b/system/mount.py
@@ -384,4 +384,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == '__main__':
+    main()

--- a/system/ping.py
+++ b/system/ping.py
@@ -56,7 +56,8 @@ def main():
         result['ping'] = module.params['data']
     module.exit_json(**result)
 
+# import module snippets
 from ansible.module_utils.basic import *
 
-main()
-
+if __name__ == '__main__':
+    main()

--- a/system/seboolean.py
+++ b/system/seboolean.py
@@ -209,4 +209,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == '__main__':
+    main()

--- a/system/service.py
+++ b/system/service.py
@@ -1507,4 +1507,6 @@ def main():
 
 from ansible.module_utils.basic import *
 
-main()
+# import module snippets
+if __name__ == '__main__':
+    main()

--- a/system/setup.py
+++ b/system/setup.py
@@ -140,9 +140,8 @@ def main():
     module.exit_json(**data)
 
 # import module snippets
-
 from ansible.module_utils.basic import *
-
 from ansible.module_utils.facts import *
 
-main()
+if __name__ == '__main__':
+    main()

--- a/system/sysctl.py
+++ b/system/sysctl.py
@@ -360,4 +360,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == '__main__':
+    main()

--- a/utilities/helper/accelerate.py
+++ b/utilities/helper/accelerate.py
@@ -726,4 +726,5 @@ def main():
         # try to start up the daemon
         daemonize(module, password, port, timeout, minutes, ipv6, pid_file)
 
-main()
+if __name__ == '__main__':
+    main()

--- a/utilities/helper/fireball.py
+++ b/utilities/helper/fireball.py
@@ -279,4 +279,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == '__main__':
+    main()

--- a/utilities/logic/async_status.py
+++ b/utilities/logic/async_status.py
@@ -98,4 +98,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The Developing Modules Guide mentions that the main function should be guarded
(as is the common idiom for Python scripts).  Most of the modules were not
written that way.  This patch updates most of them to comply with this policy.

See here: http://docs.ansible.com/ansible/developing_modules.html#common-module-boilerplate
