### PR TITLE
Fixed BOOLEANS rendering in docsite

### DIFF
--- a/network/junos/junos_config.py
+++ b/network/junos/junos_config.py
@@ -62,7 +62,7 @@ options:
         first checking if already configured.
     required: false
     default: false
-    choices: BOOLEANS
+    choices: [ "true", "false" ]
   config:
     description:
       - The module, by default, will connect to the remote device and
@@ -176,4 +176,3 @@ from ansible.module_utils.netcfg import *
 from ansible.module_utils.junos import *
 if __name__ == '__main__':
     main()
-

--- a/network/junos/junos_template.py
+++ b/network/junos/junos_template.py
@@ -45,7 +45,7 @@ options:
         without first checking if already configured.
     required: false
     default: false
-    choices: BOOLEANS
+    choices: [ "true", "false" ]
   backup:
     description:
       - When this argument is configured true, the module will backup
@@ -54,7 +54,7 @@ options:
         the root of the playbook directory.
     required: false
     default: false
-    choices: BOOLEANS
+    choices: [ "true", "false" ]
   config:
     description:
       - The module, by default, will connect to the remote device and
@@ -178,4 +178,3 @@ from ansible.module_utils.netcfg import *
 from ansible.module_utils.junos import *
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
##### Issue Type:
- Docs Pull Request
##### Plugin Name:

network/junos
##### Summary:

Currently the choices are rendering wrong. PR changes this to "true" "false" as with other boolean examples in the module docs.

```
<tr>
<td>force<br/><div style="font-size: small;"></div></td>
<td>no</td>
<td></td>
    <td><ul><li>B</li><li>O</li><li>O</li><li>L</li><li>E</li><li>A</li><li>N</li><li>S</li></ul></td>
    <td><div>The force argument instructs the module to not consider the current devices configuration.  When set to true, this will cause the module to push the contents of <em>src</em> into the device without first checking if already configured.</div></td></tr>
```
