### PR TITLE
Fixed typo in example playbook

### DIFF
--- a/cloud/amazon/ec2.py
+++ b/cloud/amazon/ec2.py
@@ -465,7 +465,7 @@ EXAMPLES = '''
         wait: True
         vpc_subnet_id: subnet-29e63245
         assign_public_ip: yes
-  role:
+  roles:
     - do_neat_stuff
     - do_more_neat_stuff
 


### PR DESCRIPTION
Changed `role:` to `roles:` in the documentation part.

A minor correction; nevertheless typo was causing an error if someone started with the example.
