### PR TITLE
Bugfix: Permit SOA record type

### DIFF
--- a/cloud/amazon/route53.py
+++ b/cloud/amazon/route53.py
@@ -50,7 +50,7 @@ options:
     description:
       - The type of DNS record to create
     required: true
-    choices: [ 'A', 'CNAME', 'MX', 'AAAA', 'TXT', 'PTR', 'SRV', 'SPF', 'NS' ]
+    choices: [ 'A', 'CNAME', 'MX', 'AAAA', 'TXT', 'PTR', 'SRV', 'SPF', 'NS', 'SOA' ]
   alias:
     description:
       - Indicates if this is an alias record.
@@ -343,7 +343,7 @@ def main():
             hosted_zone_id               = dict(required=False, default=None),
             record                       = dict(required=True),
             ttl                          = dict(required=False, type='int', default=3600),
-            type                         = dict(choices=['A', 'CNAME', 'MX', 'AAAA', 'TXT', 'PTR', 'SRV', 'SPF', 'NS'], required=True),
+            type                         = dict(choices=['A', 'CNAME', 'MX', 'AAAA', 'TXT', 'PTR', 'SRV', 'SPF', 'NS', 'SOA'], required=True),
             alias                        = dict(required=False, type='bool'),
             alias_hosted_zone_id         = dict(required=False),
             alias_evaluate_target_health = dict(required=False, type='bool', default=False),


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

```
ansible 2.1.0 (devel 4b953c4b16) last updated 2016/02/17 06:32:01 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 8d126bd877) last updated 2016/02/17 06:32:05 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD f6c5ed987f) last updated 2016/02/17 06:32:05 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### Summary:

The route53 module does not allow SOA records. It is supported by boto and the only thing needed to enable SOA records is to change the module argument spec.
##### Steps To Reproduce:

``` yaml
- route53:
    command: create
    zone: example.net
    record: example.net
    type: SOA
    value: "ns1.example.net. hostmaster.example.net. 1 7200 900 1209600 3600"
    ttl: 900
    overwrite: yes
```
##### Expected Results:

```
TASK [route53] *****************************************************************
task path: /path/to/playbook.yml:8
changed: [localhost] => {"changed": true, "invocation": {"module_args": {"alias": null, "alias_evaluate_target_health": false, "alias_hosted_zone_id": null, "aws_access_key": null, "aws_secret_key": null, "command": "create", "ec2_url": null, "failover": null, "health_check": null, "hosted_zone_id": null, "identifier": null, "overwrite": true, "private_zone": false, "profile": null, "record": "example.net", "region": null, "retry_interval": "500", "security_token": null, "ttl": 900, "type": "SOA", "validate_certs": true, "value": "ns1.example.net. hostmaster.example.net. 1 7200 900 1209600 3600", "vpc_id": null, "wait": false, "wait_timeout": 300, "weight": null, "zone": "example.net"}, "module_name": "route53"}}
```
##### Actual Results:

```
TASK [route53] *****************************************************************
task path: /path/to/playbook.yml:8
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "invocation": {"module_args": {"alias_evaluate_target_health": false, "command": "create", "private_zone": false, "record": "example.net", "retry_interval": "500", "ttl": 900, "type": "SOA", "validate_certs": true, "value": "ns1.example.net. hostmaster.example.net. 1 7200 900 1209600 3600", "wait": false, "wait_timeout": 300, "zone": "example.net"}, "module_name": "route53"}, "msg": "value of type must be one of: A,CNAME,MX,AAAA,TXT,PTR,SRV,SPF,NS, got: SOA"}
```
