### PR TITLE
Bug: invocation with state=absent always leads to error

### DIFF
--- a/cloud/digital_ocean/digital_ocean_domain.py
+++ b/cloud/digital_ocean/digital_ocean_domain.py
@@ -125,7 +125,7 @@ class Domain(JsonfyMixIn):
         self.__dict__.update(domain_json)
 
     def destroy(self):
-        self.manager.destroy_domain(self.id)
+        self.manager.destroy_domain(self.name)
 
     def records(self):
         json = self.manager.all_domain_records(self.id)
@@ -177,7 +177,6 @@ def core(module):
     except KeyError, e:
         module.fail_json(msg='Unable to load %s' % e.message)
 
-    changed = True
     state = module.params['state']
 
     Domain.setup(api_token)


### PR DESCRIPTION
**Ansible Version:** 2.0.0.2

**Ansible Configuration**: no changes

**Environment:** N/A

**Summary:** invocation with state=absent always leads to

[localhost]: FAILED! => {"changed": false, "failed": true, "msg": "'Domain' object has no attribute 'id'"}

Problem is that DigitalOcean API accepts domain name, not record ID
(https://developers.digitalocean.com/documentation/v2/#delete-a-domain)

**Steps To Reproduce:**

Define DO_API_VERSION, DO_API_TOKEN and execute
- name: create domain
  digital_ocean_domain: state=present name=DOMAIN_NAME ip=DROPLET_IP
- name: destroy domain
  digital_ocean_domain: state=absent name=DOMAIN_NAME

**Expected Results:** domain record in DigitalOcean gets deleted

**Actual Results:** domain record not deleted, "'Domain' object has no attribute 'id'" error returned
