### PR TITLE
Clarify get_url timeout documentation

### DIFF
--- a/network/basics/get_url.py
+++ b/network/basics/get_url.py
@@ -98,8 +98,8 @@ options:
         destination file will be calculated after it is downloaded to ensure
         its integrity and verify that the transfer completed successfully.
         Format: <algorithm>:<checksum>, e.g.: checksum="sha256:D98291AC[...]B6DC7B97"
-        If you worry about portability, only the sha1 algorithm is available 
-        on all platforms and python versions.  The third party hashlib 
+        If you worry about portability, only the sha1 algorithm is available
+        on all platforms and python versions.  The third party hashlib
         library can be installed for access to additional algorithms.
         Additionaly, if a checksum is passed to this parameter, and the file exist under
         the C(dest) location, the destination_checksum would be calculated, and if
@@ -124,7 +124,7 @@ options:
     choices: ['yes', 'no']
   timeout:
     description:
-      - Timeout for URL request
+      - Timeout in seconds for URL request
     required: false
     default: 10
     version_added: '1.8'


### PR DESCRIPTION
As I'm not very familiar with Python, I had to lookup the unit of the timeout in urllib2 documentation. I thought it would be helpful to others to include it in the module documentation directly.
