### PR TITLE
Add Ceph RGW S3 compatibility

### DIFF
--- a/cloud/amazon/s3.py
+++ b/cloud/amazon/s3.py
@@ -136,7 +136,7 @@ options:
     aliases: [ S3_URL ]
   rgw:
     description:
-      - Enable Ceph RGW S3 support
+      - Enable Ceph RGW S3 support. This option requires an explicit url via s3_url.
     default: false
     version_added: "2.2"
   src:

--- a/cloud/amazon/s3.py
+++ b/cloud/amazon/s3.py
@@ -138,6 +138,7 @@ options:
     description:
       - Enable Ceph RGW S3 support
     default: false
+    version_added: "2.2"
   src:
     description:
       - The source file path when performing a PUT operation.


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request (minimal impact in the current code)
##### Plugin Name:

./cloud/amazon/s3.py
##### Ansible Version:

```
$ ansible --version
ansible 2.1.0 (devel 3ddcabee0e) last updated 2016/02/11 11:21:11 (GMT +200)
  lib/ansible/modules/core: (s3-ceph 1da965e039) last updated 2016/02/11 14:27:39 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 6aeb2ab6cf) last updated 2016/02/11 11:34:36 (GMT +200)
  config file = 
  configured module search path = Default w/o overrides

```
##### Summary:

Ansible supports S3 on AWS, Walrus and FakeS3 but it doesn't support Ceph RGW S3. This patch supports Ceph RGW S3.

More information at:

https://groups.google.com/forum/#!topic/ansible-devel/XxVeoHehpSM
##### Example output:

```
```

Ceph Object Gateway (Ceph RGW) is an object storage interface built on top of
librados to provide applications with a RESTful gateway to Ceph Storage
Clusters:

http://docs.ceph.com/docs/master/radosgw/

This patch adds the required bits to use the RGW S3 RESTful API properly.

Signed-off-by: Javier M. Mellid jmunhoz@igalia.com
