### PR TITLE
[backport-1.9] docker: fix failing in case of empty image tag

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -422,6 +422,8 @@ def get_split_image_tag(image):
         resource, tag = resource.split(':', 1)
         if registry:
             resource = '/'.join((registry, resource))
+        if tag == "":
+            tag = "latest"
     else:
         tag = "latest"
         resource = image


### PR DESCRIPTION
This is backport of #2852 to the 1.9.x
