### PR TITLE
Ignore errors while deleting a directory using force

### DIFF
--- a/files/file.py
+++ b/files/file.py
@@ -247,7 +247,7 @@ def main():
             if not module.check_mode:
                 if prev_state == 'directory':
                     try:
-                        shutil.rmtree(path, ignore_errors=False)
+                        shutil.rmtree(path, ignore_errors=force)
                     except Exception, e:
                         module.fail_json(msg="rmtree failed: %s" % str(e))
                 else:


### PR DESCRIPTION
I propose to use the `force` flag in the file module to force removal of a non-empty directory.
For example, when removing a cache directory the command will fail if an application writes to the directory at the same time. We could use the `force` flag ignore these errors.
See:
- http://stackoverflow.com/questions/1557351/python-delete-non-empty-dir#answer-21966211 
- https://docs.python.org/3/library/shutil.html#shutil.rmtree
