### PR TITLE
Fix "ios_command" doc example

### DIFF
--- a/network/ios/ios_command.py
+++ b/network/ios/ios_command.py
@@ -79,9 +79,9 @@ EXAMPLES = """
       - "result[0] contains IOS"
 
 - ios_command:
-  commands:
-    - show version
-    - show interfaces
+    commands:
+      - show version
+      - show interfaces
 
 """
 


### PR DESCRIPTION
##### Issue Type:

<!-- Please pick one and delete the rest: -->
- Docs Pull Request
##### Plugin Name:

<!-- Name of the plugin/module/task  -->

ios_commands module 
##### Summary:

<!-- Please describe the change and the reason for it. -->

<!-- If you're fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does. -->

I think this doc is invalid YAML syntax.
This pull request fix the "ios_command"'s example.
##### Example:

preview

```
 - ios_command:
  commands:
    - show version
    - show interfaces
```

after

```
- ios_command:
    commands:
      - show version
      - show interfaces
```

This is not valid YAML commands. So fix it.
