### PR TITLE
ec2_ami_find.py - Treat 'is_public' option as a bool

### DIFF
--- a/cloud/amazon/ec2_ami_find.py
+++ b/cloud/amazon/ec2_ami_find.py
@@ -299,7 +299,7 @@ def main():
                 aliases = ['search_tags', 'image_tags']),
             architecture = dict(required=False),
             hypervisor = dict(required=False),
-            is_public = dict(required=False),
+            is_public = dict(required=False, type='bool'),
             name = dict(required=False),
             platform = dict(required=False),
             sort = dict(required=False, default=None,


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Plugin Name:

ansible/modules/core/cloud/amazon/ec2_ami_find.py
##### Summary:

The module doesn't return any AMIs if 'is_public' = no.
It seems the problem is that it's treated as a string.
##### Example:

```
TASK [backup : Get all AMIs created from instance] *****************************
task path: /home/******:109
ok: [localhost] => {"changed": false, "results": []}
```
