### PR TITLE
Fix for docker container labels

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -1225,9 +1225,12 @@ class DockerManager(object):
                 expected_labels[name] = str(value)
 
             actual_labels = {}
-            for container_label in container['Config']['Labels'] or []:
-                name, value = container_label.split('=', 1)
-                actual_labels[name] = value
+            if type(container['Config']['Labels']) is dict:
+                actual_labels = container['Config']['Labels']
+            else:
+                for container_label in container['Config']['Labels'] or []:
+                    name, value = container_label.split('=', 1)
+                    actual_labels[name] = value
 
             if actual_labels != expected_labels:
                 self.reload_reasons.append('labels {0} => {1}'.format(actual_labels, expected_labels))


### PR DESCRIPTION
Given a container image with labels included. When the container is
reloaded the docker module complains about parsing the present
labels. This is because the labels datastructure changed from docker api
version 1.17 to 1.18. It was a list but it became a dictionary.

This commit allows both list and dictionary versions of the api to be
parsed correctly.
