### PR TITLE
Yum module always downloads remote rpms. fixes #1452

### DIFF
--- a/packaging/os/yum.py
+++ b/packaging/os/yum.py
@@ -482,6 +482,19 @@ def local_nvra(module, path):
                             header[rpm.RPMTAG_RELEASE],
                             header[rpm.RPMTAG_ARCH])
     
+def local_name(module, path):
+    """return package name of a local rpm passed in"""
+
+    ts = rpm.TransactionSet()
+    ts.setVSFlags(rpm._RPMVSF_NOSIGNATURES)
+    fd = os.open(path, os.O_RDONLY)
+    try:
+        header = ts.hdrFromFdno(fd)
+    finally:
+        os.close(fd)
+
+    return header[rpm.RPMTAG_NAME]
+    
 def pkg_to_dict(pkgstr):
 
     if pkgstr.strip():
@@ -556,33 +569,34 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
                 res['msg'] += "No Package file matching '%s' found on system" % spec
                 module.fail_json(**res)
 
-            nvra = local_nvra(module, spec)
+            pkg_name = local_name(module, spec)
             # look for them in the rpmdb
-            if is_installed(module, repoq, nvra, conf_file, en_repos=en_repos, dis_repos=dis_repos):
+            if is_installed(module, repoq, pkg_name, conf_file, en_repos=en_repos, dis_repos=dis_repos):
                 # if they are there, skip it
                 continue
             pkg = spec
 
         # URL
         elif '://' in spec:
-            pkg = spec
-            # Check if Enterprise Linux 5 or less, as yum on those versions do not support installing via url
-            distribution_version = get_distribution_version()
-            distribution = platform.dist()
-            if distribution[0] == "redhat" and LooseVersion(distribution_version) < LooseVersion("6"):
-                package = os.path.join(tempdir, str(pkg.rsplit('/', 1)[1]))
-                try:
-                    rsp, info = fetch_url(module, pkg)
-                    f = open(package, 'w')
+            # download package so that we can check if it's already installed
+            package = os.path.join(tempdir, str(spec.rsplit('/', 1)[1]))
+            try:
+                rsp, info = fetch_url(module, spec)
+                f = open(package, 'w')
+                data = rsp.read(BUFSIZE)
+                while data:
+                    f.write(data)
                     data = rsp.read(BUFSIZE)
-                    while data:
-                        f.write(data)
-                        data = rsp.read(BUFSIZE)
-                    f.close()
-                    pkg = package
-                except Exception, e:
-                    shutil.rmtree(tempdir)
-                    module.fail_json(msg="Failure downloading %s, %s" % (spec, e))
+                f.close()
+            except Exception, e:
+                shutil.rmtree(tempdir)
+                module.fail_json(msg="Failure downloading %s, %s" % (spec, e))
+
+            pkg_name = local_name(module, package)
+            if is_installed(module, repoq, pkg_name, conf_file, en_repos=en_repos, dis_repos=dis_repos):
+                # if it's there, skip it
+                continue
+            pkg = package
 
         #groups :(
         elif spec.startswith('@'):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

yum module
##### ANSIBLE VERSION

```
ansible 2.1.0
```
##### SUMMARY

Yum module now always downloads a remote RPM file and checks if it's really installed or not.

This pull request fixes #1452
