### PR TITLE
fixes issue with return docstring

### DIFF
--- a/network/openswitch/ops_template.py
+++ b/network/openswitch/ops_template.py
@@ -119,8 +119,7 @@ tasks:
 
 RETURN = """
 updates:
-  description: The list of configuration updates to be merged  The format
-    of the return is 'key: new_value (old_value)'
+  description: The list of configuration updates to be merged
   retured: always
   type: list
   sample: ["System.hostname: ops01 (switch)"]


### PR DESCRIPTION
##### Issue Type:
- Docs Pull Request
##### Plugin Name:

ops_template
##### Summary:

RETURN docstring needed to b updated otherwise the webdocs could not be built successfully
##### Example:

This commit fixes an issue with the return doc string.  The old line
was removed that would prevent the docs form being built correctly
