### PR TITLE
Fix docker container restart

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -1729,6 +1729,8 @@ def restarted(manager, containers, count, name):
         manager.stop_containers([container])
         manager.remove_containers([container])
 
+    containers.refresh()
+
     manager.restart_containers(containers.running)
     started(manager, containers, count, name)
 


### PR DESCRIPTION
https://github.com/ansible/ansible-modules-core/issues/2824

restart_containers(containers.running) may try to restart containers
that are deleted when looping through get_differing_containers()
fix this by refreshing list after first loop
