### PR TITLE
Fix: Incorrect parameters for module.set_fs_attributes_if_different in file.py

### DIFF
--- a/files/file.py
+++ b/files/file.py
@@ -87,13 +87,6 @@ options:
       - 'force the creation of the symlinks in two cases: the source file does
         not exist (but will appear later); the destination exists and is a file (so, we need to unlink the
         "path" file and create symlink to the "src" file in place of it).'
-  follow:
-    required: false
-    default: "no"
-    choices: [ "yes", "no" ]
-    version_added: "1.8"
-    description:
-      - 'This flag indicates that filesystem links, if they exist, should be followed.'
 '''
 
 EXAMPLES = '''
@@ -280,7 +273,7 @@ def main():
             module.fail_json(path=path, msg='file (%s) is %s, cannot continue' % (path, prev_state))
 
         changed = module.set_fs_attributes_if_different(file_args, changed)
-        module.exit_json(path=path, changed=diff)
+        module.exit_json(path=path, changed=changed, diff=diff)
 
     elif state == 'directory':
         if follow and prev_state == 'link':
@@ -309,7 +302,7 @@ def main():
                         except OSError, ex:
                             # Possibly something else created the dir since the os.path.exists
                             # check above. As long as it's a dir, we don't need to error out.
-                            if not (ex.errno == errno.EEXIST and os.path.isdir(curpath)):
+                            if not (ex.errno == errno.EEXIST and os.isdir(curpath)):
                                 raise
                         tmp_file_args = file_args.copy()
                         tmp_file_args['path']=curpath
@@ -326,7 +319,7 @@ def main():
         if recurse:
             changed |= recursive_set_attributes(module, file_args['path'], follow, file_args)
 
-        module.exit_json(path=path, changed=diff)
+        module.exit_json(path=path, changed=changed, diff=diff)
 
     elif state in ['link','hard']:
 
@@ -395,10 +388,10 @@ def main():
                     module.fail_json(path=path, msg='Error while linking: %s' % str(e))
 
         if module.check_mode and not os.path.exists(path):
-            module.exit_json(dest=path, src=src, changed=diff)
+            module.exit_json(dest=path, src=src, changed=changed, diff=diff)
 
         changed = module.set_fs_attributes_if_different(file_args, changed)
-        module.exit_json(dest=path, src=src, changed=diff)
+        module.exit_json(dest=path, src=src, changed=changed, diff=diff)
 
     elif state == 'touch':
         if not module.check_mode:

--- a/files/file.py
+++ b/files/file.py
@@ -280,7 +280,7 @@ def main():
             module.fail_json(path=path, msg='file (%s) is %s, cannot continue' % (path, prev_state))
 
         changed = module.set_fs_attributes_if_different(file_args, changed)
-        module.exit_json(path=path, changed=changed=diff)
+        module.exit_json(path=path, changed=diff)
 
     elif state == 'directory':
         if follow and prev_state == 'link':
@@ -326,7 +326,7 @@ def main():
         if recurse:
             changed |= recursive_set_attributes(module, file_args['path'], follow, file_args)
 
-        module.exit_json(path=path, changed=changed=diff)
+        module.exit_json(path=path, changed=diff)
 
     elif state in ['link','hard']:
 
@@ -395,10 +395,10 @@ def main():
                     module.fail_json(path=path, msg='Error while linking: %s' % str(e))
 
         if module.check_mode and not os.path.exists(path):
-            module.exit_json(dest=path, src=src, changed=changed=diff)
+            module.exit_json(dest=path, src=src, changed=diff)
 
         changed = module.set_fs_attributes_if_different(file_args, changed)
-        module.exit_json(dest=path, src=src, changed=changed=diff)
+        module.exit_json(dest=path, src=src, changed=diff)
 
     elif state == 'touch':
         if not module.check_mode:

--- a/files/file.py
+++ b/files/file.py
@@ -42,7 +42,7 @@ description:
 notes:
     - See also M(copy), M(template), M(assemble)
 requirements: [ ]
-author: 
+author:
     - "Ansible Core Team"
     - "Michael DeHaan"
 options:
@@ -279,8 +279,8 @@ def main():
             # file is not absent and any other state is a conflict
             module.fail_json(path=path, msg='file (%s) is %s, cannot continue' % (path, prev_state))
 
-        changed = module.set_fs_attributes_if_different(file_args, changed, diff)
-        module.exit_json(path=path, changed=changed, diff=diff)
+        changed = module.set_fs_attributes_if_different(file_args, changed)
+        module.exit_json(path=path, changed=changed=diff)
 
     elif state == 'directory':
         if follow and prev_state == 'link':
@@ -313,7 +313,7 @@ def main():
                                 raise
                         tmp_file_args = file_args.copy()
                         tmp_file_args['path']=curpath
-                        changed = module.set_fs_attributes_if_different(tmp_file_args, changed, diff)
+                        changed = module.set_fs_attributes_if_different(tmp_file_args, changed)
             except Exception, e:
                 module.fail_json(path=path, msg='There was an issue creating %s as requested: %s' % (curpath, str(e)))
 
@@ -321,12 +321,12 @@ def main():
         elif prev_state != 'directory':
             module.fail_json(path=path, msg='%s already exists as a %s' % (path, prev_state))
 
-        changed = module.set_fs_attributes_if_different(file_args, changed, diff)
+        changed = module.set_fs_attributes_if_different(file_args, changed)
 
         if recurse:
             changed |= recursive_set_attributes(module, file_args['path'], follow, file_args)
 
-        module.exit_json(path=path, changed=changed, diff=diff)
+        module.exit_json(path=path, changed=changed=diff)
 
     elif state in ['link','hard']:
 
@@ -395,10 +395,10 @@ def main():
                     module.fail_json(path=path, msg='Error while linking: %s' % str(e))
 
         if module.check_mode and not os.path.exists(path):
-            module.exit_json(dest=path, src=src, changed=changed, diff=diff)
+            module.exit_json(dest=path, src=src, changed=changed=diff)
 
-        changed = module.set_fs_attributes_if_different(file_args, changed, diff)
-        module.exit_json(dest=path, src=src, changed=changed, diff=diff)
+        changed = module.set_fs_attributes_if_different(file_args, changed)
+        module.exit_json(dest=path, src=src, changed=changed=diff)
 
     elif state == 'touch':
         if not module.check_mode:
@@ -416,7 +416,7 @@ def main():
             else:
                 module.fail_json(msg='Cannot touch other than files, directories, and hardlinks (%s is %s)' % (path, prev_state))
             try:
-                module.set_fs_attributes_if_different(file_args, True, diff)
+                module.set_fs_attributes_if_different(file_args, True)
             except SystemExit, e:
                 if e.code:
                     # We take this to mean that fail_json() was called from


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Plugin Name:

files/file.py
##### Ansible Version:

```
ansible 2.0.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### Summary:

file module crashes with invalid number of parameters when set permissions or ownership
##### Example output:

```
File "/home/ubuntu/.ansible/tmp/ansible-tmp-1456176384.07-262519109202902/file, line 318, in main
  changed = module.set_fs_attributes_if_different(file_args, changed, diff)
  TypeError: set_fs_attributes_if_different() takes exactly 3 arguments (4 given)
"msg": "MODULE FAILURE"
```
