### PR TITLE
Add missing parameters so these options are usable

### DIFF
--- a/packaging/os/rhn_register.py
+++ b/packaging/os/rhn_register.py
@@ -344,7 +344,7 @@ def main():
         else:
             try:
                 rhn.enable()
-                rhn.register(module.params['enable_eus'] == True, activationkey)
+                rhn.register(module.params['enable_eus'] == True, activationkey, profilename, sslcacert, systemorgid)
                 rhn.subscribe(channels)
             except Exception, e:
                 module.fail_json(msg="Failed to register with '%s': %s" % (rhn.hostname, e))


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Plugin Name:

packaging/os/rhn_register.py
##### Summary:

I have added missing parameters to the register method call, so these options (profilename, sslcacert and systemorgid) are actually usable.
##### Example:

```
  tasks:
  - name: download Satellite certificate
    get_url: url=http://<satellite>/pub/RHN-ORG-TRUSTED-SSL-CERT dest=/etc/sysconfig/rhn/RHN-ORG-TRUSTED-SSL-CERT
  - name: ensure we are registered
    rhn_register: state=present server_url=https://<satellite>/XMLRPC username=<user> password=<password> sslcacert=/etc/sysconfig/rhn/RHN-ORG-TRUSTED-SSL-CERT
```
