### PR TITLE
Fix synchronize docs to indicate the correct default for use_ssh_args

### DIFF
--- a/files/synchronize.py
+++ b/files/synchronize.py
@@ -141,7 +141,7 @@ options:
   use_ssh_args:
     description:
       - Use the ssh_args specified in ansible.cfg
-    default: "yes"
+    default: "no"
     choices:
       - "yes"
       - "no"


### PR DESCRIPTION
##### Issue Type:

Docs Pull Request
##### Plugin Name:

synchronize
##### Summary:

The documentation for `use_ssh_args` incorrectly documents the default value as "yes" when it is actually "false".

Original PR of the addition: https://github.com/ansible/ansible-modules-core/pull/1073
##### Example:

```
N/A
```
