### PR TITLE
Show error if python-apt is absent in check mode.

### DIFF
--- a/packaging/os/apt_repository.py
+++ b/packaging/os/apt_repository.py
@@ -129,6 +129,8 @@ def install_python_apt(module):
                 HAVE_PYTHON_APT = True
             else:
                 module.fail_json(msg="Failed to auto-install python-apt. Error was: '%s'" % se.strip())
+    else:
+        module.fail_json(msg="python-apt must be installed to use check mode")
 
 class InvalidSource(Exception):
     pass


### PR DESCRIPTION
When using the apt_repository module in check mode, show an error if python-apt is not installed:

```
localhost | FAILED! => {
    "changed": false,
    "failed": true,
    "msg": "python-apt must be installed to use check mode"
}
```

Previously this would fail with an exception which did not clearly explain the reason for the failure:

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: NameError: global name 'aptsources_distro' is not defined
localhost | FAILED! => {
    "changed": false,
    "failed": true,
    "parsed": false
}
```

This should resolve https://github.com/ansible/ansible/issues/13520.
