### PR TITLE
Change hostname SLES 10 & 11

### DIFF
--- a/system/hostname.py
+++ b/system/hostname.py
@@ -185,6 +185,42 @@ class DebianStrategy(GenericStrategy):
             self.module.fail_json(msg="failed to update hostname: %s" %
                 str(err))
 
+# ===========================================
+
+class SLESStrategy(GenericStrategy):
+    """
+    This is a SLES Hostname strategy class - it edits the
+    /etc/HOSTNAME file.
+    """
+    HOSTNAME_FILE = '/etc/HOSTNAME'
+
+    def get_permanent_hostname(self):
+        if not os.path.isfile(self.HOSTNAME_FILE):
+            try:
+                open(self.HOSTNAME_FILE, "a").write("")
+            except IOError, err:
+                self.module.fail_json(msg="failed to write file: %s" %
+                    str(err))
+        try:
+            f = open(self.HOSTNAME_FILE)
+            try:
+                return f.read().strip()
+            finally:
+                f.close()
+        except Exception, err:
+            self.module.fail_json(msg="failed to read hostname: %s" %
+                str(err))
+
+    def set_permanent_hostname(self, name):
+        try:
+            f = open(self.HOSTNAME_FILE, 'w+')
+            try:
+                f.write("%s\n" % name)
+            finally:
+                f.close()
+        except Exception, err:
+            self.module.fail_json(msg="failed to update hostname: %s" %
+                str(err))
 
 # ===========================================
 
@@ -462,6 +498,8 @@ class SLESHostname(Hostname):
     distribution_version = get_distribution_version()
     if distribution_version and LooseVersion(distribution_version) >= LooseVersion("12"):
         strategy_class = SystemdStrategy
+    elif distribution_version and LooseVersion("10") <= LooseVersion(distribution_version) <= LooseVersion("12"):
+        strategy_class = SLESStrategy
     else:
         strategy_class = UnimplementedStrategy
 


### PR DESCRIPTION
##### Issue Type:

<!-- Please pick one and delete the rest: -->
- Feature Pull Request
##### Plugin Name:

system/hostname
##### Summary:

The current version only allowed to change the hostname on SLES 12+.
Added an class "SLESStrategy" which sets the hostname on "/etc/HOSTNAME" on SLES 10 & 11

<!-- If you're fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does. -->
