### PR TITLE
Fix OpenStack module failure output

### DIFF
--- a/cloud/openstack/os_auth.py
+++ b/cloud/openstack/os_auth.py
@@ -60,7 +60,7 @@ def main():
               auth_token=cloud.auth_token,
               service_catalog=cloud.service_catalog))
     except shade.OpenStackCloudException as e:
-        module.fail_json(msg=e.message)
+        module.fail_json(msg=str(e))
 
 # this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *

--- a/cloud/openstack/os_floating_ip.py
+++ b/cloud/openstack/os_floating_ip.py
@@ -175,7 +175,7 @@ def main():
             module.exit_json(changed=True, floating_ip=f_ip)
 
     except shade.OpenStackCloudException as e:
-        module.fail_json(msg=e.message, extra_data=e.extra_data)
+        module.fail_json(msg=str(e), extra_data=e.extra_data)
 
 
 # this is magic, see lib/ansible/module_common.py

--- a/cloud/openstack/os_image.py
+++ b/cloud/openstack/os_image.py
@@ -183,7 +183,7 @@ def main():
             module.exit_json(changed=changed)
 
     except shade.OpenStackCloudException as e:
-        module.fail_json(msg=e.message, extra_data=e.extra_data)
+        module.fail_json(msg=str(e), extra_data=e.extra_data)
 
 # this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *

--- a/cloud/openstack/os_image_facts.py
+++ b/cloud/openstack/os_image_facts.py
@@ -148,7 +148,7 @@ def main():
             openstack_image=image))
 
     except shade.OpenStackCloudException as e:
-        module.fail_json(msg=e.message)
+        module.fail_json(msg=str(e))
 
 # this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *

--- a/cloud/openstack/os_ironic.py
+++ b/cloud/openstack/os_ironic.py
@@ -338,7 +338,7 @@ def main():
                 module.exit_json(changed=False, result="Server not found")
 
     except shade.OpenStackCloudException as e:
-        module.fail_json(msg=e.message)
+        module.fail_json(msg=str(e))
 
 
 # this is magic, see lib/ansible/module_common.py

--- a/cloud/openstack/os_ironic_node.py
+++ b/cloud/openstack/os_ironic_node.py
@@ -324,7 +324,7 @@ def main():
                                  "maintenance, off")
 
     except shade.OpenStackCloudException as e:
-        module.fail_json(msg=e.message)
+        module.fail_json(msg=str(e))
 
 
 # this is magic, see lib/ansible/module_common.py

--- a/cloud/openstack/os_keypair.py
+++ b/cloud/openstack/os_keypair.py
@@ -162,7 +162,7 @@ def main():
             module.exit_json(changed=False)
 
     except shade.OpenStackCloudException as e:
-        module.fail_json(msg=e.message)
+        module.fail_json(msg=str(e))
 
 # this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *

--- a/cloud/openstack/os_network.py
+++ b/cloud/openstack/os_network.py
@@ -159,7 +159,7 @@ def main():
                 module.exit_json(changed=True)
 
     except shade.OpenStackCloudException as e:
-        module.fail_json(msg=e.message)
+        module.fail_json(msg=str(e))
 
 
 # this is magic, see lib/ansible/module_common.py

--- a/cloud/openstack/os_networks_facts.py
+++ b/cloud/openstack/os_networks_facts.py
@@ -132,7 +132,7 @@ def main():
             openstack_networks=networks))
 
     except shade.OpenStackCloudException as e:
-        module.fail_json(msg=e.message)
+        module.fail_json(msg=str(e))
 
 # this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *

--- a/cloud/openstack/os_nova_flavor.py
+++ b/cloud/openstack/os_nova_flavor.py
@@ -232,7 +232,7 @@ def main():
             module.exit_json(changed=False)
 
     except shade.OpenStackCloudException as e:
-        module.fail_json(msg=e.message)
+        module.fail_json(msg=str(e))
 
 
 # this is magic, see lib/ansible/module_common.py

--- a/cloud/openstack/os_object.py
+++ b/cloud/openstack/os_object.py
@@ -117,7 +117,7 @@ def main():
 
         module.exit_json(changed=changed)
     except shade.OpenStackCloudException as e:
-        module.fail_json(msg=e.message)
+        module.fail_json(msg=str(e))
 
 # this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *

--- a/cloud/openstack/os_port.py
+++ b/cloud/openstack/os_port.py
@@ -383,7 +383,7 @@ def main():
             module.exit_json(changed=changed)
 
     except shade.OpenStackCloudException as e:
-        module.fail_json(msg=e.message)
+        module.fail_json(msg=str(e))
 
 # this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *

--- a/cloud/openstack/os_router.py
+++ b/cloud/openstack/os_router.py
@@ -352,7 +352,7 @@ def main():
                 module.exit_json(changed=True)
 
     except shade.OpenStackCloudException as e:
