### PR TITLE
Suggest using uri if curl is detected

### DIFF
--- a/commands/command.py
+++ b/commands/command.py
@@ -137,7 +137,7 @@ def check_command(commandline):
     arguments = { 'chown': 'owner', 'chmod': 'mode', 'chgrp': 'group',
                   'ln': 'state=link', 'mkdir': 'state=directory',
                   'rmdir': 'state=absent', 'rm': 'state=absent', 'touch': 'state=touch' }
-    commands  = { 'git': 'git', 'hg': 'hg', 'curl': 'get_url', 'wget': 'get_url',
+    commands  = { 'git': 'git', 'hg': 'hg', 'curl': 'get_url or uri', 'wget': 'get_url or uri',
                   'svn': 'subversion', 'service': 'service',
                   'mount': 'mount', 'rpm': 'yum, dnf or zypper', 'yum': 'yum', 'apt-get': 'apt-get',
                   'tar': 'unarchive', 'unzip': 'unarchive', 'sed': 'template or lineinfile',


### PR DESCRIPTION
##### Issue Type:
- Docs Pull Request
##### Plugin Name:

command
##### Summary:

Some people use the command module to run curl not to
download file, but to interact with remote HTTP api, and the
get_url suggestion is not suitable. So adding uri in the warning
would give a more meaningful warning.

Suggested by Tahvok on #ansible irc channel.
