### PR TITLE
Fix facter path

### DIFF
--- a/system/setup.py
+++ b/system/setup.py
@@ -87,7 +87,7 @@ def run_setup(module):
 
     # Look for the path to the facter and ohai binary and set
     # the variable to that path.
-    facter_path = module.get_bin_path('facter')
+    facter_path = module.get_bin_path('facter', opt_dirs=['/opt/puppetlabs/bin'])
     ohai_path = module.get_bin_path('ohai')
 
     # if facter is installed, and we can use --json because


### PR DESCRIPTION
- Bugfix Pull Request
##### Plugin Name:

```
setup.py
```
##### Ansible Version:

```
ansible 1.9.4
```
##### Summary:

In Puppet version 4 and in Puppet PE the Puppet tree is installed in `/opt/puppetlabs` and the
commands are installed in `/opt/puppetlabs/bin`. This directory is out of scope for the `setup` or `facter` module. This fix makes sure this/these module(s) can find the facter program.
