### PR TITLE
Add get_checksum option to win_stat to work with new use of the stat module for checksumming

### DIFF
--- a/windows/win_stat.ps1
+++ b/windows/win_stat.ps1
@@ -31,6 +31,7 @@ If ($path -eq $FALSE)
 }
 
 $get_md5 = Get-Attr $params "get_md5" $TRUE | ConvertTo-Bool;
+$get_checksum = Get-Attr $params "get_checksum" $TRUE | ConvertTo-Bool;
 
 $result = New-Object psobject @{
     stat = New-Object psobject
@@ -63,7 +64,7 @@ Else
     Set-Attr $result.stat "exists" $FALSE;
 }
 
-If ($get_md5 -and $result.stat.exists -and -not $result.stat.isdir)
+If (($get_checksum -or $get_md5) -and $result.stat.exists -and -not $result.stat.isdir)
 {
     $hash = Get-FileChecksum($path);
     Set-Attr $result.stat "md5" $hash;

--- a/windows/win_stat.py
+++ b/windows/win_stat.py
@@ -34,10 +34,18 @@ options:
     aliases: []
   get_md5:
     description:
-      - Whether to return the md5 sum of the file
+      - Whether to return the checksum sum of the file. As of Ansible 1.9 this
+        is no longer a MD5, but a SHA1 instead.
     required: false
     default: yes
     aliases: []
+  get_checksum:
+    description:
+      - Whether to return a checksum of the file
+        (only sha1 currently supported)
+    required: false
+    default: yes
+    version_added: "2.1"
 author: "Chris Church (@cchurch)"
 '''
 


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Plugin Name:

`win_stat`
##### Summary:

As of https://github.com/ansible/ansible/commit/b9d0662faf2910dea503c0c8c35ad9951a4c6e9c ansible now uses the stat module for checksumming instead of shell checksum code.

Unfortunately in the invocation of the stat module we set `get_md5=False` but `get_checksum=True`.  `win_stat` did not support `get_checksum` and as such never returned a checksum.

This PR effectively aliases `get_checksum` to `get_md5`, but in a way that should allow us to expand on allowing different algorithms and leaving `get_checksum` and `get_md5` independent of each other.

There are other issues with `win_stat` right now, where `get_md5` always returns a sha1 instead of an md5, however this PR does not try to solve that, but only adds guidance around the fact that `get_md5` returns a `sha1` since ansible v1.9.  See https://github.com/ansible/ansible-modules-core/issues/2863
##### Example:

N/A
