### PR TITLE
Fix size parameter documentation

### DIFF
--- a/cloud/openstack/os_volume.py
+++ b/cloud/openstack/os_volume.py
@@ -35,8 +35,9 @@ description:
 options:
    size:
      description:
-        - Size of volume in GB
-     required: only when state is 'present'
+        - Size of volume in GB. This parameter is required when the
+          I(state) parameter is 'present'.
+     required: false
      default: None
    display_name:
      description:


### PR DESCRIPTION
##### Issue Type:
- Docs Pull Request
##### Plugin Name:

cloud/openstack/os_volume.py
##### Summary:

The generated documentation shows the size parameter as required.
Set 'required' to 'false' and move the explanation to the description.

Fixes #3278
##### Example:

```
<!-- (Paste example execution or output here if necessary) -->
```
