### PR TITLE
Split shell command to avoid use_unsafe_shell.

### DIFF
--- a/packaging/os/apt.py
+++ b/packaging/os/apt.py
@@ -567,7 +567,8 @@ def main():
 
     if not HAS_PYTHON_APT:
         try:
-            module.run_command('apt-get update && apt-get install python-apt -y -q --force-yes', use_unsafe_shell=True, check_rc=True)
+            module.run_command('apt-get update', check_rc=True)
+            module.run_command('apt-get install python-apt -y -q', check_rc=True)
             global apt, apt_pkg
             import apt
             import apt.debfile


### PR DESCRIPTION
This mirrors a nearly identical change made to apt_repository.py in 
commit https://github.com/mscherer/ansible-modules-core/commit/8c5e8f042524ab464f6e46e435f2932abba1ad5c (PR https://github.com/ansible/ansible-modules-core/pull/2661).

Also removes the use of apt-get --force-yes as it can be dangerous
and should not be necessary (apt_repository.py does not use it).

Repeating the explanation from the apt_respository change below:

Since use_unsafe_shell is suspicious from a security point
of view (or it wouldn't be unsafe), the less we have, the less
code we have to thoroughly inspect for a security audit.

In this case, the '&&' can be replaced by doing 2 calls to run_command.
