### PR TITLE
ec2_group: specify param types in argument spec

### DIFF
--- a/cloud/amazon/ec2_group.py
+++ b/cloud/amazon/ec2_group.py
@@ -233,12 +233,12 @@ def get_target_from_rule(module, ec2, rule, name, group, groups, vpc_id):
 def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
-            name=dict(required=True),
-            description=dict(required=True),
-            vpc_id=dict(),
-            rules=dict(),
-            rules_egress=dict(),
-            state = dict(default='present', choices=['present', 'absent']),
+            name=dict(required=True, type='str'),
+            description=dict(required=True, type='str'),
+            vpc_id=dict(type='str'),
+            rules=dict(type='list'),
+            rules_egress=dict(type='list'),
+            state = dict(default='present', choices=['present', 'absent'], type='str'),
             purge_rules=dict(default=True, required=False, type='bool'),
             purge_rules_egress=dict(default=True, required=False, type='bool'),
 


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

```
ansible 2.1.0 (devel 4b953c4b16) last updated 2016/02/14 22:42:33 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 8d126bd877) last updated 2016/02/12 03:47:02 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD f6c5ed987f) last updated 2016/02/12 03:47:10 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### Environment:

Arch Linux. Ansible running in virtualenv with Python 2.7.
##### Summary:

This is the first time I've used ec2_group with Ansible 2.x. I'm specifying a list of rules for the `rules` parameter containing a single rule to allow inbound TCP/22. The module fails in the `validate_rules()` function with an error that makes it look like it is parsing the rules list as a string. If I add the following after line 339:

``` python
module.fail_json(msg='debug', rules=rules, type=type(rules).__name__)
```

then the resulting failure message shows `rules` as being type `str`. I'm guessing maybe at some point module arguments started defaulting to being strings unless otherwise specified?

Even though the fix only requires specifying types for `rules` and `rules_egress`, I added types to all the module arguments as I figured that is best practise?
##### Steps To Reproduce:

Attempt the following task:

``` yaml
- name: Example security group
  ec2_group:
    name: example
    description: Example group
    rules:
      - proto: tcp
        from_port: 22
        to_port: 22
        cidr_ip: 0.0.0.0/0
    vpc_id: vpc-12345678
    state: present
```
##### Expected Results:

To create the security group with a single ingress rule allowing SSH traffic. With the proposed fix, I get expected behaviour:

```
changed: [localhost] => {"changed": true, "group_id": "sg-12345678", "invocation": {"module_args": {"aws_access_key": null, "aws_secret_key": null, "description": "Example group", "ec2_url": null, "name": "example", "profile": null, "purge_rules": true, "purge_rules_egress": true, "region": null, "rules": [{"cidr_ip": "0.0.0.0/0", "from_port": 22, "proto": "tcp", "to_port": 22}], "rules_egress": null, "security_token": null, "state": "present", "validate_certs": true, "vpc_id": "vpc-222b0947"}, "module_name": "ec2_group"}}
```
##### Actual Results:

```
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "invocation": {"module_args": {"aws_access_key": null, "aws_secret_key": null, "description": "Sysadmin instances", "ec2_url": null, "name": "sysadmin", "profile": null, "purge_rules": true, "purge_rules_egress": true, "region": null, "rules": "[{'to_port': 22, 'from_port': 22, 'cidr_ip': '0.0.0.0/0', 'proto': 'tcp'}]", "rules_egress": null, "security_token": null, "state": "present", "validate_certs": true, "vpc_id": "vpc-12345678"}, "module_name": "ec2_group"}, "msg": "Invalid rule parameter '['"}
```
