### PR TITLE
LaunchD (OSX) support for the service module

### DIFF
--- a/system/service.py
+++ b/system/service.py
@@ -28,7 +28,7 @@ version_added: "0.1"
 short_description:  Manage services.
 description:
     - Controls services on remote hosts. Supported init systems include BSD init,
-      OpenRC, SysV, Solaris SMF, systemd, upstart.
+      OpenRC, SysV, Solaris SMF, systemd, upstart, OSX launchd.
 options:
     name:
         required: true


### PR DESCRIPTION
##### Issue Type:

Feature Pull Request
##### Plugin Name:

core/system/service
##### Ansible Version:

```
ansible 2.1.0
  config file =
  configured module search path = Default w/o overrides
```
##### Summary:

This Pull Request implements support for launchd, the OSX process manager, in the system/service module. It allows user to interact with services on OSX systems the same way as they would on Linux/BSD systems.

It manipulates system agents and daemons though the launchctl(1) command, and should be compatible with OSX version >=10.9 (I didn't had the opportunity to test with previous versions).

Please review and let me know what you think :-)

Ref https://github.com/ansible/ansible/issues/10412
