### PR TITLE
Fixes #3109: Executing ec2_group with rules fails with "Inval…

### DIFF
--- a/cloud/amazon/ec2_group.py
+++ b/cloud/amazon/ec2_group.py
@@ -233,12 +233,12 @@ def get_target_from_rule(module, ec2, rule, name, group, groups, vpc_id):
 def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
-            name=dict(required=True),
-            description=dict(required=True),
-            vpc_id=dict(),
-            rules=dict(),
-            rules_egress=dict(),
-            state = dict(default='present', choices=['present', 'absent']),
+            name=dict(type='str', required=True),
+            description=dict(type='str', required=True),
+            vpc_id=dict(type='str'),
+            rules=dict(type='list'),
+            rules_egress=dict(type='list'),
+            state = dict(default='present', type='str', choices=['present', 'absent']),
             purge_rules=dict(default=True, required=False, type='bool'),
             purge_rules_egress=dict(default=True, required=False, type='bool'),
 


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Plugin Name:

ec2_group
##### Summary:

Adds types to the argument spec, without which lists of ec2 rules get converted to str.
##### Example:

See Issue, but failure looks like:

```
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "invocation": {"module_args": {"aws_access_key": nul
l, "aws_secret_key": null, "description": "test", "ec2_url": null, "name": "test", "profile": null, "purge_rules": true, "purge_rules_egress": true, "region": "$tu_region_acqui", "rules": "[...]", "rules_
egress": null, "security_token": null, "state": "present", "validate_certs": true, "vpc_id": "$tu_vpc_numero_de_identificacion_acqui"}, "module_
name": "ec2_group"}, "msg": "Invalid rule parameter '['"}
```
