### PR TITLE
Fix misspelling of the word 'certificate'

### DIFF
--- a/cloud/amazon/iam_cert.py
+++ b/cloud/amazon/iam_cert.py
@@ -65,7 +65,7 @@ options:
       - The path to the private key of the certificate in PEM encoded format.
   dup_ok:
     description:
-      - By default the module will not upload a certifcate that is already uploaded into AWS. If set to True, it will upload the certifcate as long as the name is unique.
+      - By default the module will not upload a certificate that is already uploaded into AWS. If set to True, it will upload the certificate as long as the name is unique.
     required: false
     default: False
     aliases: []
@@ -93,7 +93,7 @@ extends_documentation_fragment:
 EXAMPLES = '''
 # Basic server certificate upload
 tasks:
-- name: Upload Certifcate
+- name: Upload Certificate
   iam_cert:
     name: very_ssl
     state: present
@@ -164,7 +164,7 @@ def dup_check(module, iam, name, new_name, cert, orig_cert_names, orig_cert_bodi
                     elif orig_cert_bodies[c_index] != cert:
                         module.fail_json(changed=False, msg='A cert with the name %s already exists and'
                                                            ' has a different certificate body associated'
-                                                           ' with it. Certifcates cannot have the same name')
+                                                           ' with it. Certificates cannot have the same name')
             else:
                 update=True
                 break
@@ -218,7 +218,7 @@ def cert_action(module, iam, name, cpath, new_name, new_path, state,
             module.exit_json(changed=changed, deleted_cert=name)
         else:
             changed=False
-            module.exit_json(changed=changed, msg='Certifcate with the name %s already absent' % name)
+            module.exit_json(changed=changed, msg='Certificate with the name %s already absent' % name)
 
 def main():
     argument_spec = ec2_argument_spec()


### PR DESCRIPTION
This is just a trivial typo fix. It helps when searching for the word 'certificate'.
