### PR TITLE
Do not install python-apt in check mode.

### DIFF
--- a/packaging/os/apt.py
+++ b/packaging/os/apt.py
@@ -579,6 +579,8 @@ def main():
     module.run_command_environ_update = APT_ENV_VARS
 
     if not HAS_PYTHON_APT:
+        if module.check_mode:
+            module.fail_json(msg="python-apt must be installed to use check mode")
         try:
             module.run_command('apt-get update && apt-get install python-apt -y -q --force-yes', use_unsafe_shell=True, check_rc=True)
             global apt, apt_pkg


### PR DESCRIPTION
Resolves #3012 by returning an error in check mode if python-apt is not installed:

```
root@ubuntu1404-os:~# ansible -m apt -a 'name=nginx state=absent' --check localhost
localhost | FAILED! => {
    "changed": false,
    "failed": true,
    "msg": "python-apt must be installed to use check mode"
}
```

Tested on Ubuntu 14.04 LTS.
