### PR TITLE
add 'only_upgrade' switch to apt module

### DIFF
--- a/packaging/os/apt.py
+++ b/packaging/os/apt.py
@@ -407,7 +407,7 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
             only_upgrade = ''
 
         if build_dep:
-            cmd = "%s -y %s %s %s build-dep %s" % (APT_GET_CMD, dpkg_options, force_yes, check_arg, packages)
+            cmd = "%s -y %s %s %s %s build-dep %s" % (APT_GET_CMD, dpkg_options, only_upgrade, force_yes, check_arg, packages)
         else:
             cmd = "%s -y %s %s %s %s %s install %s" % (APT_GET_CMD, dpkg_options, only_upgrade, force_yes, autoremove, check_arg, packages)
 

--- a/packaging/os/apt.py
+++ b/packaging/os/apt.py
@@ -102,6 +102,13 @@ options:
     choices: [ "yes", "no" ]
     aliases: [ 'autoclean']
     version_added: "2.1"
+  only_upgrade:
+    description:
+     - Only install/upgrade a package it it is already installed.
+     required: false
+     default: false
+     version_added: "2.1"
+
 requirements: [ python-apt, aptitude ]
 author: "Matthew Williams (@mgwilliams)"
 notes:
@@ -355,7 +362,7 @@ def expand_pkgspec_from_fnmatches(m, pkgspec, cache):
 def install(m, pkgspec, cache, upgrade=False, default_release=None,
             install_recommends=None, force=False,
             dpkg_options=expand_dpkg_options(DPKG_OPTIONS),
-            build_dep=False, autoremove=False):
+            build_dep=False, autoremove=False, only_upgrade=False):
     pkg_list = []
     packages = ""
     pkgspec = expand_pkgspec_from_fnmatches(m, pkgspec, cache)
@@ -394,10 +401,15 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
         else:
             autoremove = ''
 
+        if only_upgrade:
+            only_upgrade = '--only-upgrade'
+        else:
+            only_upgrade = ''
+
         if build_dep:
             cmd = "%s -y %s %s %s build-dep %s" % (APT_GET_CMD, dpkg_options, force_yes, check_arg, packages)
         else:
-            cmd = "%s -y %s %s %s %s install %s" % (APT_GET_CMD, dpkg_options, force_yes, autoremove, check_arg, packages)
+            cmd = "%s -y %s %s %s %s %s install %s" % (APT_GET_CMD, dpkg_options, only_upgrade, force_yes, autoremove, check_arg, packages)
 
         if default_release:
             cmd += " -t '%s'" % (default_release,)
@@ -570,7 +582,8 @@ def main():
             force = dict(default='no', type='bool'),
             upgrade = dict(choices=['no', 'yes', 'safe', 'full', 'dist']),
             dpkg_options = dict(default=DPKG_OPTIONS),
-            autoremove = dict(type='bool', default=False, aliases=['autoclean'])
+            autoremove = dict(type='bool', default=False, aliases=['autoclean']),
+            only_upgrade = dict(type='bool', default=False)
         ),
         mutually_exclusive = [['package', 'upgrade', 'deb']],
         required_one_of = [['package', 'upgrade', 'update_cache', 'deb']],
@@ -692,7 +705,8 @@ def main():
                     default_release=p['default_release'],
                     install_recommends=install_recommends,
                     force=force_yes, dpkg_options=dpkg_options,
-                    build_dep=state_builddep, autoremove=autoremove)
+                    build_dep=state_builddep, autoremove=autoremove,
+                    only_upgrade=p['only_upgrade'])
             (success, retvals) = result
             retvals['cache_updated']=updated_cache
             retvals['cache_update_time']=updated_cache_time


### PR DESCRIPTION
##### Issue Type:

Please pick one and delete the rest:
- Feature Pull Request
##### Plugin Name:

apt
##### Ansible Version:

```
ansible 2.1.0 (devel f9526b2ab2) last updated 2016/02/19 09:45:54 (GMT +200)
  lib/ansible/modules/core: (devel 4822861483) last updated 2016/02/19 09:56:13 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD f6c5ed987f) last updated 2016/02/19 08:40:12 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### Summary:

Especially when managing a lot of hosts it comes in handy to be able to just install/upgrade packages that are already installed. apt-get provides the '--only-upgrade' flag for this. You can now run an adhoc command or a special playbook against all your hosts to upgrade a package only where it is already installed.
##### Example output:

```
$ ansible all -m apt -a "name=postgresql-9.3 state=present only_upgrade=True"

db.example.com | SUCCESS => {
    "cache_update_time": 0, 
    "cache_updated": false, 
    "changed": true, 
    "stderr": "", 
    "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nSkipping postgresql-9.3, it is not installed and only upgrades are requested.\n0 upgraded, 0 newly installed, 0 to remove and 67 not upgraded.\n", 
    "stdout_lines": [
        "Reading package lists...", 
        "Building dependency tree...", 
        "Reading state information...", 
        "Skipping postgresql-9.3, it is not installed and only upgrades are requested.", 
        "0 upgraded, 0 newly installed, 0 to remove and 67 not upgraded."
    ]
}
```

A current drawback is that "changed" is always true.
