### PR TITLE
Fix to ensure youngest snapshot is retrieved rather than oldest

### DIFF
--- a/cloud/amazon/ec2_snapshot.py
+++ b/cloud/amazon/ec2_snapshot.py
@@ -145,7 +145,7 @@ def _get_most_recent_snapshot(snapshots, max_snapshot_age_secs=None, now=None):
     if not now:
         now = datetime.datetime.utcnow()
 
-    youngest_snapshot = min(snapshots, key=_get_snapshot_starttime)
+    youngest_snapshot = max(snapshots, key=_get_snapshot_starttime)
 
     # See if the snapshot is younger that the given max age
     snapshot_start = datetime.datetime.strptime(youngest_snapshot.start_time, '%Y-%m-%dT%H:%M:%S.000Z')


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Plugin Name:

ec2_snapshot
##### Summary:

Fixes https://github.com/ansible/ansible-modules-core/issues/3114 by changing from a min() function to a max() function to get the youngest snapshot rather than the oldest.

Including @willthames as module author
