### PR TITLE
Making unarchive idempotent

### DIFF
--- a/files/unarchive.py
+++ b/files/unarchive.py
@@ -297,7 +297,7 @@ class ZipArchive(object):
             dest = os.path.join(self.dest, path)
             try:
                 st = os.lstat(dest)
-            except Exception as e:
+            except:
                 change = True
                 self.includes.append(path)
                 err += 'Path %s is missing\n' % path
@@ -374,7 +374,7 @@ class ZipArchive(object):
             owner = uid = None
             try:
                 owner = pwd.getpwuid(st.st_uid).pw_name
-            except Exception as e:
+            except:
                 uid = st.st_uid
 
             # If we are not root and requested owner is not our user, fail

--- a/files/unarchive.py
+++ b/files/unarchive.py
@@ -713,6 +713,9 @@ def main():
     if module.params['list_files']:
         res_args['files'] = handler.files_in_archive
 
+    if not res_args['changed']:
+        del(res_args['check_results'])
+
     module.exit_json(**res_args)
 
 # import module snippets

--- a/files/unarchive.py
+++ b/files/unarchive.py
@@ -297,6 +297,8 @@ class ZipArchive(object):
             if len(permstr) == 6:
                 if path[-1] == '/':
                     permstr = 'rwxrwxrwx'
+                elif permstr == 'rwx---':
+                    permstr = 'rwxrwxrwx'
                 else:
                     permstr = 'rw-rw-rw-'
 

--- a/files/unarchive.py
+++ b/files/unarchive.py
@@ -120,7 +120,7 @@ from zipfile import ZipFile
 OWNER_DIFF_RE = re.compile(r': Uid differs$')
 GROUP_DIFF_RE = re.compile(r': Gid differs$')
 MODE_DIFF_RE = re.compile(r': Mode differs$')
-MODE_DIFF_RE = re.compile(r' is newer or same age.$')
+#NEWER_DIFF_RE = re.compile(r' is newer or same age.$')
 MISSING_FILE_RE = re.compile(r': Warning: Cannot stat: No such file or directory$')
 ZIP_FILE_MODE_RE = re.compile(r'([r-][w-][stx-]){3}')
 # When downloading an archive, how much of the archive to download before

--- a/files/unarchive.py
+++ b/files/unarchive.py
@@ -685,8 +685,12 @@ def main():
     res_args = dict(handler=handler.__class__.__name__, dest=dest, src=src)
 
     # do we need to do unpack?
-    res_args['check_results'] = handler.is_unarchived()
-    if res_args['check_results']['unarchived']:
+    check_results = handler.is_unarchived()
+
+    # DEBUG
+#    res_args['check_results'] = check_results
+
+    if check_results['unarchived']:
         res_args['changed'] = False
     else:
         # do the unpack
@@ -699,9 +703,8 @@ def main():
         else:
             res_args['changed'] = True
 
-        if res_args['check_results'].get('diff', False):
-            res_args['diff'] = dict(prepared=res_args['check_results']['diff'])
-            del(res_args['check_results']['diff'])
+        if check_results.get('diff', False):
+            res_args['diff'] = { 'prepared': check_results['diff'] }
 
     # Run only if we found differences (idempotence) or diff was missing
     if res_args.get('diff', True):
@@ -715,9 +718,6 @@ def main():
 
     if module.params['list_files']:
         res_args['files'] = handler.files_in_archive
-
-    if not res_args['changed']:
-        del(res_args['check_results'])
 
     module.exit_json(**res_args)
 

--- a/files/unarchive.py
+++ b/files/unarchive.py
@@ -404,10 +404,11 @@ class ZipArchive(object):
         cmd = '%s -o "%s"' % (self.cmd_path, self.src)
         if self.opts:
             cmd += ' ' + ' '.join(self.opts)
-        if self.excludes:
-            cmd += ' -x ' + ' '.join(self.excludes)
         if self.includes:
-            cmd += ' ' + ' '.join(self.excludes)
+            cmd += ' ' + ' '.join(self.includes)
+        # We don't need to handle excluded files, since we simply do not include them
+#        if self.excludes:
+#            cmd += ' -x ' + ' '.join(self.excludes)
         cmd += ' -d "%s"' % self.dest
         rc, out, err = self.module.run_command(cmd)
         return dict(cmd=cmd, rc=rc, out=out, err=err)

--- a/files/unarchive.py
+++ b/files/unarchive.py
@@ -236,14 +236,14 @@ class ZipArchive(object):
                 change = True
                 self.includes.append(path)
                 err += 'Path %s is missing\n' % path
-                diff += '>%s......... %s\n' % (ftype, path)
+                diff += '>%s++++++.?? %s\n' % (ftype, path)
                 continue
 
             if ftype == 'd' and not stat.S_ISDIR(st.st_mode):
                 change = True
                 self.includes.append(path)
                 err += 'File %s already exists, but not as a directory\n' % path
