### PR TITLE
Fix ec2 module source_dest_check when running on non VPC instances (E…

### DIFF
--- a/cloud/amazon/ec2.py
+++ b/cloud/amazon/ec2.py
@@ -1284,7 +1284,7 @@ def startstop_instances(module, ec2, instance_ids, state, instance_tags):
         for inst in res.instances:
 
             # Check "source_dest_check" attribute
-            if inst.get_attribute('sourceDestCheck')['sourceDestCheck'] != source_dest_check:
+            if inst.vpc_id is not None and inst.get_attribute('sourceDestCheck')['sourceDestCheck'] != source_dest_check:
                 inst.modify_attribute('sourceDestCheck', source_dest_check)
                 changed = True
 


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Plugin Name:

ec2.py
##### Summary:

<!-- Please describe the change and the reason for it. -->

It looks like the ec2.py module is broken when running it against non VPC instances (known as EC2 Classic).

Indeed non VPC instance does not have the concept of `sourceDestCheck`:

```
>>> print conn.get_all_instances(['i-xxx'])[0].instances[0].get_attribute('sourceDestCheck')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/boto/ec2/instance.py", line 527, in get_attribute
    dry_run=dry_run
  File "/usr/local/lib/python2.7/dist-packages/boto/ec2/connection.py", line 1136, in get_instance_attribute
    InstanceAttribute, verb='POST')
  File "/usr/local/lib/python2.7/dist-packages/boto/connection.py", line 1208, in get_object
    raise self.ResponseError(response.status, response.reason, body)
boto.exception.EC2ResponseError: EC2ResponseError: 400 Bad Request
<?xml version="1.0" encoding="UTF-8"?>
<Response><Errors><Error><Code>InvalidParameterCombination</Code><Message>You may only describe the sourceDestCheck attribute for VPC instances</Message></Error></Errors><RequestID>d3019de0-2ca0-4091-a2ef-87ccb3369168</RequestID></Response>
```

An EC2 Classic instance has its `vpc_id` attribute set to `None`:

```
>>> print conn.get_all_instances(['i-xxx'])[0].instances[0].vpc_id
None
```
##### Example:

The Ansible task I am running:

```

---
# Stop the EC2 instance
- name: Stop the EC2 Classic instance before taking a snapshot
  local_action:
    module: ec2
    aws_access_key: "{{ ec2_ami_aws_access_key }}"
    aws_secret_key: "{{ ec2_ami_aws_secret_key }}"
    instance_ids:
      - "{{ ec2_id }}"
    region: "{{ ec2_region }}"
    state: stopped
    wait: yes
    source_dest_check: no
  register: ec2_classic
```

The associated output:

```
2016-03-14 08:34:10,696 p=22302 u=root |  TASK [ec2-ami-001 : Stop the EC2 Classic instance before taking a snapshot] ****
2016-03-14 08:34:10,964 p=22302 u=root | An exception occurred during task execution. To see the full traceback, use -vvv. The error was: <Response><Errors><Error><Code>InvalidParameterCombination</Code><Message>You may only describe the sourceDestCheck attribute for VPC instances</Message></Error></Errors><RequestID>9253658f-fac7-4b75-98d7-c7a6ee99666b</RequestID></Response>
2016-03-14 08:34:10,964 p=22302 u=root |  fatal: [ip-W-X-Y-Z.ec2.internal -> localhost]: FAILED! => {"changed": false, "failed": true, "parsed": false}
```
