### PR TITLE
Fix elasticache cache_security_group defaults

### DIFF
--- a/cloud/amazon/elasticache.py
+++ b/cloud/amazon/elasticache.py
@@ -480,7 +480,6 @@ class ElastiCacheManager(object):
 
 def main():
     argument_spec = ec2_argument_spec()
-    default = object()
     argument_spec.update(dict(
             state={'required': True, 'choices': ['present', 'absent', 'rebooted']},
             name={'required': True},
@@ -492,7 +491,7 @@ def main():
             cache_parameter_group={'required': False, 'default': None, 'aliases': ['parameter_group']},
             cache_port={'required': False, 'type': 'int'},
             cache_subnet_group={'required': False, 'default': None},
-            cache_security_groups={'required': False, 'default': [default],
+            cache_security_groups={'required': False, 'default': [],
                                 'type': 'list'},
             security_group_ids={'required': False, 'default': [],
                                 'type': 'list'},
@@ -526,12 +525,10 @@ def main():
     hard_modify = module.params['hard_modify']
     cache_parameter_group = module.params['cache_parameter_group']
 
-    if cache_subnet_group and cache_security_groups == [default]:
-        cache_security_groups = []
     if cache_subnet_group and cache_security_groups:
         module.fail_json(msg="Can't specify both cache_subnet_group and cache_security_groups")
 
-    if cache_security_groups == [default]:
+    if cache_subnet_group is None and cache_security_groups == []:
         cache_security_groups = ['default']
 
     if state == 'present' and not num_nodes:


### PR DESCRIPTION
This PR removes the `object()` default for `cache_security_groups`, which causes the module to fail with a `TypeError` in Ansible 2.0. This happens because the `invocation` of the module sets the value of `cache_security_groups` to `[object()]`, which fails parsing by either `exit_json()` or `fail_json()`.

It's worth noting that this change doesn't alter the behavior of the module, which should continue to set reasonable defaults for both VPC and non-VPC ElastiCache clusters.
