### PR TITLE
Fixes #2039 Convert None to 0 when checking ELB cookie expiration

### DIFF
--- a/cloud/amazon/ec2_elb_lb.py
+++ b/cloud/amazon/ec2_elb_lb.py
@@ -888,7 +888,7 @@ class ElbManager(object):
     def _set_stickiness_policy(self, elb_info, listeners_dict, policy, **policy_attrs):
         for p in getattr(elb_info.policies, policy_attrs['attr']):
             if str(p.__dict__['policy_name']) == str(policy[0]):
-                if str(p.__dict__[policy_attrs['dict_key']]) != str(policy_attrs['param_value']):
+                if str(p.__dict__[policy_attrs['dict_key']]) != str(policy_attrs['param_value'] or 0):
                     self._set_listener_policy(listeners_dict)
                     self._update_policy(policy_attrs['param_value'], policy_attrs['method'], policy_attrs['attr'], policy[0])
                     self.changed = True


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Plugin Name:

ec2_elb_lb
##### Summary:

When disabling the cookie expiration for an AWS ELB and setting `expiration: 0`, the task always is considered as `changed`, because "0" is compared to "None".

AWS does not allow saving an expiration value of `0`, it needs to be replaced with `None` (as it is currently). But when describing the policy, AWS returns "0" for the expiration value.

Fixes #2039 
##### Example:

```
ec2_elb_lb:
  name: "example-lb"
  state: present
  region: "eu-west-1"
  zones:
    - "eu-west-1a"
    - "eu-west-1b"
  listeners:
    - protocol: http
      load_balancer_port: 80
      instance_port: 80
  health_check:
      ping_protocol: http
      ping_port: 80
      ping_path: "/"
      response_timeout: 5
      interval: 30
      unhealthy_threshold: 2
      healthy_threshold: 2
  stickiness:
      type: loadbalancer
      enabled: yes
      expiration: 0
```
