### PR TITLE
Make it clear that the dest path delimiters must be escaped

### DIFF
--- a/windows/win_lineinfile.py
+++ b/windows/win_lineinfile.py
@@ -31,6 +31,7 @@ options:
     aliases: [ name, destfile ]
     description:
       - The path of the file to modify.
+      - Note that the Windows path delimiter '\' must be escaped as '\\' (see examples below)
   regexp:
     required: false
     description:


### PR DESCRIPTION
Make it clear that the dest path delimiters must be escaped
