### PR TITLE
apache2_module: Properly detect enabled/disabled modules on SLES12

### DIFF
--- a/web_infrastructure/apache2_module.py
+++ b/web_infrastructure/apache2_module.py
@@ -56,7 +56,7 @@ def _disable_module(module):
 
     result, stdout, stderr = module.run_command("%s %s" % (a2dismod_binary, name))
 
-    if re.match(r'.*\b' + name + r' already disabled', stdout, re.S|re.M):
+    if re.match(r'.*(\b|")' + name + r'"? (already disabled|not present)', stdout, re.S|re.M):
         module.exit_json(changed = False, result = "Success")
     elif result != 0:
         module.fail_json(msg="Failed to disable module %s: %s" % (name, stdout))
@@ -71,7 +71,7 @@ def _enable_module(module):
 
     result, stdout, stderr = module.run_command("%s %s" % (a2enmod_binary, name))
 
-    if re.match(r'.*\b' + name + r' already enabled', stdout, re.S|re.M):
+    if re.match(r'.*(\b|")' + name + r'"? already (enabled|present)', stdout, re.S|re.M):
         module.exit_json(changed = False, result = "Success")
     elif result != 0:
         module.fail_json(msg="Failed to enable module %s: %s" % (name, stdout))


### PR DESCRIPTION
The output has to match:

```
"module" already present
"module" already absent
```

otherwise tasks will always report "changed' although the module was
already enabled/disabled.
