### PR TITLE
use new method of setting locale and other environment variables

### DIFF
--- a/packaging/os/apt.py
+++ b/packaging/os/apt.py
@@ -181,9 +181,14 @@ import itertools
 
 # APT related constants
 APT_ENV_VARS = dict(
-  DEBIAN_FRONTEND = 'noninteractive',
-  DEBIAN_PRIORITY = 'critical',
-  LANG = 'C'
+        DEBIAN_FRONTEND = 'noninteractive',
+        DEBIAN_PRIORITY = 'critical',
+        # We screenscrape apt-get and aptitude output for information so we need
+        # to make sure we use the C locale when running commands
+        LANG = 'C',
+        LC_ALL = 'C',
+        LC_MESSAGES = 'C',
+        LC_CTYPE = 'C',
 )
 
 DPKG_OPTIONS = 'force-confdef,force-confold'
@@ -388,9 +393,6 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
         else:
             autoremove = ''
 
-        for (k,v) in APT_ENV_VARS.iteritems():
-            os.environ[k] = v
-
         if build_dep:
             cmd = "%s -y %s %s %s build-dep %s" % (APT_GET_CMD, dpkg_options, force_yes, check_arg, packages)
         else:
@@ -455,9 +457,6 @@ def install_deb(m, debs, cache, force, install_recommends, dpkg_options):
         if force:
             options += " --force-all"
 
-        for (k,v) in APT_ENV_VARS.iteritems():
-            os.environ[k] = v
-
         cmd = "dpkg %s -i %s" % (options, " ".join(pkgs_to_install))
         rc, out, err = m.run_command(cmd)
         if "stdout" in retvals:
@@ -494,9 +493,6 @@ def remove(m, pkgspec, cache, purge=False,
             purge = '--purge'
         else:
             purge = ''
-
-        for (k,v) in APT_ENV_VARS.iteritems():
-            os.environ[k] = v
 
         if autoremove:
             autoremove = '--auto-remove'
@@ -546,9 +542,6 @@ def upgrade(m, mode="yes", force=False, default_release=None,
 
     apt_cmd_path = m.get_bin_path(apt_cmd, required=True)
 
-    for (k,v) in APT_ENV_VARS.iteritems():
-        os.environ[k] = v
-
     cmd = '%s -y %s %s %s %s' % (apt_cmd_path, dpkg_options,
                                     force_yes, check_arg, upgrade_command)
 
@@ -582,6 +575,8 @@ def main():
         required_one_of = [['package', 'upgrade', 'update_cache', 'deb']],
         supports_check_mode = True
     )
+
+    module.run_command_environ_update = APT_ENV_VARS
 
     if not HAS_PYTHON_APT:
         try:


### PR DESCRIPTION
The old method left settings in the environment.  The new method takes
care of clearing them after use.  In this module, the old method was
also setting the environment too late to affect all the command line
tools which lead to a bug.

Fixes #14264
