### PR TITLE
added sql_log_bin setting to disable binary logging as option

### DIFF
--- a/database/mysql/mysql_user.py
+++ b/database/mysql/mysql_user.py
@@ -69,6 +69,13 @@ options:
     choices: [ "yes", "no" ]
     default: "no"
     version_added: "1.4"
+  sql_log_bin:
+    description:
+      - Whether binary logging should be enabled or disabled for the connection.
+    required: false
+    choices: ["yes", "no" ]
+    default: "yes"
+    version_added: "2.1"
   state:
     description:
       - Whether the user should exist.  When C(absent), removes
@@ -138,6 +145,9 @@ mydb.*:INSERT,UPDATE/anotherdb.*:SELECT/yetanotherdb.*:ALL
 
 # Example using login_unix_socket to connect to server
 - mysql_user: name=root password=abc123 login_unix_socket=/var/run/mysqld/mysqld.sock
+
+# Example of skipping binary logging while adding user 'bob'
+- mysql_user: name=bob password=12345 priv=*.*:USAGE state=present sql_log_bin=no
 
 # Example .my.cnf file for setting the root password
 
@@ -479,6 +489,7 @@ def main():
             check_implicit_admin=dict(default=False, type='bool'),
             update_password=dict(default="always", choices=["always", "on_create"]),
             config_file=dict(default="~/.my.cnf"),
+            sql_log_bin=dict(default=True, type='bool'),
             ssl_cert=dict(default=None),
             ssl_key=dict(default=None),
             ssl_ca=dict(default=None),
@@ -502,6 +513,7 @@ def main():
     ssl_key = module.params["ssl_key"]
     ssl_ca = module.params["ssl_ca"]
     db = 'mysql'
+    sql_log_bin = module.params["sql_log_bin"]
 
     config_file = os.path.expanduser(os.path.expandvars(config_file))
     if not mysqldb_found:
@@ -519,6 +531,9 @@ def main():
             cursor = mysql_connect(module, login_user, login_password, config_file, ssl_cert, ssl_key, ssl_ca, db)
     except Exception, e:
         module.fail_json(msg="unable to connect to database, check login_user and login_password are correct or %s has the credentials. Exception message: %s" % (config_file, e))
+
+    if not sql_log_bin:
+        cursor.execute("SET SQL_LOG_BIN=0;")
 
     if priv is not None:
         try:


### PR DESCRIPTION
##### Issue Type:

``````
 - Feature Pull Request

##### Plugin Name:

mysql_user

##### Ansible Version:

```
ansible 2.1.0
```

##### Summary:

Adds ability to disable sql_log_bin
``````
