### PR TITLE
add an IPv6 option to Digital Ocean droplet creation module

### DIFF
--- a/cloud/digital_ocean/digital_ocean.py
+++ b/cloud/digital_ocean/digital_ocean.py
@@ -86,6 +86,12 @@ options:
     version_added: "1.10"
     required: false
     default: None
+  ipv6:
+    description:
+     - Optional, Boolean, enables IPv6 for your droplet.
+    version_added: "2.1?"
+    default: "no"
+    choices: [ "yes", "no" ]
   wait:
     description:
      - Wait for the droplet to be in state 'running' before returning.  If wait is "no" an ip_address may not be returned.
@@ -239,10 +245,11 @@ class Droplet(JsonfyMixIn):
         cls.manager = DoManager(None, api_token, api_version=2)
 
     @classmethod
-    def add(cls, name, size_id, image_id, region_id, ssh_key_ids=None, virtio=True, private_networking=False, backups_enabled=False, user_data=None):
+    def add(cls, name, size_id, image_id, region_id, ssh_key_ids=None, virtio=True, private_networking=False, backups_enabled=False, user_data=None, ipv6=False):
         private_networking_lower = str(private_networking).lower()
         backups_enabled_lower = str(backups_enabled).lower()
-        json = cls.manager.new_droplet(name, size_id, image_id, region_id, ssh_key_ids, virtio, private_networking_lower, backups_enabled_lower,user_data)
+        ipv6_lower = str(ipv6).lower()
+        json = cls.manager.new_droplet(name, size_id, image_id, region_id, ssh_key_ids, virtio, private_networking_lower, backups_enabled_lower, user_data, ipv6_lower)
         droplet = cls(json)
         return droplet
 
@@ -346,6 +353,7 @@ def core(module):
                     private_networking=module.params['private_networking'],
                     backups_enabled=module.params['backups_enabled'],
                     user_data=module.params.get('user_data'),
+                    ipv6=module.params['ipv6'],
                 )
 
             if droplet.is_powered_on():
@@ -406,6 +414,7 @@ def main():
             virtio = dict(type='bool', default='yes'),
             private_networking = dict(type='bool', default='no'),
             backups_enabled = dict(type='bool', default='no'),
+            ipv6 = dict(type='bool', default='no'),
             id = dict(aliases=['droplet_id'], type='int'),
             unique_name = dict(type='bool', default='no'),
             user_data = dict(default=None),


### PR DESCRIPTION
The option to request IPv6 for a droplet already exist in dopy. This commit simply exposes it to ansible users, following closely the existing code conventions.
