### PR TITLE
Fix openstack module documentation

### DIFF
--- a/cloud/openstack/os_object.py
+++ b/cloud/openstack/os_object.py
@@ -61,7 +61,7 @@ options:
 
 EXAMPLES = '''
 # Creates a object named 'fstab' in the 'config' container
-- os_object: cloud=mordred state=present name=fstab container=config file=/etc/fstab
+- os_object: cloud=mordred state=present name=fstab container=config filename=/etc/fstab
 
 # Deletes a container called config and all of its contents
 - os_object: cloud=rax-iad state=absent container=config


### PR DESCRIPTION
##### Issue Type:
- Docs Pull Request
##### Plugin Name:

openstack
##### Summary:

Documentation bug
##### Example:

Documentation uses 'file' option for os_object, but the option name is 'filename'.
