### PR TITLE
Update cron.py documentation

### DIFF
--- a/system/cron.py
+++ b/system/cron.py
@@ -45,7 +45,7 @@ version_added: "0.9"
 options:
   name:
     description:
-      - Description of a crontab entry.
+      - Description of a crontab entry. Required if state=absent
     default: null
     required: false
   user:


### PR DESCRIPTION
Minor update to documentation for the cron module to reflect the required "name" parameter when the value of "state" is "absent".
