### PR TITLE
Allow passing domain name on os_user

### DIFF
--- a/cloud/openstack/os_user.py
+++ b/cloud/openstack/os_user.py
@@ -175,6 +175,22 @@ def main():
                 module.fail_json(msg='Default project %s is not valid' % default_project)
             project_id = project['id']
 
+        if domain:
+            opcloud = shade.operator_cloud(**module.params)
+            try:
+                # We assume admin is passing domain id
+                dom = opcloud.get_domain(domain)['id']
+                domain = dom
+            except:
+                # If we fail, maybe admin is passing a domain name.
+                # Note that domains have unique names, just like id.
+                try:
+                    dom = opcloud.search_domains(filters={'name': domain})[0]['id']
+                    domain = dom
+                except:
+                    # Ok, let's hope the user is non-admin and passing a sane id
+                    pass
+
         if state == 'present':
             if user is None:
                 user = cloud.create_user(


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Plugin Name:

os_user
##### Summary:

Domain names are unique, just like domain ids.
A cloud admin is able to search by domain name, and as such we should cover
the use case for passing a domain name instead of an id.
##### Example:

```
ubuntu@devstack:~$ cat test_os_user.yml 

---
- hosts: localhost
  connection: local
  gather_facts: false
  tasks:
  - os_user:
      cloud: devstack-admin
      state: present
      name: openstackci-user
      password: openstack
      email: test@test.lol
      default_project: openstackci
      domain: infra
ubuntu@devstack:~$ ansible-playbook -i inventory test_os_user.yml -e "@resources.yml" -vvv
No config file found; using defaults

PLAYBOOK: test_os_user.yml *****************************************************
1 plays in test_os_user.yml

PLAY [localhost] ***************************************************************

TASK [os_user] *****************************************************************
task path: /home/ubuntu/test_os_user.yml:6
ESTABLISH LOCAL CONNECTION FOR USER: ubuntu
localhost EXEC /bin/sh -c '( umask 22 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1458649692.46-254087540995756 `" && echo "` echo $HOME/.ansible/tmp/ansible-tmp-1458649692.46-254087540995756 `" )'
localhost PUT /tmp/tmpNUiF06 TO /home/ubuntu/.ansible/tmp/ansible-tmp-1458649692.46-254087540995756/os_user
localhost EXEC /bin/sh -c 'LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/env python /home/ubuntu/.ansible/tmp/ansible-tmp-1458649692.46-254087540995756/os_user; rm -rf "/home/ubuntu/.ansible/tmp/ansible-tmp-1458649692.46-254087540995756/" > /dev/null 2>&1'
changed: [localhost] => {"changed": true, "invocation": {"module_args": {"api_timeout": null, "auth": null, "auth_type": null, "availability_zone": null, "cacert": null, "cert": null, "cloud": "devstack-admin", "default_project": "openstackci", "domain": "infra", "email": "test@test.lol", "enabled": true, "endpoint_type": "public", "key": null, "name": "openstackci-user", "password": "openstack", "region_name": null, "state": "present", "timeout": 180, "verify": true, "wait": true}, "module_name": "os_user"}, "user": {"default_project_id": "2f394d2be66c4f3ab18378e8af7f1b24", "domain_id": "92d5bcbeb0da4227b31f276a552d3700", "email": "test@test.lol", "enabled": true, "id": "35eeab56b6ab4819b3e8f149764ea9df", "name": "openstackci-user", "username": null}}

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0 
```
