### PR TITLE
port 'scheduler_hints' feature from nova_compute to os_server module

### DIFF
--- a/cloud/openstack/os_server.py
+++ b/cloud/openstack/os_server.py
@@ -560,7 +560,7 @@ def main():
         boot_volume                     = dict(default=None, aliases=['root_volume']),
         terminate_volume                = dict(default=False, type='bool'),
         volumes                         = dict(default=[], type='list'),
-        scheduler_hints                 = dict(default=None),
+        scheduler_hints                 = dict(default=None, type='dict'),
         state                           = dict(default='present', choices=['absent', 'present']),
     )
     module_kwargs = openstack_module_kwargs(

--- a/cloud/openstack/os_server.py
+++ b/cloud/openstack/os_server.py
@@ -167,6 +167,11 @@ options:
        - A list of preexisting volumes names or ids to attach to the instance
      required: false
      default: []
+   scheduler_hints:
+     description:
+        - Arbitrary key/value pairs to the scheduler for custom use
+     required: false
+     default: None
    state:
      description:
        - Should the resource be present or absent.
@@ -451,7 +456,7 @@ def _create_server(module, cloud):
     )
     for optional_param in (
             'key_name', 'availability_zone', 'network',
-            'volume_size', 'volumes'):
+            'scheduler_hints', 'volume_size', 'volumes'):
         if module.params[optional_param]:
             bootkwargs[optional_param] = module.params[optional_param]
 
@@ -555,6 +560,7 @@ def main():
         boot_volume                     = dict(default=None, aliases=['root_volume']),
         terminate_volume                = dict(default=False, type='bool'),
         volumes                         = dict(default=[], type='list'),
+        scheduler_hints                 = dict(default=None),
         state                           = dict(default='present', choices=['absent', 'present']),
     )
     module_kwargs = openstack_module_kwargs(


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Plugin Name:

os_server
##### Summary:
- adds support for creating VMs with scheduler hints (eg. affinity groups and anti-affinity groups)
- port 'scheduler_hints' feature from _nova_compute to os_server module  
- migrates support added in #761 to new os_server core module introduced in ansible 2.x
##### Example:

```
  os_server:
    ...
    scheduler_hints:
      group: "<affinity group guid>"
```
