### PR TITLE
Add optional connect timeout to mysql* modules.

### DIFF
--- a/database/mysql/mysql_db.py
+++ b/database/mysql/mysql_db.py
@@ -224,6 +224,7 @@ def main():
             ssl_cert=dict(default=None),
             ssl_key=dict(default=None),
             ssl_ca=dict(default=None),
+            connect_timeout=dict(default=30, type='int'),
             config_file=dict(default="~/.my.cnf"),
         )
     )
@@ -243,6 +244,7 @@ def main():
     ssl_cert = module.params["ssl_cert"]
     ssl_key = module.params["ssl_key"]
     ssl_ca = module.params["ssl_ca"]
+    connect_timeout = module.params['connect_timeout']
     config_file = module.params['config_file']
     config_file = os.path.expanduser(os.path.expandvars(config_file))
     login_password = module.params["login_password"]
@@ -265,7 +267,8 @@ def main():
         if db == 'all':
             module.fail_json(msg="name is not allowed to equal 'all' unless state equals import, or dump.")
     try:
-        cursor = mysql_connect(module, login_user, login_password, config_file, ssl_cert, ssl_key, ssl_ca)
+        cursor = mysql_connect(module, login_user, login_password, config_file, ssl_cert, ssl_key, ssl_ca,
+                               connect_timeout=connect_timeout)
     except Exception, e:
         if os.path.exists(config_file):
             module.fail_json(msg="unable to connect to database, check login_user and login_password are correct or %s has the credentials. Exception message: %s" % (config_file, e))

--- a/database/mysql/mysql_user.py
+++ b/database/mysql/mysql_user.py
@@ -478,6 +478,7 @@ def main():
             append_privs=dict(default=False, type='bool'),
             check_implicit_admin=dict(default=False, type='bool'),
             update_password=dict(default="always", choices=["always", "on_create"]),
+            connect_timeout=dict(default=30, type='int'),
             config_file=dict(default="~/.my.cnf"),
             ssl_cert=dict(default=None),
             ssl_key=dict(default=None),
@@ -495,6 +496,7 @@ def main():
     state = module.params["state"]
     priv = module.params["priv"]
     check_implicit_admin = module.params['check_implicit_admin']
+    connect_timeout = module.params['connect_timeout']
     config_file = module.params['config_file']
     append_privs = module.boolean(module.params["append_privs"])
     update_password = module.params['update_password']
@@ -511,12 +513,14 @@ def main():
     try:
         if check_implicit_admin:
             try:
-                cursor = mysql_connect(module, 'root', '', config_file, ssl_cert, ssl_key, ssl_ca, db)
+                cursor = mysql_connect(module, 'root', '', config_file, ssl_cert, ssl_key, ssl_ca, db,
+                                       connect_timeout=connect_timeout)
             except:
                 pass
 
         if not cursor:
-            cursor = mysql_connect(module, login_user, login_password, config_file, ssl_cert, ssl_key, ssl_ca, db)
+            cursor = mysql_connect(module, login_user, login_password, config_file, ssl_cert, ssl_key, ssl_ca, db,
+                                   connect_timeout=connect_timeout)
     except Exception, e:
         module.fail_json(msg="unable to connect to database, check login_user and login_password are correct or %s has the credentials. Exception message: %s" % (config_file, e))
 

--- a/database/mysql/mysql_variables.py
+++ b/database/mysql/mysql_variables.py
@@ -127,6 +127,7 @@ def main():
             ssl_cert=dict(default=None),
             ssl_key=dict(default=None),
             ssl_ca=dict(default=None),
+            connect_timeout=dict(default=30, type='int'),
             config_file=dict(default="~/.my.cnf")
         )
     )
@@ -137,6 +138,7 @@ def main():
     ssl_cert = module.params["ssl_cert"]
     ssl_key = module.params["ssl_key"]
     ssl_ca = module.params["ssl_ca"]
+    connect_timeout = module.params['connect_timeout']
     config_file = module.params['config_file']
     config_file = os.path.expanduser(os.path.expandvars(config_file))
     db = 'mysql'
@@ -153,7 +155,8 @@ def main():
         warnings.filterwarnings('error', category=MySQLdb.Warning)
 
     try:
-        cursor = mysql_connect(module, user, password, config_file, ssl_cert, ssl_key, ssl_ca, db)
+        cursor = mysql_connect(module, user, password, config_file, ssl_cert, ssl_key, ssl_ca, db,
+                               connect_timeout=connect_timeout)
     except Exception, e:
         if os.path.exists(config_file):
             module.fail_json(msg="unable to connect to database, check login_user and login_password are correct or %s has the credentials. Exception message: %s" % (config_file, e))


### PR DESCRIPTION
##### Issue Type:

Feature Pull Request
##### Plugin Name:

mysql_db
mysql_user
mysql_variables
##### Summary:

Add optional connect_timeout option.

Support for the connection timeout was previously added in commit https://github.com/ansible/ansible/commit/16f107a49196f2afc38d204c61bce0f3ff37a4ae
##### Example:

Tested on Ubuntu 15.10:

```
# time ansible -m mysql_db -a 'name="test" state=present login_host=12.0.0.9 connect_timeout=1' all -i 'localhost,' -e 'ansible_connection=local'
localhost | FAILED! => {
    "changed": false, 
    "failed": true, 
    "msg": "unable to find /root/.my.cnf. Exception message: (2003, \"Can't connect to MySQL server on '12.0.0.9' (110)\")"
}

real    0m1.951s
user    0m0.924s
sys 0m0.240s
```

```
# time ansible -m mysql_user -a 'name="" state=absent login_host=12.0.0.9 connect_timeout=1' all -i 'localhost,' -e 'ansible_connection=local'
localhost | FAILED! => {
    "changed": false, 
    "failed": true, 
    "msg": "unable to connect to database, check login_user and login_password are correct or /root/.my.cnf has the credentials. Exception message: (2003, \"Can't connect to MySQL server on '12.0.0.9' (110)\")"
}

real    0m2.171s
user    0m1.136s
sys 0m0.268s
```

```
# time ansible -m mysql_variables -a 'variable=wait_timeout login_host=12.0.0.9 connect_timeout=1' all -i 'localhost,' -e 'ansible_connection=local'
localhost | FAILED! => {
    "changed": false, 
    "failed": true, 
    "msg": "unable to find /root/.my.cnf. Exception message: (2003, \"Can't connect to MySQL server on '12.0.0.9' (110)\")"
}

real    0m2.175s
user    0m1.108s
sys 0m0.268s
```
