### PR TITLE
Documentation Adjustments for Digital Ocean module

### DIFF
--- a/cloud/digital_ocean/digital_ocean.py
+++ b/cloud/digital_ocean/digital_ocean.py
@@ -115,26 +115,28 @@ EXAMPLES = '''
 # If a key matches this name, will return the ssh key id and changed = False
 # If no existing key matches this name, a new key is created, the ssh key id is returned and changed = False
 
-- digital_ocean: >
-      state=present
-      command=ssh
-      name=my_ssh_key
-      ssh_pub_key='ssh-rsa AAAA...'
-      api_token=XXX
+- digital_ocean:
+    state: present
+    command: ssh
+    name: my_ssh_key
+    ssh_pub_key: 'ssh-rsa AAAA...'
+    api_token: XXX
 
 # Create a new Droplet
 # Will return the droplet details including the droplet id (used for idempotence)
 
-- digital_ocean: >
-      state=present
-      command=droplet
-      name=mydroplet
-      api_token=XXX
-      size_id=2gb
-      region_id=ams2
-      image_id=fedora-19-x64
-      wait_timeout=500
+- digital_ocean:
+    state: present
+    command: droplet
+    name: mydroplet
+    api_token: XXX
+    size_id: 2gb
+    region_id: ams2
+    image_id: fedora-19-x64
+    wait_timeout: 500
+
   register: my_droplet
+
 - debug: msg="ID is {{ my_droplet.droplet.id }}"
 - debug: msg="IP is {{ my_droplet.droplet.ip_address }}"
 
@@ -142,30 +144,31 @@ EXAMPLES = '''
 # If droplet id already exist, will return the droplet details and changed = False
 # If no droplet matches the id, a new droplet will be created and the droplet details (including the new id) are returned, changed = True.
 
-- digital_ocean: >
-      state=present
-      command=droplet
-      id=123
-      name=mydroplet
-      api_token=XXX
-      size_id=2gb
-      region_id=ams2
-      image_id=fedora-19-x64
-      wait_timeout=500
+- digital_ocean:
+    state: present
+    command: droplet
+    id: 123
+    name: mydroplet
+    api_token: XXX
+    size_id: 2gb
+    region_id: ams2
+    image_id: fedora-19-x64
+    wait_timeout: 500
 
 # Create a droplet with ssh key
 # The ssh key id can be passed as argument at the creation of a droplet (see ssh_key_ids).
 # Several keys can be added to ssh_key_ids as id1,id2,id3
 # The keys are used to connect as root to the droplet.
 
-- digital_ocean: >
-      state=present
-      ssh_key_ids=123,456
-      name=mydroplet
-      api_token=XXX
-      size_id=2gb
-      region_id=ams2
-      image_id=fedora-19-x64
+- digital_ocean:
+    state: present
+    ssh_key_ids: 123,456
+    name: mydroplet
+    api_token: XXX
+    size_id: 2gb
+    region_id: ams2
+    image_id: fedora-19-x64
+
 '''
 
 import os

--- a/cloud/digital_ocean/digital_ocean.py
+++ b/cloud/digital_ocean/digital_ocean.py
@@ -115,26 +115,28 @@ EXAMPLES = '''
 # If a key matches this name, will return the ssh key id and changed = False
 # If no existing key matches this name, a new key is created, the ssh key id is returned and changed = False
 
-- digital_ocean: >
-      state=present
-      command=ssh
-      name=my_ssh_key
-      ssh_pub_key='ssh-rsa AAAA...'
-      api_token=XXX
+- digital_ocean:
+    state: present
+    command: ssh
+    name: my_ssh_key
+    ssh_pub_key: 'ssh-rsa AAAA...'
+    api_token: XXX
 
 # Create a new Droplet
 # Will return the droplet details including the droplet id (used for idempotence)
 
-- digital_ocean: >
-      state=present
-      command=droplet
-      name=mydroplet
-      api_token=XXX
-      size_id=2gb
-      region_id=ams2
-      image_id=fedora-19-x64
-      wait_timeout=500
+- digital_ocean:
+    state: present
+    command: droplet
+    name: mydroplet
+    api_token: XXX
+    size_id: 2gb
+    region_id: ams2
+    image_id: fedora-19-x64
+    wait_timeout: 500
+
   register: my_droplet
