### PR TITLE
Make 'executable' and 'virtualenv' mutually exclusive

### DIFF
--- a/packaging/language/pip.py
+++ b/packaging/language/pip.py
@@ -50,7 +50,8 @@ options:
     default: null
   virtualenv:
     description:
-      - An optional path to a I(virtualenv) directory to install into
+      - An optional path to a I(virtualenv) directory to install into.
+        It cannot be specified together with the 'executable' parameter (added in 2.1).
     required: false
     default: null
   virtualenv_site_packages:
@@ -111,6 +112,7 @@ options:
         run pip for a specific version of Python installed in the system. For
         example C(pip-3.3), if there are both Python 2.7 and 3.3 installations
         in the system and you want to run pip for the Python 3.3 installation.
+        It cannot be specified together with the 'virtualenv' parameter (added in 2.1).
     version_added: "1.3"
     required: false
     default: null
@@ -260,7 +262,7 @@ def main():
             executable=dict(default=None, required=False),
         ),
         required_one_of=[['name', 'requirements']],
-        mutually_exclusive=[['name', 'requirements']],
+        mutually_exclusive=[['name', 'requirements'], ['executable', 'virtualenv']],
         supports_check_mode=True
     )
 


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Plugin Name:

pip
##### Ansible Version:

```
ansible 2.1.0
  config file =
  configured module search path = Default w/o overrides
```

Also note that I have run the full ansible test suite with tox on python 2.7 and 3.4 and no failure is reported.
##### Summary:

Fixes  https://github.com/ansible/ansible/issues/14415 
(probably an issue in the ansible-modules-core repo should be created too).

Specifying both `executable` and `virtualenv` in the pip module will create a virtual environment in and install the Python package in the system.

Making them mutually exclusive will avoid confusion and force the user to knowingly pick the right one.
##### Example output:

Specifying both `executable` and `virtualenv` will now result in:

```
TASK [pip] *********************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "parameters are mutually exclusive: ['executable', 'virtualenv']"}
```
