### PR TITLE
docker_image path param doesn't support home directory #3175

### DIFF
--- a/cloud/docker/docker_image.py
+++ b/cloud/docker/docker_image.py
@@ -353,7 +353,7 @@ class DockerImageManager:
 def main():
     module = AnsibleModule(
         argument_spec = dict(
-            path               = dict(required=False, default=None),
+            path               = dict(required=False, default=None, type='path'),
             dockerfile         = dict(required=False, default="Dockerfile"),
             name               = dict(required=True),
             tag                = dict(required=False, default="latest"),


### PR DESCRIPTION
##### Issue Type:

<!-- Please pick one and delete the rest: -->
- Bugfix Pull Request
##### Plugin Name:

<!-- Name of the plugin/module/task  -->

docker_image
##### Summary:

<!-- Please describe the change and the reason for it. -->

<!-- If you're fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does. -->

Fixes  #3175. Adding os.path.expanduser to `path` param of docker_image because for the moment
home path doesn't work with `path`.
