### PR TITLE
Improve/fix type checking for docker module

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -1798,7 +1798,7 @@ def absent(manager, containers, count, name):
 def main():
     module = AnsibleModule(
         argument_spec = dict(
-            count           = dict(default=1),
+            count           = dict(default=1, type='int'),
             image           = dict(required=True),
             pull            = dict(required=False, default='missing', choices=['missing', 'always']),
             entrypoint      = dict(required=False, default=None, type='str'),
@@ -1815,14 +1815,14 @@ def main():
             cpu_shares      = dict(default=0),
             docker_url      = dict(),
             use_tls         = dict(default=None, choices=['no', 'encrypt', 'verify']),
-            tls_client_cert = dict(required=False, default=None, type='str'),
-            tls_client_key  = dict(required=False, default=None, type='str'),
-            tls_ca_cert     = dict(required=False, default=None, type='str'),
+            tls_client_cert = dict(required=False, default=None, type='path'),
+            tls_client_key  = dict(required=False, default=None, type='path'),
+            tls_ca_cert     = dict(required=False, default=None, type='path'),
             tls_hostname    = dict(required=False, type='str', default=None),
             docker_api_version = dict(required=False, default=DEFAULT_DOCKER_API_VERSION, type='str'),
             docker_user     = dict(default=None),
             username        = dict(default=None),
-            password        = dict(),
+            password        = dict(no_log=True),
             email           = dict(),
             registry        = dict(),
             hostname        = dict(default=None),
@@ -1864,7 +1864,7 @@ def main():
 
     try:
         manager = DockerManager(module)
-        count = int(module.params.get('count'))
+        count = module.params.get('count')
         name = module.params.get('name')
         pull = module.params.get('pull')
 


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Plugin Name:

docker
##### Summary:

tls_\* point to files, so should be path
count is a int, so tag it as such and avoid converting later
password should be tagged as no_log
