### PR TITLE
if user is empty, it is not converted to tuple when using host_all

### DIFF
--- a/database/mysql/mysql_user.py
+++ b/database/mysql/mysql_user.py
@@ -203,7 +203,7 @@ def get_mode(cursor):
 
 def user_exists(cursor, user, host, host_all):
     if host_all:
-        cursor.execute("SELECT count(*) FROM user WHERE user = %s", user)
+        cursor.execute("SELECT count(*) FROM user WHERE user = %s", ([user]))
     else:
         cursor.execute("SELECT count(*) FROM user WHERE user = %s AND host = %s", (user,host))
 
@@ -240,7 +240,7 @@ def user_mod(cursor, user, host, host_all, password, encrypted, new_priv, append
     grant_option = False
 
     if host_all:
-        hostnames = user_get_hostnames(cursor, user)
+        hostnames = user_get_hostnames(cursor, [user])
     else:
         hostnames = [host]
 
@@ -330,7 +330,7 @@ def user_delete(cursor, user, host, host_all, check_mode):
         return True
 
     if host_all:
-        hostnames = user_get_hostnames(cursor, user)
+        hostnames = user_get_hostnames(cursor, [user])
 
         for hostname in hostnames:
             cursor.execute("DROP USER %s@%s", (user, hostname))


### PR DESCRIPTION
We have an exception if user is empty in combination with host_all: true
Traceback (most recent call last):
  File "/home/user/.ansible/tmp/ansible-tmp-1455456621.39-33584363856625/mysql_user.2.1", line 2690, in <module>
    main()
  File "/home/user/.ansible/tmp/ansible-tmp-1455456621.39-33584363856625/mysql_user.2.1", line 555, in main
    changed = user_delete(cursor, user, host, host_all, module.check_mode)
  File "/home/user/.ansible/tmp/ansible-tmp-1455456621.39-33584363856625/mysql_user.2.1", line 334, in user_delete
    hostnames = user_get_hostnames(cursor, user)
  File "/home/user/.ansible/tmp/ansible-tmp-1455456621.39-33584363856625/mysql_user.2.1", line 344, in user_get_hostnames
    cursor.execute("SELECT Host FROM mysql.user WHERE user = %s", user)
  File "/usr/lib/python2.7/site-packages/MySQLdb/cursors.py", line 187, in execute
    query = query % tuple([db.literal(item) for item in args])
TypeError: not enough arguments for format string
