### PR TITLE
Bug: repeatable invocation with state=present leads to error

### DIFF
--- a/cloud/digital_ocean/digital_ocean_domain.py
+++ b/cloud/digital_ocean/digital_ocean_domain.py
@@ -128,7 +128,7 @@ class Domain(JsonfyMixIn):
         self.manager.destroy_domain(self.id)
 
     def records(self):
-        json = self.manager.all_domain_records(self.id)
+        json = self.manager.all_domain_records(self.name)
         return map(DomainRecord, json)
 
     @classmethod
@@ -195,12 +195,12 @@ def core(module):
             records = domain.records()
             at_record = None
             for record in records:
-                if record.name == "@" and record.record_type == 'A':
+                if record.name == "@" and record.type == 'A':
                     at_record = record
 
             if not at_record.data == getkeyordie("ip"):
                 record.update(data=getkeyordie("ip"), record_type='A')
-                module.exit_json(changed=True, domain=Domain.find(id=record.domain_id).to_json())
+                module.exit_json(changed=True, domain=Domain.find(id=record.id).to_json())
 
         module.exit_json(changed=False, domain=domain.to_json())
 


### PR DESCRIPTION
**Ansible Version:** 2.0.0.2

**Ansible Configuration**: no changes

**Environment:** N/A

**Summary:** repeatable invocation with state=present leads to

[localhost]: FAILED! => {"changed": false, "failed": true, "msg": "'Domain' object has no attribute 'id'"}

Problem: DigitalOcean API has changed (https://developers.digitalocean.com/documentation/v2/#list-all-domain-records)

**Steps To Reproduce:**

Define DO_API_VERSION, DO_API_TOKEN and execute
- name: create domain
  digital_ocean_domain: state=present name=DOMAIN_NAME ip=DROPLET_IP

Then try to create the same domain again (for example, playbook is executed again)
- name: create domain
  digital_ocean_domain: state=present name=DOMAIN_NAME ip=DROPLET_IP

**Expected Results:** successful execution

**Actual Results:** Error "'Domain' object has no attribute 'id'" is returned