-                diff += 'c%s......... %s\n' % (ftype, path)
+                diff += 'c%s++++++.?? %s\n' % (ftype, path)
                 continue
 
             if ftype == 'f' and not stat.S_ISREG(st.st_mode):
@@ -251,17 +251,17 @@ class ZipArchive(object):
                 unarchived = False
                 self.includes.append(path)
                 err += 'Directory %s already exists, but not as a regular file\n' % path
-                diff += 'c%s......... %s\n' % (ftype, path)
+                diff += 'c%s++++++.?? %s\n' % (ftype, path)
                 continue
 
             if ftype == 'L' and not stat.S_ISLNK(st.st_mode):
                 change = True
                 self.includes.append(path)
                 err += 'Directory %s already exists, but not as a symlink\n' % path
-                diff += 'c%s......... %s\n' % (ftype, path)
+                diff += 'c%s++++++.?? %s\n' % (ftype, path)
                 continue
 
-            itemized = bytearray('.%s.........' % ftype)
+            itemized = bytearray('.%s.......??' % ftype)
 
             dt_object = datetime.datetime(*(time.strptime(pcs[6], '%Y%m%d.%H%M%S')[0:6]))
             timestamp = time.mktime(dt_object.timetuple())

--- a/files/unarchive.py
+++ b/files/unarchive.py
@@ -78,7 +78,7 @@ options:
     default:
     required: false
     version_added: "2.1"
-author: "Dylan Martin (@pileofrogs)"
+author: "Dag Wieers (@dagwieers)"
 todo:
     - re-implement tar support using native tarfile module
     - re-implement zip support using native zipfile module

--- a/files/unarchive.py
+++ b/files/unarchive.py
@@ -197,7 +197,7 @@ class ZipArchive(object):
     def is_unarchived(self):
         cmd = '%s -ZT -s "%s"' % (self.cmd_path, self.src)
         if self.excludes:
-            cmd += ' -x ' + ' '.join(self.excludes)
+            cmd += ' -x "' + '" "'.join(self.excludes) + '"'
         rc, out, err = self.module.run_command(cmd)
 
         old_out = out
@@ -454,7 +454,7 @@ class ZipArchive(object):
         if self.opts:
             cmd += ' ' + ' '.join(self.opts)
         if self.includes:
-            cmd += ' ' + ' '.join(self.includes)
+            cmd += ' "' + '" "'.join(self.includes) + '"'
         # We don't need to handle excluded files, since we simply do not include them
 #        if self.excludes:
 #            cmd += ' -x ' + ' '.join(self.excludes)
@@ -499,7 +499,7 @@ class TgzArchive(object):
         if self.opts:
             cmd += ' ' + ' '.join(self.opts)
         if self.excludes:
-            cmd += ' --exclude=' + ' --exclude='.join(self.excludes)
+            cmd += ' --exclude="' + '" --exclude="'.join(self.excludes) + '"'
         cmd += ' -f "%s"' % self.src
         rc, out, err = self.module.run_command(cmd)
         if rc != 0:
@@ -523,10 +523,9 @@ class TgzArchive(object):
         if self.module.params['keep_newer']:
             cmd += ' --keep-newer-files'
         if self.excludes:
-            cmd += ' --exclude=' + ' --exclude='.join(self.excludes)
+            cmd += ' --exclude="' + '" --exclude="'.join(self.excludes) + '"'
         cmd += ' -f "%s"' % self.src
         rc, out, err = self.module.run_command(cmd)
-        diff = ''
         # Check whether the differences are in something that we're
         # setting anyway
 
@@ -553,16 +552,16 @@ class TgzArchive(object):
         cmd = '%s -C "%s" -x%s' % (self.cmd_path, self.dest, self.zipflag)
         if self.opts:
             cmd += ' ' + ' '.join(self.opts)
-        if self.module.params['keep_newer']:
-            cmd += ' --keep-newer-files'
         if self.file_args['owner']:
             cmd += ' --owner="%s"' % self.file_args['owner']
         if self.file_args['group']:
             cmd += ' --group="%s"' % self.file_args['group']
         if self.file_args['mode']:
             cmd += ' --mode="%s"' % self.file_args['mode']
+        if self.module.params['keep_newer']:
+            cmd += ' --keep-newer-files'
         if self.excludes:
-            cmd += ' --exclude=' + ' --exclude='.join(self.excludes)
+            cmd += ' --exclude="' + '" --exclude="'.join(self.excludes) + '"'
         cmd += ' -f "%s"' % (self.src)
         rc, out, err = self.module.run_command(cmd, cwd=self.dest)
         return dict(cmd=cmd, rc=rc, out=out, err=err)

