### PR TITLE
Log git error stdout/stderr to fail_json

### DIFF
--- a/source_control/git.py
+++ b/source_control/git.py
@@ -650,7 +650,8 @@ def switch_version(git_path, module, dest, remote, version, verify_commit):
             else:
                 (rc, out, err) = module.run_command("%s checkout --force %s" % (git_path, version), cwd=dest)
                 if rc != 0:
-                    module.fail_json(msg="Failed to checkout branch %s" % version)
+                    module.fail_json(msg="Failed to checkout branch %s" % version,
+                                     stdout=out, stderr=err, rc=rc)
                 cmd = "%s reset --hard %s/%s" % (git_path, remote, version)
         else:
             cmd = "%s checkout --force %s" % (git_path, version)
@@ -658,14 +659,17 @@ def switch_version(git_path, module, dest, remote, version, verify_commit):
         branch = get_head_branch(git_path, module, dest, remote)
         (rc, out, err) = module.run_command("%s checkout --force %s" % (git_path, branch), cwd=dest)
         if rc != 0:
-            module.fail_json(msg="Failed to checkout branch %s" % branch)
+            module.fail_json(msg="Failed to checkout branch %s" % branch,
+                             stdout=out, stderr=err, rc=rc)
         cmd = "%s reset --hard %s" % (git_path, remote)
     (rc, out1, err1) = module.run_command(cmd, cwd=dest)
     if rc != 0:
         if version != 'HEAD':
-            module.fail_json(msg="Failed to checkout %s" % (version), stdout=out1, stderr=err1)
+            module.fail_json(msg="Failed to checkout %s" % (version),
+                             stdout=out1, stderr=err1, rc=rc, cmd=cmd)
         else:
-            module.fail_json(msg="Failed to checkout branch %s" % (branch))
+            module.fail_json(msg="Failed to checkout branch %s" % (branch),
+                             stdout=out1, stderr=err1, rc=rc, cmd=cmd)
 
     if verify_commit:
         verify_commit_sign(git_path, module, dest, version)


### PR DESCRIPTION
This changeset logs the stdout and stderr output as well as return code from `switch_version` in the core git module to `fail_json` to assist users debugging failed git operations.

We recently had a shallow clone of a repo on branchA and `ansible-pull --checkout=branchB` was failing with just 

> ```
> "msg": "Failed to checkout branchB",
> ```

in the error JSON output.

This change would include the raw git output in the JSON so it's more obvious what exactly went wrong

>    "msg": "Failed to checkout branchB",
>     "rc": 128, 
>     "stderr": "fatal: Cannot update paths and switch to branch 'branchB' at the same time.\nDid you intend to checkout 'origin/branchB' which can not be resolved as commit?\n",
>     "stdout": "",

The changes are minimal and low risk, and should help other users with similar problems.  
Issue #2736 seems like it should be resolved with this change.