+
 - debug: msg="ID is {{ my_droplet.droplet.id }}"
 - debug: msg="IP is {{ my_droplet.droplet.ip_address }}"
 
@@ -142,30 +144,30 @@ EXAMPLES = '''
 # If droplet id already exist, will return the droplet details and changed = False
 # If no droplet matches the id, a new droplet will be created and the droplet details (including the new id) are returned, changed = True.
 
-- digital_ocean: >
-      state=present
-      command=droplet
-      id=123
-      name=mydroplet
-      api_token=XXX
-      size_id=2gb
-      region_id=ams2
-      image_id=fedora-19-x64
-      wait_timeout=500
+- digital_ocean:
+    state: present
+    command: droplet
+    id: 123
+    name: mydroplet
+    api_token: XXX
+    size_id: 2gb
+    region_id: ams2
+    image_id: fedora-19-x64
+    wait_timeout: 500
 
 # Create a droplet with ssh key
 # The ssh key id can be passed as argument at the creation of a droplet (see ssh_key_ids).
 # Several keys can be added to ssh_key_ids as id1,id2,id3
 # The keys are used to connect as root to the droplet.
 
-- digital_ocean: >
-      state=present
-      ssh_key_ids=123,456
-      name=mydroplet
-      api_token=XXX
-      size_id=2gb
-      region_id=ams2
-      image_id=fedora-19-x64
+- digital_ocean:
+    state: present
+    ssh_key_ids: 123,456
+    name: mydroplet
+    api_token: XXX
+    size_id: 2gb
+    region_id: ams2
+    image_id: fedora-19-x64
 '''
 
 import os

--- a/cloud/digital_ocean/digital_ocean_domain.py
+++ b/cloud/digital_ocean/digital_ocean_domain.py
@@ -57,25 +57,28 @@ requirements:
 EXAMPLES = '''
 # Create a domain record
 
-- digital_ocean_domain: >
-      state=present
-      name=my.digitalocean.domain
-      ip=127.0.0.1
+- digital_ocean_domain:
+    state: present
+    name: my.digitalocean.domain
+    ip: 127.0.0.1
 
 # Create a droplet and a corresponding domain record
 
-- digital_ocean: >
-      state=present
-      name=test_droplet
-      size_id=1gb
-      region_id=sgp1
-      image_id=ubuntu-14-04-x64
+- digital_ocean:
+    state: present
+    name: test_droplet
+    size_id: 1gb
+    region_id: sgp1
+    image_id: ubuntu-14-04-x64
+
+
   register: test_droplet
 
-- digital_ocean_domain: >
-      state=present
-      name={{ test_droplet.droplet.name }}.my.domain
-      ip={{ test_droplet.droplet.ip_address }}
+- digital_ocean_domain:
+    state: present
+    name: "{{ test_droplet.droplet.name }}.my.domain"
+    ip: "{{ test_droplet.droplet.ip_address }}"
+
 '''
 
 import os

--- a/cloud/digital_ocean/digital_ocean_sshkey.py
+++ b/cloud/digital_ocean/digital_ocean_sshkey.py
@@ -59,12 +59,12 @@ EXAMPLES = '''
 # If a key matches this name, will return the ssh key id and changed = False
 # If no existing key matches this name, a new key is created, the ssh key id is returned and changed = False
 
-- digital_ocean_sshkey: >
-      state=present
-      name=my_ssh_key
-      ssh_pub_key='ssh-rsa AAAA...'
-      client_id=XXX
-      api_key=XXX
+- digital_ocean_sshkey:
+    state: present
+    name: my_ssh_key
+    ssh_pub_key: 'ssh-rsa AAAA...'
+    client_id: XXX
+    api_key: XXX
 
 '''
 


### PR DESCRIPTION
Documentation updates to use complete YAML : syntax instead of key=val syntax.

Adjusted example to use "" where appropriate to pass YAML Syntax checker per Contribution guidelines.

See Issue [# 2879](https://github.com/ansible/ansible-modules-core/issues/2879)
