### PR TITLE
Add 'root_device_type' filter to ec2_ami_find module

### DIFF
--- a/cloud/amazon/ec2_ami_find.py
+++ b/cloud/amazon/ec2_ami_find.py
@@ -121,7 +121,12 @@ options:
       - Virtualization type to match (e.g. hvm).
     default: null
     required: false
-  no_result_action:
+  root_device_type:
+    description:
+      - Root device type of the AMI (ebs or instance_store)
+    default: null
+    required: false
+   no_result_action:
     description:
       - What to do when no results are found.
       - "'success' reports success and returns an empty array"
@@ -315,6 +320,7 @@ def main():
             virtualization_type = dict(required=False),
             no_result_action = dict(required=False, default='success',
                 choices = ['success', 'fail']),
+            root_device_type = dict(required=False),
         )
     )
 
@@ -341,6 +347,7 @@ def main():
     state = module.params.get('state')
     virtualization_type = module.params.get('virtualization_type')
     no_result_action = module.params.get('no_result_action')
+    root_device_type = module.params.get('root_device_type')
 
     filter = {'state': state}
 
@@ -361,6 +368,8 @@ def main():
         filter['platform'] = platform
     if virtualization_type:
         filter['virtualization_type'] = virtualization_type
+    if root_device_type:
+        filter['root_device_type'] = root_device_type
 
     ec2 = ec2_connect(module)
 


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Plugin Name:
- `ec2_ami_find` module
##### Summary:

Add support to filter by root_device_type. This is useful when using general-purpose AMIs like Amazon Linux and the user needs it to guarantee it is EBS-backed (or instance-store).
##### Example:

```
ansible -i localhost, --connection local -m ec2_ami_find -a 'owner=amazon name="amzn-ami-hvm*" region=us-east-1 sort=name sort_order=descending root_device_type=ebs' all
localhost | SUCCESS => {
    "changed": false,
    "results": [
        {
            "ami_id": "ami-ac8ab6c6",
            "architecture": "x86_64",
            "block_device_mapping": {
                "/dev/xvda": {
                    "delete_on_termination": true,
                    "encrypted": false,
                    "size": 8,
                    "snapshot_id": "snap-538d3ec5",
                    "volume_type": "gp2"
                }
            },
            "creationDate": "2016-02-27T22:38:44.000Z",
            "description": "Amazon Linux AMI 2016.03.rc-0 x86_64 HVM GP2",
            "hypervisor": "xen",
            "is_public": true,
            "location": "amazon/amzn-ami-hvm-2016.03.rc-0.x86_64-gp2",
            "name": "amzn-ami-hvm-2016.03.rc-0.x86_64-gp2",
            "owner_id": "137112412989",
            "platform": null,
            "root_device_name": "/dev/xvda",
            "root_device_type": "ebs",
            "state": "available",
            "tags": {},
            "virtualization_type": "hvm"
        }
    ]
}
```
