### PR TITLE
add `env_file` support

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -223,6 +223,15 @@ options:
     description:
       - Pass a dict of environment variables to the container.
     default: null
+  env_file:
+    version_added: "2.1"
+    description:
+      - Pass in a path to a file with environment variable (FOO=BAR).
+        If a key value is present in both explicitly presented (i.e. as 'env')
+        and in the environment file, the explicit value will override.
+        Requires docker-py >= 1.4.0.
+    default: null
+    required: false
   dns:
     description:
       - List of custom DNS servers for the container.
@@ -661,7 +670,8 @@ class DockerManager(object):
             'labels': ((1, 2, 0), '1.18'),
             'stop_timeout': ((0, 5, 0), '1.0'),
             # Clientside only
-            'insecure_registry': ((0, 5, 0), '0.0')
+            'insecure_registry': ((0, 5, 0), '0.0'),
+            'env_file': ((1, 4, 0), '0.0')
             }
 
     def __init__(self, module):
@@ -712,7 +722,9 @@ class DockerManager(object):
         if self.module.params.get('links'):
             self.links = self.get_links(self.module.params.get('links'))
 
-        self.env = self.module.params.get('env', None)
+        env = self.module.params.get('env', None)
+        env_file = self.module.params.get('env_file', None)
+        self.environment = self.get_environment(env, env_file)
 
         # Connect to the docker server using any configured host and TLS settings.
 
@@ -837,6 +849,25 @@ class DockerManager(object):
                     self._cap_ver_req[capability][1],
                     '.'.join(map(str, self.docker_py_versioninfo)),
                     api_version))
+
+    def get_environment(self, env, env_file):
+        """
+        If environment files are combined with explicit environment variables, the explicit environment variables will override the key from the env file.
+        """
+        final_env = {}
+
+        if env_file:
+            self.ensure_capability('env_file')
+            parsed_env_file = docker.utils.parse_env_file(env_file)
+
+            for name, value in parsed_env_file.iteritems():
+                final_env[name] = str(value)
+
+        if env:
+            for name, value in env.iteritems():
+                final_env[name] = str(value)
+
+        return final_env
 
     def get_links(self, links):
         """
@@ -1203,8 +1234,8 @@ class DockerManager(object):
                 name, value = image_env.split('=', 1)
                 expected_env[name] = value
 
-            if self.env:
-                for name, value in self.env.iteritems():
+            if self.environment:
+                for name, value in self.environment.iteritems():
                     expected_env[name] = str(value)
 
             actual_env = {}
@@ -1545,7 +1576,7 @@ class DockerManager(object):
                   'command':      self.module.params.get('command'),
                   'ports':        self.exposed_ports,
                   'volumes':      self.volumes,
-                  'environment':  self.env,
+                  'environment':  self.environment,
                   'labels':       self.module.params.get('labels'),
                   'hostname':     self.module.params.get('hostname'),
                   'domainname':   self.module.params.get('domainname'),
@@ -1788,6 +1819,7 @@ def main():
             hostname        = dict(default=None),
             domainname      = dict(default=None),
             env             = dict(type='dict'),
+            env_file        = dict(default=None),
             dns             = dict(),
             detach          = dict(default=True, type='bool'),
             state           = dict(default='started', choices=['present', 'started', 'reloaded', 'restarted', 'stopped', 'killed', 'absent', 'running']),


### PR DESCRIPTION
This adds a new configuration parameter `env_file`. When `env_file` and `env` properties are present, they will be merged, while `env` parameters override the same keys of `env_file`. This is identical to the behaviour of the official Docker client.

_note_: credits go to @vpetersson, see #2155 and #792. This PR obsoletes #2155.
