### PR TITLE
Add optional force parameter for apache2_module

### DIFF
--- a/web_infrastructure/apache2_module.py
+++ b/web_infrastructure/apache2_module.py
@@ -29,6 +29,12 @@ options:
      description:
         - name of the module to enable/disable
      required: true
+   force:
+     description:
+        - force disabling of the module and override apache2 warnings
+     required: false
+     choices: ['yes', 'no']
+     default: no
    state:
      description:
         - indicate the desired state of the resource

--- a/web_infrastructure/apache2_module.py
+++ b/web_infrastructure/apache2_module.py
@@ -31,7 +31,7 @@ options:
      required: true
    force:
      description:
-        - force disabling of the module and override apache2 warnings
+        - force disabling of default modules and override Debian warnings
      required: false
      choices: ['yes', 'no']
      default: no

--- a/web_infrastructure/apache2_module.py
+++ b/web_infrastructure/apache2_module.py
@@ -50,9 +50,13 @@ import re
 
 def _disable_module(module):
     name = module.params['name']
+    force = module.params['force']
     a2dismod_binary = module.get_bin_path("a2dismod")
     if a2dismod_binary is None:
         module.fail_json(msg="a2dismod not found.  Perhaps this system does not use a2dismod to manage apache")
+
+    if force:
+        a2dismod_binary += ' -f'
 
     result, stdout, stderr = module.run_command("%s %s" % (a2dismod_binary, name))
 
@@ -82,6 +86,7 @@ def main():
     module = AnsibleModule(
         argument_spec = dict(
             name  = dict(required=True),
+            force = dict(required=False, type='bool', default=False),
             state = dict(default='present', choices=['absent', 'present'])
         ),
     )


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Plugin Name:

module: apache2_module
##### Summary:

Add optional _force_ parameter to apache2_module. 

When _force=yes_ the _-f_ flag will be added to the a2dismod command to force disabling modules. In my case the _-f_ flag is needed to disable the autoindex module in Apache 2.4.18.

Fixes #2499
