### PR TITLE
One more bug yum non English locales

### DIFF
--- a/packaging/os/yum.py
+++ b/packaging/os/yum.py
@@ -657,7 +657,8 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
 
         changed = True
 
-        rc, out, err = module.run_command(cmd)
+        lang_env = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C')
+        rc, out, err = module.run_command(cmd, environ_update=lang_env)
 
         if (rc == 1):
             for spec in items:


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Plugin Name:

yum:
packaging/os/yum.py
##### Summary:

At non English locale, 
yum: name=<url> 
and <url> is already installed package, returns error (can not ignore 'Nothing to do') 
##### Example:

```
ansible -i hosts node1 -m yum -s --args "name=http://nginx.org/packages/centos/6/noarch/RPMS/nginx-release-centos-6-0.el6.ngx.noarch.rpm"
```

https://github.com/ansible/ansible-modules-core/commit/d7fac82f97c153af08dbea2b2ae9718b19abeb8a
