### PR TITLE
docker: If cmd and entrypoint not set, don't match them

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -1474,10 +1474,17 @@ class DockerManager(object):
 
                 image_matches = running_image in repo_tags
 
-                command_matches = command == details['Config']['Cmd']
-                entrypoint_matches = (
-                    entrypoint == details['Config']['Entrypoint']
-                )
+                if command == None:
+                    command_matches = True
+                else:
+                    command_matches = (command == details['Config']['Cmd'])
+
+                if entrypoint == None:
+                    entrypoint_matches = True
+                else:
+                    entrypoint_matches = (
+                        entrypoint == details['Config']['Entrypoint']
+                    )
 
                 matches = (image_matches and command_matches and
                            entrypoint_matches)


### PR DESCRIPTION
Hello!
I wanted stop the containers matched only by image name, but can't do this, if I not set cmd in playbook.
This behavior confused me.

If cmd or entrypoint is defined for running container, but not defined in playbook, makes matching behavior as this sample:
https://github.com/ansible/ansible-modules-core/blob/devel/cloud/docker/docker.py#L463