--- a/files/unarchive.py
+++ b/files/unarchive.py
@@ -616,11 +616,11 @@ def main():
     module = AnsibleModule(
         # not checking because of daisy chain to file module
         argument_spec = dict(
-            src               = dict(required=True),
-            original_basename = dict(required=False), # used to handle 'dest is a directory' via template, a slight hack
-            dest              = dict(required=True),
+            src               = dict(required=True, type='path'),
+            original_basename = dict(required=False, type='str'), # used to handle 'dest is a directory' via template, a slight hack
+            dest              = dict(required=True, type='path'),
             copy              = dict(default=True, type='bool'),
-            creates           = dict(required=False),
+            creates           = dict(required=False, type='path'),
             list_files        = dict(required=False, default=False, type='bool'),
             keep_newer        = dict(required=False, default=False, type='bool'),
             exclude           = dict(requited=False, default=[], type='list'),
@@ -632,8 +632,8 @@ def main():
 
     src    = os.path.expanduser(module.params['src'])
     dest   = os.path.expanduser(module.params['dest'])
-    file_args = module.load_file_common_arguments(module.params)
     copy   = module.params['copy']
+    file_args = module.load_file_common_arguments(module.params)
     # did tar file arrive?
     if not os.path.exists(src):
         if copy:

--- a/files/unarchive.py
+++ b/files/unarchive.py
@@ -184,16 +184,15 @@ class ZipArchive(object):
         #       Problem is that parsing the unzip -Zv info is going to be ugly
         cmd = '%s -ZT -s "%s"' % (self.cmd_path, self.src)
         if self.excludes:
-            cmd += '-x ' + ' '.join(self.excludes)
+            cmd += ' -x ' + ' '.join(self.excludes)
         rc, out, err = self.module.run_command(cmd)
 
         old_out = out
         diff = ''
+        out = ''
         if rc == 0:
-            output = ''
             unarchived = True
         else:
-            output = out
             unarchived = False
 
         for line in old_out.splitlines():
@@ -209,6 +208,7 @@ class ZipArchive(object):
 
             # Skip excluded files
             if path in self.excludes:
+                out += 'Path %s is excluded on request\n' % path
                 continue
 
             # Itemized change requires L for symlink


### PR DESCRIPTION
##### ISSUE TYPE

<!-- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### PLUGIN NAME

<!-- Name of the plugin/module/task  -->

unarchive
##### SUMMARY

<!-- Describe the change and the reason for it. -->

<!-- If you're fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does. -->

<!-- (Paste example execution or output here if necessary) -->

Originally unarchive was not idempotent and has many rough edges and bugs.
The current pull-request is a workable improvement on many fronts:
- zip support is now idempotent and fully functional
  - compares filetype, time, size, permission, ownership and CRC32
  - but gtar lacks check-mode, so check-mode is currently disabled
  - supports diff-mode (using rsync's itemized output format)
  - only extracts files that are in fact different (not all-or-nothing)
- gtar now better supports owner/group/mode changes (e.g. when provided as options, or as non-root)
- New option `exclude` to exclude specific paths/files
- New option `keep_newer` to exclude newer files on target
- New option `extra_opts` to influence unzip/gtar (like synchronize module)

This fixes #74, #348, #1292, #2037, #2250, #2438, #2491, #2772, #3229 and #3570 , but also fixes ansible/ansible#7188, ansible/ansible#7189 and ansible/ansible#9553.
(Please test your use-case again using this module)

The following items are part of future development (v2.1 ?):
- Re-implement the zip support using native zipfile module
- Re-implement the gtar support using native tarfile/gzip/bz2 modules (lzma/rarfile/cpio external)
- Implement diff-mode for gtar (using rsync's itemized output)
- Enable check-mode when gtar supports it (requires native re-implementation)
#### REVIEW AND TESTING

We need (more) feedback on the changes to the unarchive module. Please help review the code or test it in your environment. Testing is easy, simply perform the following in your playbook directory:

``` bash
mkdir -p ./library/
wget -O ./library/unarchive.py https://raw.githubusercontent.com/dagwieers/ansible-modules-core/idempotent-unarchive/files/unarchive.py
```
#### FUTURE NATIVE RE-IMPLEMENTATION APPROACH

The re-implementation of unzip/gtar support using native python modules will not only simplify the codebase, additional functionality can be implemented correctly and identically for all supported formats, which is currently not possible.

Whereas with the current implementation we cannot add specific functionality across archive formats, except by using non-generic `extra_opts` directives.

Native implementation will work for other platforms that may not have proper support/options that we rely one (e.g. Solaris, AIX, HP-UX).

Making unarchive idempotent is also nearly impossible using external commands. The current PR makes it possible for unzip, but gtar is a whole other beast to have a working check-mode. Same problem with unrar and other formats. Whereas if we use native libraries, we can abstract all layers natively and have a single implementation for all formats. In an idempotent fashion !
#### PYTHON 2.4

Since python 2.4 support is still needed for the next 2 years or so, we will have to implement some zipfile functionality ourselves on python 2.4, and possibly add lzma support directly into the module.
