### PR TITLE
ec2_group: Add a check for invalid ports on make_rule_key

### DIFF
--- a/cloud/amazon/ec2_group.py
+++ b/cloud/amazon/ec2_group.py
@@ -365,6 +365,11 @@ def main():
                 if target_group_created:
                     changed = True
 
+                if rule['proto'] in ('all', '-1', -1):
+                    rule['proto'] = -1
+                    rule['from_port'] = None
+                    rule['to_port'] = None
+
                 # Convert ip to list we can iterate over
                 if not isinstance(ip, list):
                     ip = [ip]
@@ -411,6 +416,11 @@ def main():
                 group_id, ip, target_group_created = get_target_from_rule(module, ec2, rule, name, group, groups, vpc_id)
                 if target_group_created:
                     changed = True
+
+                if rule['proto'] in ('all', '-1', -1):
+                    rule['proto'] = -1
+                    rule['from_port'] = None
+                    rule['to_port'] = None
 
                 # Convert ip to list we can iterate over
                 if not isinstance(ip, list):

--- a/cloud/amazon/ec2_group.py
+++ b/cloud/amazon/ec2_group.py
@@ -136,14 +136,21 @@ try:
 except ImportError:
     HAS_BOTO = False
 
+def is_valid_port(s):
+    try:
+        val = int(s)
+        return val > 0 and val < 65536
+    except:
+        return False
 
 def make_rule_key(prefix, rule, group_id, cidr_ip):
     """Creates a unique key for an individual group rule"""
     if isinstance(rule, dict):
         proto, from_port, to_port = [rule.get(x, None) for x in ('proto', 'from_port', 'to_port')]
         #fix for 11177
-        if proto not in ['icmp', 'tcp', 'udp'] and from_port == -1 and to_port == -1:
+        if not is_valid_port(from_port):
             from_port = 'none'
+        if not is_valid_port(to_port):
             to_port   = 'none'
 
     else:  # isinstance boto.ec2.securitygroup.IPPermissions


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Plugin Name:

Module: `ec2_group`
##### Summary:

Fix to: https://github.com/ansible/ansible/issues/11177

Although it is already closed, the problem is not completely solved. For instance, this playbook:

```
- hosts: localhost
  gather_facts: false
  connection: local

  vars:
    sg_name: test-sg
    sg_rules:
      - {cidr_ip: 0.0.0.0/0, from_port: '-1', proto: 50, to_port: '-1'}
      - {cidr_ip: 0.0.0.0/0, from_port: '-1', proto: 51, to_port: '-1'}

  tasks:
    - name: Create security group
      ec2_group:
        region: us-east-1
        name: "{{ sg_name }}"
        description: "{{ sg_name }}"
        vpc_id: "vpc-zzzzzz"
        rules: "{{ sg_rules }}"
      register: security_group
```

If executed multiple times, we get:

```
...
EC2ResponseError: 400 Bad Request
...
<Response><Errors><Error>
<Code>InvalidPermission.Duplicate</Code>
<Message>the specified rule \"peer: 0.0.0.0/0, protocol: 50, ALLOW\" already exists</Message>
</Error></Errors>
...

```
