### PR TITLE
Add missing quote in docker documentation

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -386,7 +386,7 @@ author:
     - "Ash Wilson (@smashwilson)"
     - "Thomas Steinbach (@ThomasSteinbach)"
     - "Philippe Jandot (@zfil)"
-    - "Daan Oosterveld (@dusdanig)
+    - "Daan Oosterveld (@dusdanig)"
 requirements:
     - "python >= 2.6"
     - "docker-py >= 0.3.0"


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
- Docs Pull Request
##### Plugin Name:

_cloud/docker/docker.py_
##### Summary:

A string in the DOCUMENTATION variable of this module was missing its closing `"`. This adds it. It was preventing the module docs from being built.
##### Example:

```
$ cd ansible/docsite
$ make modules
PYTHONPATH=../lib ../hacking/module_formatter.py -t rst --template-dir=../hacking/templates --module-dir=../lib/ansible/modules -o rst/
*** recording category all in rst/list_of_all_modules.rst ***
rendering: a10_server
rendering: a10_service_group
…
rendering: dnsmadeeasy
rendering: docker
 [ERROR]: unable to parse ../lib/ansible/modules/core/cloud/docker/docker.py

*** ERROR: MODULE MISSING DOCUMENTATION: ../lib/ansible/modules/core/cloud/docker/docker.py, docker ***
make: *** [modules] Error 1
```

This no longer occurs.
