### PR TITLE
gem: add support for --bindir

### DIFF
--- a/packaging/language/gem.py
+++ b/packaging/language/gem.py
@@ -90,6 +90,11 @@ options:
       - Allow adding build flags for gem compilation
     required: false
     version_added: "2.0"
+  binary_dir:
+    description:
+      - Set target directory for installing any gem command-line components.
+    required: false
+    version_added: "2.3.0"
 author:
     - "Ansible Core Team"
     - "Johan Wiren"
@@ -212,6 +217,8 @@ def install(module):
     cmd.append(module.params['gem_source'])
     if module.params['build_flags']:
         cmd.extend([ '--', module.params['build_flags'] ])
+    if module.params['binary_dir']:
+        cmd.extend([ '--bindir', module.params['binary_dir'] ])
     module.run_command(cmd, check_rc=True)
 
 def main():
@@ -230,6 +237,7 @@ def main():
             env_shebang          = dict(required=False, default=False, type='bool'),
             version              = dict(required=False, type='str'),
             build_flags          = dict(required=False, type='str'),
+            binary_dir           = dict(required=False, type='str'),
         ),
         supports_check_mode = True,
         mutually_exclusive = [ ['gem_source','repository'], ['gem_source','version'] ],


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Plugin Name:

gem
##### Summary:

gems installed by e.g. apt or other tools have a different location than
what gem defaults to for user parameters. This change allows installing
user gems to the same location as packaged software, or indeed
anywhere else in the filesystem if needed.
##### Example:

```
    - name: install facter into /usr/bin using new binary_dir directive
      gem:
        name: "{{ item }}"
        user_install: no
        state: present
        binary_dir: "/usr/bin"
        include_doc: no
      with_items:
        - facter
```
