### PR TITLE
Remove explicit region parameter from ec2_ami_find

### DIFF
--- a/cloud/amazon/ec2_ami_find.py
+++ b/cloud/amazon/ec2_ami_find.py
@@ -293,8 +293,6 @@ def get_block_device_mapping(image):
 def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
-            region = dict(required=True,
-                aliases = ['aws_region', 'ec2_region']),
             owner = dict(required=False, default=None),
             ami_id = dict(required=False),
             ami_tags = dict(required=False, type='dict',


### PR DESCRIPTION
No need to specify the region parameter in the module when it uses the standard `ec2_argument_spec()`. Indeed it breaks when specifying the region by environment variable rather than configuring the playbook task with a `region` argument.

Before this change:

```
$ EC2_REGION=eu-west-1 ansible-playbook ami-find-test.yml -vv
Using /etc/ansible/ansible.cfg as config file
1 plays in ami-find-test.yml

PLAY ***************************************************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [ec2_ami_find] ************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "missing required arguments: region"}

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1
```

After this change:

```
$ EC2_REGION=eu-west-1 ansible-playbook ami-find-test.yml -vv
Using /etc/ansible/ansible.cfg as config file
1 plays in ami-find-test.yml

PLAY ***************************************************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [ec2_ami_find] ************************************************************
ok: [localhost] => {"changed": false, "results": [{"ami_id": "ami-050f3972", "architecture": "x86_64", "block_device_mapping": {"/dev/sda1": {"delete_on_termination": true, "encrypted": false, "size": 8, "snapshot_id": "snap-3a5f9f6d", "volume_type": "gp2"}, "/dev/sdb": {"delete_on_termination": false, "encrypted": null, "size": null, "snapshot_id": null, "volume_type": null}, "/dev/sdc": {"delete_on_termination": false, "encrypted": null, "size": null, "snapshot_id": null, "volume_type": null}}, "creationDate": "2015-10-08T08:54:46.000Z", "description": null, "hypervisor": "xen", "is_public": true, "location": "099720109477/ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20151007", "name": "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20151007", "owner_id": "099720109477", "platform": null, "root_device_name": "/dev/sda1", "root_device_type": "ebs", "state": "available", "tags": {}, "virtualization_type": "hvm"}]}

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0
```
