### PR TITLE
Update django_manage documentation

### DIFF
--- a/web_infrastructure/django_manage.py
+++ b/web_infrastructure/django_manage.py
@@ -90,8 +90,9 @@ notes:
    - I(virtualenv) (U(http://www.virtualenv.org)) must be installed on the remote host if the virtualenv parameter is specified.
    - This module will create a virtualenv if the virtualenv parameter is specified and a virtualenv does not already exist at the given location.
    - This module assumes English error messages for the 'createcachetable' command to detect table existence, unfortunately.
-   - To be able to use the migrate command with django versions < 1.7, you must have south installed and added as an app in your settings
-   - To be able to use the collectstatic command, you must have enabled staticfiles in your settings
+   - To be able to use the migrate command with django versions < 1.7, you must have south installed and added as an app in your settings.
+   - To be able to use the collectstatic command, you must have enabled staticfiles in your settings.
+   - As of ansible 2.x, your I(manage.py) application must be executable (rwxr-xr-x), and must have a valid I(shebang), i.e. "#!/usr/bin/env python", for invoking the appropriate Python interpreter.
 requirements: [ "virtualenv", "django" ]
 author: "Scott Anderson (@tastychutney)"
 '''


### PR DESCRIPTION
As of Ansible 2.x, invocation of Django's `manage.py` requires a valid "shebang". Additionally, `manage.py` must be executable.
The old invocation was hardcoded as `python manage.py ...` while the new invocation is `./manage.py ...`. See [this PR](https://github.com/ansible/ansible-modules-core/pull/1165).
This change allows more flexibility for which Python interpreter is invoked, but breaks existing deployment when `manage.py` is not properly configured. This documentation update adds a note explaining the new requirements for `manage.py`.
