### PR TITLE
Fix for delete aws iam user.

### DIFF
--- a/cloud/amazon/iam.py
+++ b/cloud/amazon/iam.py
@@ -203,11 +203,10 @@ def delete_user(module, iam, name):
         except boto.exception.BotoServerError, err:
             error_msg = boto_exception(err)
             if ('Cannot find Login Profile') in error_msg:
-
                del_meta = iam.delete_user(name).delete_user_response
-            else:
-              iam.delete_login_profile(name)
-              del_meta = iam.delete_user(name).delete_user_response
+        else:
+          iam.delete_login_profile(name)
+          del_meta = iam.delete_user(name).delete_user_response
     except Exception as ex:
         module.fail_json(changed=False, msg="delete failed %s" %ex)
         if ('must detach all policies first') in error_msg:


### PR DESCRIPTION
After some testing in our aws environment we noticed that the delete user functionality was not working.  We noticed that we were not getting any exception on line 202.  This returned the login_profile just fine.  The next step to delete was to just call iam.delete_user.  I noticed there was a space on line 206 which looked out of place.  I suspect that there were some indentation issues here.  I also noticed the author(s) like using try/except/else clauses.  This would make sense that these lines in the pull-request were incorrectly indented.  When indenting them properly a delete_user works great.

Test yaml:
- name: create user
  iam20:
    iam_type: user
    name: mrtest
    state: present
    password: "XXXXXXX"
    update_password: on_create
  register: user_create
- debug:
    msg: "{{ user_create }}"
- name: delete user
  iam20:
    iam_type: user
    name: mrtest
    state: absent
  register: user_delete
- debug:
    msg: "{{ user_delete }}"
