### PR TITLE
Add user_data alias for userdata in os_server

### DIFF
--- a/cloud/openstack/os_server.py
+++ b/cloud/openstack/os_server.py
@@ -545,7 +545,7 @@ def main():
         network                         = dict(default=None),
         nics                            = dict(default=[], type='list'),
         meta                            = dict(default=None),
-        userdata                        = dict(default=None),
+        userdata                        = dict(default=None, aliases=['user_data']),
         config_drive                    = dict(default=False, type='bool'),
         auto_ip                         = dict(default=True, type='bool', aliases=['auto_floating_ip', 'public_ip']),
         floating_ips                    = dict(default=None),


### PR DESCRIPTION
The old nova_compute module called the parameter user_data - having an
alias to the old name is friendly.

Fixes Issue #2920
