### PR TITLE
Guard against too old boto library

### DIFF
--- a/cloud/amazon/route53.py
+++ b/cloud/amazon/route53.py
@@ -263,10 +263,12 @@ EXAMPLES = '''
 
 '''
 
+MINIMUM_BOTO_VERSION = '2.28.0'
 WAIT_RETRY_SLEEP = 5  # how many seconds to wait between propagation status polls
 
 
 import time
+import distutils.version
 
 try:
     import boto
@@ -365,6 +367,9 @@ def main():
 
     if not HAS_BOTO:
         module.fail_json(msg='boto required for this module')
+
+    if distutils.version.StrictVersion(boto.__version__) < distutils.version.StrictVersion(MINIMUM_BOTO_VERSION):
+        module.fail_json(msg='Found boto in version %s, but >= %s is required' % (boto.__version__, MINIMUM_BOTO_VERSION))
 
     command_in                      = module.params.get('command')
     zone_in                         = module.params.get('zone').lower()


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Plugin Name:

cloud/amazon/route53
##### Summary:

route53 creates Record objects using `health check` and `failover`
parameters. Those parameters only became available in boto 2.28.0.
As some prominent LTS Linux releases (e.g.: Ubuntu 14.04) only ship
older boto versions (e.g.: 2.20.1 for Ubuntu 14.04), users are getting
unhelpful error messages like

```
TypeError: __init__() got an unexpected keyword argument 'health_check'
```

when running Ansible 2 against their LTS install's default boto.
We improve upon this error message by checking the boto version
beforehand.

Fixes ansible/ansible#13646
