### PR TITLE
The parameters 'template' and 'template_url' are incorrectly required in all cases in the cloudformation module

### DIFF
--- a/cloud/amazon/cloudformation.py
+++ b/cloud/amazon/cloudformation.py
@@ -258,9 +258,6 @@ def main():
     if not HAS_BOTO:
         module.fail_json(msg='boto required for this module')
 
-    if module.params['template'] is None and module.params['template_url'] is None:
-        module.fail_json(msg='Either template or template_url expected')
-
     state = module.params['state']
     stack_name = module.params['stack_name']
 


### PR DESCRIPTION
The parameters 'template' and 'template_url' are incorrectly required in all cases in the cloudformation module

If the state is 'absent' they should not be required. A few lines below the correct check is already in place.

This commit fixes #2575, #2314
