### PR TITLE
Add path type to argument_spec where applicable

### DIFF
--- a/cloud/amazon/iam_cert.py
+++ b/cloud/amazon/iam_cert.py
@@ -226,9 +226,9 @@ def main():
         state=dict(
             default=None, required=True, choices=['present', 'absent']),
         name=dict(default=None, required=False),
-        cert=dict(default=None, required=False),
-        key=dict(default=None, required=False),
-        cert_chain=dict(default=None, required=False),
+        cert=dict(default=None, required=False, type='path'),
+        key=dict(default=None, required=False, type='path'),
+        cert_chain=dict(default=None, required=False, type='path'),
         new_name=dict(default=None, required=False),
         path=dict(default='/', required=False),
         new_path=dict(default=None, required=False),


### PR DESCRIPTION
The cert, key and cert_chain arguments didn't previously use expanduser or expandvars, so adding type='path' is all that is required to support paths with ~, $HOME etc (see ansible/ansible#12263).
