### PR TITLE
Enable env vars for vsphere_guest

### DIFF
--- a/cloud/vmware/vsphere_guest.py
+++ b/cloud/vmware/vsphere_guest.py
@@ -1562,9 +1562,18 @@ def main():
 
     module = AnsibleModule(
         argument_spec=dict(
-            vcenter_hostname=dict(required=True, type='str'),
-            username=dict(required=True, type='str'),
-            password=dict(required=True, type='str', no_log=True),
+            vcenter_hostname=dict(
+                type='str',
+                default=os.environ['VMWARE_HOST']
+            ),
+            username=dict(
+                type='str',
+                default=os.environ['VMWARE_USER']
+            ),
+            password=dict(
+                type='str', no_log=True,
+                default=os.environ['VMWARE_PASSWORD']
+            ),
             state=dict(
                 required=False,
                 choices=[


### PR DESCRIPTION
This commit allows the connection information for
the vsphere_guest module to be provided as environment
variables, which makes it possible to use Cloud
Credentials from Ansible Tower in playbooks that utilize
vsphere_guest.

| ENV VAR | vsphere_guest param |
| --- | --- |
| VMWARE_HOST | vcenter_hostname |
| VMWARE_USER | username |
| VMWARE_PASSWORD | password |
