### PR TITLE
unarchive: Ensure that download failure is properly raised before read fails

### DIFF
--- a/files/unarchive.py
+++ b/files/unarchive.py
@@ -282,6 +282,9 @@ def main():
             package = os.path.join(tempdir, str(src.rsplit('/', 1)[1]))
             try:
                 rsp, info = fetch_url(module, src)
+                # If download fails, raise a proper exception
+                if rsp is None:
+                    raise Exception(info['msg'])
                 f = open(package, 'w')
                 # Read 1kb at a time to save on ram
                 while True:


### PR DESCRIPTION
##### Issue Type:

<!-- Please pick one and delete the rest: -->
- Bugfix Pull Request
##### Plugin Name:

unarchive
##### Summary:

<!-- Please describe the change and the reason for it. -->

<!-- If you're fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does. -->

Without this change, a download failure may bail out with the message:

```
"Failure downloading http://foo/bar, 'NoneType' object has no attribute 'read'"
```

whereas with this fix, you'd get a proper error like:

```
"Failure downloading http://foo/bar, Request failed: <urlopen error [Errno 113] No route to host>"
```

or one of the many other possible download errors that can occur.
##### Example:

``` yaml
- hosts: localhost
  gather_facts: no
  tasks:
  - unarchive:
      src: http://1.2.3.4/foo/bar
      dest: /tmp
      copy: no
    connection: local
```

Results in:

```
[dag@moria ansible.testing]$ ansible-playbook test74.yml

PLAY ***************************************************************************

TASK [unarchive] ***************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "Failure downloading http://1.2.3.4/foo/bar, 'NoneType' object has no attribute 'read'"}

NO MORE HOSTS LEFT *************************************************************
        to retry, use: --limit @test74.retry

PLAY RECAP *********************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1   
```
