### PR TITLE
Reset all locale environment variables before running svn commands

### DIFF
--- a/source_control/subversion.py
+++ b/source_control/subversion.py
@@ -216,7 +216,10 @@ def main():
     export = module.params['export']
     switch = module.params['switch']
 
-    os.environ['LANG'] = 'C'
+    # We screenscrape a huge amount of svn commands so use C locale anytime we
+    # call run_command()
+    module.run_command_environ_update = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C', LC_CTYPE='C')
+
     svn = Subversion(module, dest, repo, revision, username, password, svn_path)
 
     if export or not os.path.exists(dest):


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Plugin Name:

subversion
##### Summary:

Reset all locale environment variables so that svn(1) output can be parsed.

Fixes #3255