-        module.fail_json(msg=e.message)
+        module.fail_json(msg=str(e))
 
 
 # this is magic, see lib/ansible/module_common.py

--- a/cloud/openstack/os_security_group.py
+++ b/cloud/openstack/os_security_group.py
@@ -134,7 +134,7 @@ def main():
             module.exit_json(changed=changed)
 
     except shade.OpenStackCloudException as e:
-        module.fail_json(msg=e.message)
+        module.fail_json(msg=str(e))
 
 # this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *

--- a/cloud/openstack/os_security_group_rule.py
+++ b/cloud/openstack/os_security_group_rule.py
@@ -317,7 +317,7 @@ def main():
             module.exit_json(changed=changed)
 
     except shade.OpenStackCloudException as e:
-        module.fail_json(msg=e.message)
+        module.fail_json(msg=str(e))
 
 # this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *

--- a/cloud/openstack/os_server.py
+++ b/cloud/openstack/os_server.py
@@ -606,7 +606,7 @@ def main():
             _get_server_state(module, cloud)
             _delete_server(module, cloud)
     except shade.OpenStackCloudException as e:
-        module.fail_json(msg=e.message, extra_data=e.extra_data)
+        module.fail_json(msg=str(e), extra_data=e.extra_data)
 
 # this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *

--- a/cloud/openstack/os_server_actions.py
+++ b/cloud/openstack/os_server_actions.py
@@ -204,7 +204,7 @@ def main():
             module.exit_json(changed=True)
 
     except shade.OpenStackCloudException as e:
-        module.fail_json(msg=e.message, extra_data=e.extra_data)
+        module.fail_json(msg=str(e), extra_data=e.extra_data)
 
 # this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *

--- a/cloud/openstack/os_server_facts.py
+++ b/cloud/openstack/os_server_facts.py
@@ -89,7 +89,7 @@ def main():
             openstack_servers=openstack_servers))
 
     except shade.OpenStackCloudException as e:
-        module.fail_json(msg=e.message)
+        module.fail_json(msg=str(e))
 
 # this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *

--- a/cloud/openstack/os_server_volume.py
+++ b/cloud/openstack/os_server_volume.py
@@ -146,7 +146,7 @@ def main():
             )
 
     except (shade.OpenStackCloudException, shade.OpenStackCloudTimeout) as e:
-        module.fail_json(msg=e.message)
+        module.fail_json(msg=str(e))
 
 # this is magic, see lib/ansible/module_utils/common.py
 from ansible.module_utils.basic import *

--- a/cloud/openstack/os_subnet.py
+++ b/cloud/openstack/os_subnet.py
@@ -315,7 +315,7 @@ def main():
             module.exit_json(changed=changed)
 
     except shade.OpenStackCloudException as e:
-        module.fail_json(msg=e.message)
+        module.fail_json(msg=str(e))
 
 
 # this is magic, see lib/ansible/module_common.py

--- a/cloud/openstack/os_subnets_facts.py
+++ b/cloud/openstack/os_subnets_facts.py
@@ -145,7 +145,7 @@ def main():
             openstack_subnets=subnets))
 
     except shade.OpenStackCloudException as e:
-        module.fail_json(msg=e.message)
+        module.fail_json(msg=str(e))
 
 # this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *

--- a/cloud/openstack/os_user.py
+++ b/cloud/openstack/os_user.py
@@ -202,7 +202,7 @@ def main():
             module.exit_json(changed=changed)
 
     except shade.OpenStackCloudException as e:
-        module.fail_json(msg=e.message, extra_data=e.extra_data)
+        module.fail_json(msg=str(e), extra_data=e.extra_data)
 
 from ansible.module_utils.basic import *
 from ansible.module_utils.openstack import *

--- a/cloud/openstack/os_user_group.py
+++ b/cloud/openstack/os_user_group.py
@@ -106,7 +106,7 @@ def main():
         module.exit_json(changed=changed)
 
     except shade.OpenStackCloudException as e:
-        module.fail_json(msg=e.message, extra_data=e.extra_data)
+        module.fail_json(msg=str(e), extra_data=e.extra_data)
 
 
 from ansible.module_utils.basic import *

--- a/cloud/openstack/os_volume.py
+++ b/cloud/openstack/os_volume.py
@@ -153,7 +153,7 @@ def main():
         if state == 'absent':
             _absent_volume(module, cloud)
     except shade.OpenStackCloudException as e:
-        module.fail_json(msg=e.message)
+        module.fail_json(msg=str(e))
 
 # this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *


### PR DESCRIPTION
The exception message, when shade fails, will contain much more
specific information about the failure if the exception is treated
as a string. The 'message' attribute alone is usually not helpful.
