### PR TITLE
Fix aws elasticache idempotency

### DIFF
--- a/cloud/amazon/elasticache.py
+++ b/cloud/amazon/elasticache.py
@@ -227,8 +227,8 @@ class ElastiCacheManager(object):
                                                       port=self.cache_port)
         except boto.exception.BotoServerError, e:
             self.module.fail_json(msg=e.message)
-        cache_cluster_data = response['CreateCacheClusterResponse']['CreateCacheClusterResult']['CacheCluster']
-        self._refresh_data(cache_cluster_data)
+
+        self._refresh_data()
 
         self.changed = True
         if self.wait:
@@ -304,8 +304,7 @@ class ElastiCacheManager(object):
         except boto.exception.BotoServerError, e:
             self.module.fail_json(msg=e.message)
 
-        cache_cluster_data = response['ModifyCacheClusterResponse']['ModifyCacheClusterResult']['CacheCluster']
-        self._refresh_data(cache_cluster_data)
+        self._refresh_data()
 
         self.changed = True
         if self.wait:
@@ -333,8 +332,7 @@ class ElastiCacheManager(object):
         except boto.exception.BotoServerError, e:
             self.module.fail_json(msg=e.message)
 
-        cache_cluster_data = response['RebootCacheClusterResponse']['RebootCacheClusterResult']['CacheCluster']
-        self._refresh_data(cache_cluster_data)
+        self._refresh_data()
 
         self.changed = True
         if self.wait:
@@ -384,23 +382,23 @@ class ElastiCacheManager(object):
             'EngineVersion': self.cache_engine_version
         }
         for key, value in modifiable_data.iteritems():
-            if self.data[key] != value:
+            if value is not None and self.data[key] != value:
                 return True
 
         # Check cache security groups
         cache_security_groups = []
         for sg in self.data['CacheSecurityGroups']:
             cache_security_groups.append(sg['CacheSecurityGroupName'])
-            if set(cache_security_groups) - set(self.cache_security_groups):
-                return True
+        if set(cache_security_groups) != set(self.cache_security_groups):
+            return True
 
         # check vpc security groups
         vpc_security_groups = []
         security_groups = self.data['SecurityGroups'] or []
         for sg in security_groups:
             vpc_security_groups.append(sg['SecurityGroupId'])
-            if set(vpc_security_groups) - set(self.security_group_ids):
-                return True
+        if set(vpc_security_groups) != set(self.security_group_ids):
+            return True
 
         return False
 
@@ -417,7 +415,7 @@ class ElastiCacheManager(object):
         if self.zone is not None:
             unmodifiable_data['zone'] = self.data['PreferredAvailabilityZone']
         for key, value in unmodifiable_data.iteritems():
-            if getattr(self, key) != value:
+            if getattr(self, key) is not None and getattr(self, key) != value:
                 return True
         return False
 


### PR DESCRIPTION
##### Issue Type:

 Bugfix Pull Request
##### Plugin Name:

elasticache
##### Summary:

Current version of the module is not idempotent:
- when cache_port is not specified then the module will fail on rerun
- when cache_engine_version is not specified then the module will consider that the task has to change the resource on subsequent run
- The registered variable is not consistent across describe/create/modify because CacheNodes is not included in the boto response on create/modify
- security groups changes are not properly captured

This fix contains two things:
- ignore unspecified attributes when evaluating if the resource "can be modified" and "should be modified"
- always call "describe" when refreshing resource data so that CacheNodes is included even on create and modify. "Delete" has been untouched.
- fix comparison of cache_security_groups (non-VPC) and security_group_ids (VPC). (No examples provided for this fix)
##### Example:

Without the fix and without specifying cache_port, the return value on rerun was:

```
# Task fails while it should not
failed: [localhost] => {"failed": true}
msg: 'some-redis' requires destructive modification. 'hard_modify' must be set to true to proceed.
```

Without the fix and but when specifying cache_port, the return value on rerun was:

```
# Resource appear as changed while it should not
# CacheNodes is not included in the response
changed: [localhost] => {"changed": true, "elasticache": {"data": {"AutoMinorVersionUpgrade": true, "CacheClusterCreateTime": 1456649996.144, "CacheClusterId": "some-redis", "CacheClusterStatus": "available", "CacheNodeType": "cache.t2.micro", "CacheNodes": null, "CacheParameterGroup": {"CacheNodeIdsToReboot": [], "CacheParameterGroupName": "default.redis2.8", "ParameterApplyStatus": "in-sync"}, "CacheSecurityGroups": [], "CacheSubnetGroupName": "some-subnet", "ClientDownloadLandingPage": "https://console.aws.amazon.com/elasticache/home#client-download:", "ConfigurationEndpoint": null, "Engine": "redis", "EngineVersion": "2.8.24", "NotificationConfiguration": null, "NumCacheNodes": 1, "PendingModifiedValues": {"CacheNodeIdsToRemove": null, "EngineVersion": null, "NumCacheNodes": null}, "PreferredAvailabilityZone": "ap-southeast-1b", "PreferredMaintenanceWindow": "fri:20:00-fri:21:00", "ReplicationGroupId": null, "SecurityGroups": null}, "name": "some-redis", "status": "available"}}
```

With the fix and and without specifying cache_port, the return value on rerun is now:

```
# Run is successful as expected
# Resource appear as "ok" as expected
# CacheNodes is now included in the response
ok: [localhost] => {"changed": false, "elasticache": {"data": {"AutoMinorVersionUpgrade": true, "CacheClusterCreateTime": 1456649996.144, "CacheClusterId": "some-redis", "CacheClusterStatus": "available", "CacheNodeType": "cache.t2.micro", "CacheNodes": [{"CacheNodeCreateTime": 1456649996.144, "CacheNodeId": "0001", "CacheNodeStatus": "available", "Endpoint": {"Address": "some-redis.57rrse.0001.apse1.cache.amazonaws.com", "Port": 6379}, "ParameterGroupStatus": "in-sync", "SourceCacheNodeId": null}], "CacheParameterGroup": {"CacheNodeIdsToReboot": [], "CacheParameterGroupName": "default.redis2.8", "ParameterApplyStatus": "in-sync"}, "CacheSecurityGroups": [], "CacheSubnetGroupName": "some-subnet", "ClientDownloadLandingPage": "https://console.aws.amazon.com/elasticache/home#client-download:", "ConfigurationEndpoint": null, "Engine": "redis", "EngineVersion": "2.8.24", "NotificationConfiguration": null, "NumCacheNodes": 1, "PendingModifiedValues": {"CacheNodeIdsToRemove": null, "EngineVersion": null, "NumCacheNodes": null}, "PreferredAvailabilityZone": "ap-southeast-1b", "PreferredMaintenanceWindow": "fri:20:00-fri:21:00", "ReplicationGroupId": null, "SecurityGroups": null}, "name": "some-redis", "status": "available"}}
```
