### PR TITLE
replaced sudo with become

### DIFF
--- a/cloud/amazon/ec2.py
+++ b/cloud/amazon/ec2.py
@@ -428,7 +428,7 @@ EXAMPLES = '''
 
 - name: Configure instance(s)
   hosts: launched
-  sudo: True
+  become: True
   gather_facts: True
   roles:
     - my_awesome_role

--- a/cloud/google/gce.py
+++ b/cloud/google/gce.py
@@ -201,7 +201,7 @@ EXAMPLES = '''
 
 - name: Configure instance(s)
   hosts: launched
-  sudo: True
+  become: True
   roles:
     - my_awesome_role
     - my_awesome_tasks


### PR DESCRIPTION
Update documentation examples to use 'become' as 'sudo' is deprecated.
