### PR TITLE
Fixed typo json_fail to fail_json

### DIFF
--- a/cloud/amazon/ec2_ami.py
+++ b/cloud/amazon/ec2_ami.py
@@ -377,7 +377,7 @@ def main():
     try:
         ec2 = ec2_connect(module)
     except Exception, e:
-        module.json_fail(msg="Error while connecting to aws: %s" % str(e))
+        module.fail_json(msg="Error while connecting to aws: %s" % str(e))
 
     if module.params.get('state') == 'absent':
         if not module.params.get('image_id'):


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Plugin Name:

ec2_ami
##### Summary:

Fixes #3262 

fixed typo that caused:
AttributeError: 'AnsibleModule' object has no attribute 'json_fail'

instead of the actual error being printed
##### Example:
