### PR TITLE
Fix non RFC 2606 domain name in doc

### DIFF
--- a/network/basics/uri.py
+++ b/network/basics/uri.py
@@ -190,7 +190,7 @@ EXAMPLES = '''
 # access the app in later tasks
 
 - uri:
-    url: https://your.form.based.auth.examle.com/index.php
+    url: https://your.form.based.auth.example.com/index.php
     method: POST
     body: "name=your_username&password=your_password&enter=Sign%20in"
     status_code: 302


### PR DESCRIPTION
##### Issue Type:
- Docs Pull Request
##### Plugin Name:

uri
##### Summary:

There is a documentation with examle.com instead of example.com, which is slightly incorrect
