### PR TITLE
Add support for setting fstab location on Linux too for mount

### DIFF
--- a/system/mount.py
+++ b/system/mount.py
@@ -240,6 +240,9 @@ def mount(module, **kwargs):
     if get_platform().lower() == 'freebsd':
         cmd += [ '-F', args['fstab'], ]
 
+    if get_platform().lower() == 'linux':
+        cmd += [ '-T', args['fstab'], ]
+
     cmd += [ name, ]
 
     rc, out, err = module.run_command(cmd)


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Plugin Name:

mount
##### Summary:

The mount module support using a different fstab. While that's a advanced feature and seldomly used, it wasn't working on Linux as seen on #3153 for mounting new FS. 

I am not sure since when the -T option was supported, but it work on RHEL 7, but not on RHEL 6.
