### PR TITLE
Add custom diff field to synchronize module

### DIFF
--- a/files/synchronize.py
+++ b/files/synchronize.py
@@ -389,8 +389,14 @@ def main():
         out_lines=out_clean.split('\n')
         while '' in out_lines: 
             out_lines.remove('')
-        return module.exit_json(changed=changed, msg=out_clean,
-                                rc=rc, cmd=cmdstr, stdout_lines=out_lines)
+        if module._diff:
+            diff = {'prepared': out_clean}
+            return module.exit_json(changed=changed, msg=out_clean,
+                                    rc=rc, cmd=cmdstr, stdout_lines=out_lines,
+                                    diff=diff)
+        else:
+            return module.exit_json(changed=changed, msg=out_clean,
+                                    rc=rc, cmd=cmdstr, stdout_lines=out_lines)
 
 # import module snippets
 from ansible.module_utils.basic import *


### PR DESCRIPTION
This PR depends on pull request ansible/ansible#14105

rsync has a custom diff output that cannot easily be expressed as
`/usr/bin/diff before after`

Use the diff['custom'] key introduced in the above PR to show a useful diff to the user who requested it.

Closes Issue https://github.com/ansible/ansible/issues/11262
