### PR TITLE
Fix for os_server module when specifying region

### DIFF
--- a/cloud/openstack/os_server.py
+++ b/cloud/openstack/os_server.py
@@ -450,7 +450,7 @@ def _create_server(module, cloud):
         config_drive=module.params['config_drive'],
     )
     for optional_param in (
-            'region_name', 'key_name', 'availability_zone', 'network',
+            'key_name', 'availability_zone', 'network',
             'volume_size', 'volumes'):
         if module.params[optional_param]:
             bootkwargs[optional_param] = module.params[optional_param]


### PR DESCRIPTION
Fix the OpenStack os_server module for when region_name is specified.
This should not be passed through to the shade create_server() call
as it's only used with the auth parameters. Removed from the examples
where a cloud is named since region should be given in the clouds.yaml
cloud definition.

Fixes bug: https://github.com/ansible/ansible-modules-core/issues/2797
