### PR TITLE
Add state=empty into file module (Fixes #902)

### DIFF
--- a/files/file.py
+++ b/files/file.py
@@ -63,9 +63,13 @@ options:
         If C(touch) (new in 1.4), an empty file will be created if the C(path) does not
         exist, while an existing file or directory will receive updated file access and
         modification times (similar to the way `touch` works from the command line).
+        If C(empty) (new in 2.1), an existing file will be truncated with a new size of 0.
+        if C(empty), an existing directory will have all files and subdirs recursively removed,
+        leaving the directory empty. If C(empty), absent files or directories are not
+        created.
     required: false
     default: file
-    choices: [ file, link, directory, hard, touch, absent ]
+    choices: [ file, link, directory, hard, touch, absent, empty ]
   src:
     required: false
     default: null

--- a/files/file.py
+++ b/files/file.py
@@ -159,7 +159,7 @@ def main():
 
     module = AnsibleModule(
         argument_spec = dict(
-            state = dict(choices=['file','directory','link','hard','touch','absent'], default=None),
+            state = dict(choices=['file','directory','link','hard','touch','absent','empty'], default=None),
             path  = dict(aliases=['dest', 'name'], required=True),
             original_basename = dict(required=False), # Internal use only, for recursive ops
             recurse  = dict(default=False, type='bool'),
@@ -427,6 +427,47 @@ def main():
                 raise e
 
         module.exit_json(dest=path, changed=True, diff=diff)
+
+    elif state == "empty":
+        # NOTE(robputt796): Initial response to https://github.com/ansible/ansible-modules-core/issues/902
+        # Allows truncate of file, or removal of sub files for a directory for empty state.
+        if not module.check_mode:
+            # Empty state can only be used against a file (to truncate) or directory (to empty)
+            if prev_state in ['file', 'directory']:
+                changed = False
+                try:
+                    if prev_state == 'file':
+                        if os.stat(path).st_size != 0:
+                            # File not empty, truncate.
+                            try:
+                                file = open(path, 'w')
+                                file.truncate(0)
+                                changed = True
+                                file.close()
+                            except IOError, e:
+                                module.fail_json(path=path,
+                                                 msg='There was an issue ensuring %s is empty: %s' % (path, str(e)))
+
+                    if prev_state == 'directory':
+                        file_listing = os.listdir(path)
+                        if file_listing != []:
+                            # Directory is not empty, emptying
+                            changed = True
+                            for file_name in file_listing:
+                                full_path = "%s/%s" % (path, file_name)
+                                if os.path.isdir(full_path):
+                                    shutil.rmtree(full_path)
+                                else:
+                                    os.remove(full_path)
+
+                except OSError, e:
+                    module.fail_json(path=path, msg='There was an issue ensuring %s is empty: %s' % (path, str(e)))
+
+                module.exit_json(dest=path, changed=changed, diff=diff)
+
+            # Fail for any other state then file / directory
+            elif prev_state in ['absent', 'hard', 'link']:
+                module.fail_json(msg='Cannot ensure %s is empty as it\'s current state is %s' % (path, prev_state))
 
     module.fail_json(path=path, msg='unexpected position reached')
 


### PR DESCRIPTION
**Note to reviewer - I could see no unit tests included in ansible-modules-core so I have assumed tests are not required, however please let me know if a test or docs commit is also required.**
##### Issue Type:

Please pick one and delete the rest:
- Feature Pull Request (Fixes #902)
##### Plugin Name:

File
##### Ansible Version:

ansible 1.9.4
##### Summary:

(Fixes #902)

Adds the ability to perform the following

file: path=/tmp/myfolder state=empty
or
file: path=/tmp/myfile state=empty

In the case of a file this truncates the file to 0 bytes leaving an empty file, in the case of a folder it removes recursively all contents of the folder leaving an empty folder without editing any other elements such as ownership or permissions. If it is ran against a file or directory which does not exist it does not create the file or directory, this should be done via an ensure prior to making sure the state is empty.
##### Example output:

ansible-playbook -vvvv -i '104.130.30.247,' ~/test.yaml --user=root

---

< PLAY [all] >

---

```
    \   ^__^
     \  (oo)\_______
        (__)\       )\/\
            ||----w |
            ||     ||
```

---

< GATHERING FACTS >

---

```
    \   ^__^
     \  (oo)\_______
        (__)\       )\/\
            ||----w |
            ||     ||
```

<104.130.30.247> ESTABLISH CONNECTION FOR USER: root
<104.130.30.247> REMOTE_MODULE setup
<104.130.30.247> EXEC ssh -C -tt -vvv -o ControlMaster=auto -o ControlPersist=60s -o ControlPath="/home/robe8437/.ansible/cp/ansible-ssh-%h-%p-%r" -o Port=22 -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=root -o ConnectTimeout=10 104.130.30.247 /bin/sh -c 'mkdir -p $HOME/.ansible/tmp/ansible-tmp-1456161437.45-166695396617657 && echo $HOME/.ansible/tmp/ansible-tmp-1456161437.45-166695396617657'
<104.130.30.247> PUT /tmp/tmpMR9AA6 TO /root/.ansible/tmp/ansible-tmp-1456161437.45-166695396617657/setup
<104.130.30.247> EXEC ssh -C -tt -vvv -o ControlMaster=auto -o ControlPersist=60s -o ControlPath="/home/robe8437/.ansible/cp/ansible-ssh-%h-%p-%r" -o Port=22 -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=root -o ConnectTimeout=10 104.130.30.247 /bin/sh -c 'LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /root/.ansible/tmp/ansible-tmp-1456161437.45-166695396617657/setup; rm -rf /root/.ansible/tmp/ansible-tmp-1456161437.45-166695396617657/ >/dev/null 2>&1'
ok: [104.130.30.247]

---

< TASK: empty file >

---

```
    \   ^__^
     \  (oo)\_______
        (__)\       )\/\
            ||----w |
            ||     ||
```

<104.130.30.247> ESTABLISH CONNECTION FOR USER: root
<104.130.30.247> REMOTE_MODULE file path=/tmp/file state=empty
<104.130.30.247> EXEC ssh -C -tt -vvv -o ControlMaster=auto -o ControlPersist=60s -o ControlPath="/home/robe8437/.ansible/cp/ansible-ssh-%h-%p-%r" -o Port=22 -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=root -o ConnectTimeout=10 104.130.30.247 /bin/sh -c 'mkdir -p $HOME/.ansible/tmp/ansible-tmp-1456161439.8-132728730069085 && echo $HOME/.ansible/tmp/ansible-tmp-1456161439.8-132728730069085'
<104.130.30.247> PUT /tmp/tmp19i2YN TO /root/.ansible/tmp/ansible-tmp-1456161439.8-132728730069085/file
<104.130.30.247> EXEC ssh -C -tt -vvv -o ControlMaster=auto -o ControlPersist=60s -o ControlPath="/home/robe8437/.ansible/cp/ansible-ssh-%h-%p-%r" -o Port=22 -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=root -o ConnectTimeout=10 104.130.30.247 /bin/sh -c 'LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /root/.ansible/tmp/ansible-tmp-1456161439.8-132728730069085/file; rm -rf /root/.ansible/tmp/ansible-tmp-1456161439.8-132728730069085/ >/dev/null 2>&1'
changed: [104.130.30.247] => {"changed": true, "dest": "/tmp/file", "diff": {"after": {"path": "/tmp/file", "state": "empty"}, "before": {"path": "/tmp/file", "state": "file"}}, "gid": 0, "group": "root", "mode": "0644", "owner": "root", "size": 0, "state": "file", "uid": 0}

---

< TASK: empty dir >

---

```
    \   ^__^
     \  (oo)\_______
        (__)\       )\/\
            ||----w |
            ||     ||
```

<104.130.30.247> ESTABLISH CONNECTION FOR USER: root
<104.130.30.247> REMOTE_MODULE file path=/tmp/folder state=empty
<104.130.30.247> EXEC ssh -C -tt -vvv -o ControlMaster=auto -o ControlPersist=60s -o ControlPath="/home/robe8437/.ansible/cp/ansible-ssh-%h-%p-%r" -o Port=22 -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=root -o ConnectTimeout=10 104.130.30.247 /bin/sh -c 'mkdir -p $HOME/.ansible/tmp/ansible-tmp-1456161441.87-249090456980746 && echo $HOME/.ansible/tmp/ansible-tmp-1456161441.87-249090456980746'
<104.130.30.247> PUT /tmp/tmpgLlafp TO /root/.ansible/tmp/ansible-tmp-1456161441.87-249090456980746/file
<104.130.30.247> EXEC ssh -C -tt -vvv -o ControlMaster=auto -o ControlPersist=60s -o ControlPath="/home/robe8437/.ansible/cp/ansible-ssh-%h-%p-%r" -o Port=22 -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=root -o ConnectTimeout=10 104.130.30.247 /bin/sh -c 'LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /root/.ansible/tmp/ansible-tmp-1456161441.87-249090456980746/file; rm -rf /root/.ansible/tmp/ansible-tmp-1456161441.87-249090456980746/ >/dev/null 2>&1'
changed: [104.130.30.247] => {"changed": true, "dest": "/tmp/folder", "diff": {"after": {"path": "/tmp/folder", "state": "empty"}, "before": {"path": "/tmp/folder", "state": "directory"}}, "gid": 0, "group": "root", "mode": "0755", "owner": "root", "size": 4096, "state": "directory", "uid": 0}

---

< PLAY RECAP >

---

```
    \   ^__^
     \  (oo)\_______
        (__)\       )\/\
            ||----w |
            ||     ||
```

104.130.30.247             : ok=3    changed=2    unreachable=0    failed=0 
