### PR TITLE
Add support for encrypted EBS volumes in launch configuration

### DIFF
--- a/cloud/amazon/ec2.py
+++ b/cloud/amazon/ec2.py
@@ -755,7 +755,7 @@ def create_block_device(module, ec2, volume):
             if int(volume['iops']) > MAX_IOPS_TO_SIZE_RATIO * size:
                 module.fail_json(msg = 'IOPS must be at most %d times greater than size' % MAX_IOPS_TO_SIZE_RATIO)
         if 'encrypted' in volume:
-            module.fail_json(msg = 'You can not set encyrption when creating a volume from a snapshot')
+            module.fail_json(msg = 'You can not set encryption when creating a volume from a snapshot')
     if 'ephemeral' in volume:
         if 'snapshot' in volume:
             module.fail_json(msg = 'Cannot set both ephemeral and snapshot')

--- a/cloud/amazon/ec2_lc.py
+++ b/cloud/amazon/ec2_lc.py
@@ -167,6 +167,8 @@ def create_block_device(module, volume):
     if 'snapshot' in volume:
         if 'device_type' in volume and volume.get('device_type') == 'io1' and 'iops' not in volume:
             module.fail_json(msg='io1 volumes must have an iops value set')
+        if 'encrypted' in volume:
+            module.fail_json(msg = 'You can not set encryption when creating a volume from a snapshot')
     if 'ephemeral' in volume:
         if 'snapshot' in volume:
             module.fail_json(msg='Cannot set both ephemeral and snapshot')
@@ -175,7 +177,8 @@ def create_block_device(module, volume):
                            size=volume.get('volume_size'),
                            volume_type=volume.get('device_type'),
                            delete_on_termination=volume.get('delete_on_termination', False),
-                           iops=volume.get('iops'))
+                           iops=volume.get('iops'),
+                           encrypted=volume.get('encrypted', None))
 
 
 def create_launch_config(connection, module):


### PR DESCRIPTION
Add support for encrypted EBS volumes in launch configuration. This uses the same logic as encrypted volumes in the ec2 module.
