### PR TITLE
use expanduser() before testing user_data as file

### DIFF
--- a/cloud/rackspace/rax.py
+++ b/cloud/rackspace/rax.py
@@ -285,7 +285,7 @@ def create(module, names=[], flavor=None, image=None, meta={}, key_name=None,
     if user_data:
         config_drive = True
 
-    if user_data and os.path.isfile(os.path.expanduser('user_data')):
+    if user_data and os.path.isfile(os.path.expanduser(user_data)):
         try:
             user_data = os.path.expanduser('user_data')
             f = open(user_data)

--- a/cloud/rackspace/rax.py
+++ b/cloud/rackspace/rax.py
@@ -285,7 +285,7 @@ def create(module, names=[], flavor=None, image=None, meta={}, key_name=None,
     if user_data:
         config_drive = True
 
-    if user_data and os.path.isfile(user_data):
+    if user_data and os.path.isfile(os.path.expanduser('user_data')):
         try:
             f = open(user_data)
             user_data = f.read()

--- a/cloud/rackspace/rax.py
+++ b/cloud/rackspace/rax.py
@@ -287,6 +287,7 @@ def create(module, names=[], flavor=None, image=None, meta={}, key_name=None,
 
     if user_data and os.path.isfile(os.path.expanduser('user_data')):
         try:
+            user_data = os.path.expanduser('user_data')
             f = open(user_data)
             user_data = f.read()
             f.close()


### PR DESCRIPTION
I like to use ~/somepath instead of absolute paths because
that's more shareable.  Without expansion, the path wasn't
considered a file, and the resulting cloud-config user_data
contained a string for the file path instead of the file context.
So, expand it.
