### PR TITLE
Create subnet by project

### DIFF
--- a/cloud/openstack/os_subnet.py
+++ b/cloud/openstack/os_subnet.py
@@ -104,6 +104,11 @@ options:
      choices: ['dhcpv6-stateful', 'dhcpv6-stateless', 'slaac']
      required: false
      default: None
+   project:
+     description:
+        - Project name or ID containing the subnet (name admin-only)
+     required: false
+     default: None
 requirements:
     - "python >= 2.6"
     - "shade"
@@ -232,6 +237,7 @@ def main():
         ipv6_ra_mode=dict(default=None, choice=ipv6_mode_choices),
         ipv6_address_mode=dict(default=None, choice=ipv6_mode_choices),
         state=dict(default='present', choices=['absent', 'present']),
+        project=dict(default=None)
     )
 
     module_kwargs = openstack_module_kwargs()
@@ -255,6 +261,7 @@ def main():
     host_routes = module.params['host_routes']
     ipv6_ra_mode = module.params['ipv6_ra_mode']
     ipv6_a_mode = module.params['ipv6_address_mode']
+    project = module.params.pop('project')
 
     # Check for required parameters when state == 'present'
     if state == 'present':
@@ -271,7 +278,17 @@ def main():
 
     try:
         cloud = shade.openstack_cloud(**module.params)
-        subnet = cloud.get_subnet(subnet_name)
+        if project is not None:
+            proj = cloud.get_project(project)
+            if proj is None:
+                module.fail_json(msg='Project %s could not be found' % project)
+            project_id = proj['id']
+            filters = {'tenant_id': project_id}
+        else:
+            project_id = None
+            filters = None
+
+        subnet = cloud.get_subnet(subnet_name, filters=filters)
 
         if module.check_mode:
             module.exit_json(changed=_system_state_change(module, subnet,
@@ -288,7 +305,8 @@ def main():
                                              allocation_pools=pool,
                                              host_routes=host_routes,
                                              ipv6_ra_mode=ipv6_ra_mode,
-                                             ipv6_address_mode=ipv6_a_mode)
+                                             ipv6_address_mode=ipv6_a_mode,
+                                             tenant_id=project_id)
                 changed = True
             else:
                 if _needs_update(subnet, module, cloud):


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Plugin Name:

os_subnet
##### Summary:

A cloud/domain admin should be able to create a subnet on any
project it is granted on.
This change adds the 'project' parameter that accepts either
a name (admin-only) or id.
##### Example:

```
(venv) ubuntu@devstack:~$ cat test_os_subnet.yml

---
- hosts: localhost
  connection: local
  gather_facts: false
  tasks:
  - os_subnet:
      cloud: devstack-cloud_admin
      state: present
      name: openstackci-subnet
      network_name: openstackci-net
      cidr: 192.168.3.0/24
      dns_nameservers:
        - 8.8.8.8
      project: 7d517c389898420d8113d557357914eb
(venv) ubuntu@devstack:~$ ansible-playbook -i inventory test_os_subnet.yml -e "@infra_config.yml" -vvv
No config file found; using defaults

PLAYBOOK: test_os_subnet.yml ***************************************************
1 plays in test_os_subnet.yml

PLAY [localhost] ***************************************************************

TASK [os_subnet] ***************************************************************
task path: /home/ubuntu/test_os_subnet.yml:6
ESTABLISH LOCAL CONNECTION FOR USER: ubuntu
localhost EXEC /bin/sh -c '( umask 22 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1457958779.2-28797766643306 `" && echo "` echo $HOME/.ansible/tmp/ansible-tmp-1457958779.2-28797766643306 `" )'
localhost PUT /tmp/tmpsu8RfO TO /home/ubuntu/.ansible/tmp/ansible-tmp-1457958779.2-28797766643306/os_subnet
localhost EXEC /bin/sh -c 'LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/env python /home/ubuntu/.ansible/tmp/ansible-tmp-1457958779.2-28797766643306/os_subnet'
changed: [localhost] => {"changed": true, "id": "d1ba731f-1332-4389-946e-e96bb1bb6d38", "invocation": {"module_args": {"allocation_pool_end": null, "allocation_pool_start": null, "api_timeout": null, "auth": null, "auth_type": null, "availability_zone": null, "cacert": null, "cert": null, "cidr": "192.168.3.0/24", "cloud": "devstack-cloud_admin", "dns_nameservers": ["8.8.8.8"], "enable_dhcp": true, "endpoint_type": "public", "gateway_ip": null, "host_routes": null, "ip_version": "4", "ipv6_address_mode": null, "ipv6_ra_mode": null, "key": null, "name": "openstackci-subnet", "network_name": "openstackci-net", "region_name": null, "state": "present", "timeout": 180, "verify": true, "wait": true}, "module_name": "os_subnet"}, "subnet": {"allocation_pools": [{"end": "192.168.3.254", "start": "192.168.3.2"}], "cidr": "192.168.3.0/24", "dns_nameservers": ["8.8.8.8"], "enable_dhcp": true, "gateway_ip": "192.168.3.1", "host_routes": [], "id": "d1ba731f-1332-4389-946e-e96bb1bb6d38", "ip_version": 4, "ipv6_address_mode": null, "ipv6_ra_mode": null, "name": "openstackci-subnet", "network_id": "82e3abb6-05e3-4a70-8de7-ae0a13bdc6d6", "subnetpool_id": null, "tenant_id": "7d517c389898420d8113d557357914eb"}}

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0

(venv) ubuntu@devstack:~$ openstack subnet show openstackci-subnet
+-------------------+--------------------------------------+
| Field             | Value                                |
+-------------------+--------------------------------------+
| allocation_pools  | 192.168.3.2-192.168.3.254            |
| cidr              | 192.168.3.0/24                       |
| dns_nameservers   | 8.8.8.8                              |
| enable_dhcp       | True                                 |
| gateway_ip        | 192.168.3.1                          |
| host_routes       |                                      |
| id                | d1ba731f-1332-4389-946e-e96bb1bb6d38 |
| ip_version        | 4                                    |
| ipv6_address_mode | None                                 |
| ipv6_ra_mode      | None                                 |
| name              | openstackci-subnet                   |
| network_id        | 82e3abb6-05e3-4a70-8de7-ae0a13bdc6d6 |
| project_id        | 7d517c389898420d8113d557357914eb     |
| subnetpool_id     | None                                 |
+-------------------+--------------------------------------+

```
