### PR TITLE
fix to allow named profiles to work correctly with cloudformation core module

### DIFF
--- a/cloud/amazon/cloudformation.py
+++ b/cloud/amazon/cloudformation.py
@@ -151,6 +151,7 @@ import yaml
 
 try:
     import boto
+    import boto.ec2
     import boto.cloudformation.connection
     HAS_BOTO = True
 except ImportError:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

cloudformation
##### ANSIBLE VERSION

```
ansible 2.1.0 (devel 85cc3b734f) last updated 2016/03/24 11:39:03 (GMT +100)
  lib/ansible/modules/core: (devel 5a1b1512dc) last updated 2016/03/24 12:03:20 (GMT +100)
  lib/ansible/modules/extras: (detached HEAD 7f9cdc0350) last updated 2016/03/24 11:47:18 (GMT +100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Use of named boto profiles with the core cloudformation module does not seem to be working correctly. I note that use of profiles has been fixed in Nov 2015, but cloudformation core module does not seem to import boto.ec2 so the resultant connection object is not handled correctly. I'm not sure whether this is the correct place to do the import but it works for me and I can see the import in other similar core AWS modules: 
imports boto.ec2 in the cloudformation core module so that it works with named profiles - otherwise I get the error outlined below.
This is when trying to use the following cloudformation module syntax using 'profile': 
-  hosts: localhost
  vars_files:
  -  "params/params-{{ Environment }}.yml"
    connection: local
    gather_facts: False
    tasks:
    -  name: create MariaDB RDS database stack
      vars:
        Component: "rds"
        StackName: "{{ Region }}-{{ Service }}-{{ Environment }}-{{ Component }}"
      cloudformation:
        stack_name: "{{ StackName }}"
        state: "present"
        profile: "{{ Profile }}"
        region: "{{ Region }}"
        disable_rollback: true
        template: "cloudformation/{{ Component }}-template.json"
        template_parameters:
           AlarmSnsTopic: "{{ AlarmSnsTopic }}"
           AllocatedStorage: "{{ AllocatedStorage }}"
           BackupRetentionPeriod: "{{ BackupRetentionPeriod }}"
           Component: "{{ Component }}"
           DBInstanceClass: "{{ DBInstanceClass }}"
           DBSubnetGroupName: "{{ lookup('cloudformation', Region + '/core-shared-vpc-' + Region + '/output/DBSubnetGroupName') }}"
           Environment: "{{ Environment }}"
           LowStorageThreshold: "{{ LowStorageThreshold }}"
           MasterUserPassword: "{{ MasterUserPassword }}"
           MultiAZ: "{{ MultiAZ }}"
           Region: "{{ Region }}"
           Service: "{{ Service }}"
           VpcId: "{{ lookup('cloudformation', Region + '/core-shared-vpc-' + Region + '/output/VpcId') }}"
        tags:
           Name: "{{ StackName }}"
      register: "rds"

```
##### BEFORE: 

[dsbutler@dsb-centos7-001 blog]$ ansible-playbook -vvv cloudformation.yml -e Environment=dev
Using /etc/ansible/ansible.cfg as config file

PLAYBOOK: cloudformation.yml ***************************************************
1 plays in cloudformation.yml

PLAY [localhost] ***************************************************************

TASK [create MariaDB RDS database stack] ***************************************
task path: /home/dsbutler/git/blog/cloudformation.yml:7
ESTABLISH LOCAL CONNECTION FOR USER: dsbutler
127.0.0.1 EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1458834397.26-86942486220457 `" && echo "` echo $HOME/.ansible/tmp/ansible-tmp-1458834397.26-86942486220457 `" )'
127.0.0.1 PUT /tmp/tmpMcVbS1 TO /home/dsbutler/.ansible/tmp/ansible-tmp-1458834397.26-86942486220457/cloudformation
127.0.0.1 EXEC /bin/sh -c 'LANG=en_GB.UTF-8 LC_ALL=en_GB.UTF-8 LC_MESSAGES=en_GB.UTF-8 /usr/bin/python /home/dsbutler/.ansible/tmp/ansible-tmp-1458834397.26-86942486220457/cloudformation; rm -rf "/home/dsbutler/.ansible/tmp/ansible-tmp-1458834397.26-86942486220457/" > /dev/null 2>&1'
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/home/dsbutler/.ansible/tmp/ansible-tmp-1458834397.26-86942486220457/cloudformation", line 2724, in <module>
    main()
  File "/home/dsbutler/.ansible/tmp/ansible-tmp-1458834397.26-86942486220457/cloudformation", line 292, in main
    region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module)
  File "/home/dsbutler/.ansible/tmp/ansible-tmp-1458834397.26-86942486220457/cloudformation", line 2635, in get_aws_connection_info
    if not boto_supports_profile_name():
  File "/home/dsbutler/.ansible/tmp/ansible-tmp-1458834397.26-86942486220457/cloudformation", line 2546, in boto_supports_profile_name
    return hasattr(boto.ec2.EC2Connection, 'profile_name')
AttributeError: 'module' object has no attribute 'ec2'

fatal: [127.0.0.1]: FAILED! => {"changed": false, "failed": true, "invocation": {"module_name": "cloudformation"}, "module_stderr": "Traceback (most recent call last):\n  File \"/home/dsbutler/.ansible/tmp/ansible-tmp-1458834397.26-86942486220457/cloudformation\", line 2724, in <module>\n    main()\n  File \"/home/dsbutler/.ansible/tmp/ansible-tmp-1458834397.26-86942486220457/cloudformation\", line 292, in main\n    region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module)\n  File \"/home/dsbutler/.ansible/tmp/ansible-tmp-1458834397.26-86942486220457/cloudformation\", line 2635, in get_aws_connection_info\n    if not boto_supports_profile_name():\n  File \"/home/dsbutler/.ansible/tmp/ansible-tmp-1458834397.26-86942486220457/cloudformation\", line 2546, in boto_supports_profile_name\n    return hasattr(boto.ec2.EC2Connection, 'profile_name')\nAttributeError: 'module' object has no attribute 'ec2'\n", "module_stdout": "", "msg": "MODULE FAILURE", "parsed": false}

NO MORE HOSTS LEFT *************************************************************
        to retry, use: --limit @cloudformation.retry

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=0    changed=0    unreachable=0    failed=1

##### AFTER: 

[dsbutler@dsb-centos7-001 blog]$ ansible-playbook -vvv cloudformation.yml -e Environment=dev
Using /etc/ansible/ansible.cfg as config file

PLAYBOOK: cloudformation.yml ***************************************************
1 plays in cloudformation.yml

PLAY [localhost] ***************************************************************

TASK [create MariaDB RDS database stack] ***************************************
task path: /home/dsbutler/git/blog/cloudformation.yml:7
ESTABLISH LOCAL CONNECTION FOR USER: dsbutler
127.0.0.1 EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1458834524.79-207531208368985 `" && echo "` echo $HOME/.ansible/tmp/ansible-tmp-1458834524.79-207531208368985 `" )'
127.0.0.1 PUT /tmp/tmppPEKV8 TO /home/dsbutler/.ansible/tmp/ansible-tmp-1458834524.79-207531208368985/cloudformation
127.0.0.1 EXEC /bin/sh -c 'LANG=en_GB.UTF-8 LC_ALL=en_GB.UTF-8 LC_MESSAGES=en_GB.UTF-8 /usr/bin/python /home/dsbutler/.ansible/tmp/ansible-tmp-1458834524.79-207531208368985/cloudformation; rm -rf "/home/dsbutler/.ansible/tmp/ansible-tmp-1458834524.79-207531208368985/" > /dev/null 2>&1'
ok: [127.0.0.1] => {"changed": false, "invocation": {"module_args": {"aws_access_key": null, "aws_secret_key": null, "disable_rollback": true, "ec2_url": null, "notification_arns": null, "profile": "home-mfa", "region": "eu-west-1", "security_token": null, "stack_name": "REMOVED", "stack_policy": null, "state": "present", "tags": {"Name": "REMOVED"}, "template": "cloudformation/rds-template.json", "template_format": "json", "template_parameters": {"AlarmSnsTopic": "REMOVED", "AllocatedStorage": 5, "BackupRetentionPeriod": 21, "Component": "rds", "DBInstanceClass": "db.t2.micro", "DBSubnetGroupName": "REMOVED", "Environment": "dev", "LowStorageThreshold": 1, "MasterUserPassword": "REMOVED", "MultiAZ": false, "Region": "eu-west-1", "Service": "blog", "VpcId": "REMOVED"}, "template_url": null, "validate_certs": true}, "module_name": "cloudformation"}, "output": "Stack is already up-to-date.", "stack_outputs": {"DBAccessSecurityGroup": "REMOVED", "DBEndpoint": "REMOVED"}, "stack_resources": [{"last_updated_time": null, "logical_resource_id": "AlarmOnLowAvailableStorage", "physical_resource_id": "REMOVED", "resource_type": "AWS::CloudWatch::Alarm", "status": "CREATE_COMPLETE", "status_reason": null}, {"last_updated_time": null, "logical_resource_id": "DBAccessSecurityGroup", "physical_resource_id": "REMOVED", "resource_type": "AWS::EC2::SecurityGroup", "status": "CREATE_COMPLETE", "status_reason": null}, {"last_updated_time": null, "logical_resource_id": "DBInstance", "physical_resource_id": "edi89aia179w24", "resource_type": "AWS::RDS::DBInstance", "status": "CREATE_COMPLETE", "status_reason": null}, {"last_updated_time": null, "logical_resource_id": "DBSecurityGroup", "physical_resource_id": "REMOVED", "resource_type": "AWS::RDS::DBSecurityGroup", "status": "CREATE_COMPLETE", "status_reason": null}]}

TASK [create ec2 instance stack] ***********************************************
task path: /home/dsbutler/git/blog/cloudformation.yml:35
ESTABLISH LOCAL CONNECTION FOR USER: dsbutler
127.0.0.1 EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1458834527.81-108118293886914 `" && echo "` echo $HOME/.ansible/tmp/ansible-tmp-1458834527.81-108118293886914 `" )'
127.0.0.1 PUT /tmp/tmpmn0BOH TO /home/dsbutler/.ansible/tmp/ansible-tmp-1458834527.81-108118293886914/cloudformation
127.0.0.1 EXEC /bin/sh -c 'LANG=en_GB.UTF-8 LC_ALL=en_GB.UTF-8 LC_MESSAGES=en_GB.UTF-8 /usr/bin/python /home/dsbutler/.ansible/tmp/ansible-tmp-1458834527.81-108118293886914/cloudformation; rm -rf "/home/dsbutler/.ansible/tmp/ansible-tmp-1458834527.81-108118293886914/" > /dev/null 2>&1'
ok: [127.0.0.1] => {"changed": false, "invocation": {"module_args": {"aws_access_key": null, "aws_secret_key": null, "disable_rollback": true, "ec2_url": null, "notification_arns": null, "profile": "home-mfa", "region": "eu-west-1", "security_token": null, "stack_name": "REMOVED", "stack_policy": null, "state": "present", "tags": {"Name": "eu-west-1-blog-dev-instance"}, "template": "cloudformation/instance-template.json", "template_format": "json", "template_parameters": {"DBAccessSecurityGroup": "REMOVED", "Environment": "dev", "ExternalDomain": "REMOVED", "ImageId": "REMOVED", "InstanceType": "t2.nano", "InternalDomain": "REMOVED", "KeyName": "id_rsa_home.pub", "MgmtSecurityGroup": "REMOVED", "Service": "blog", "SubnetId": "REMOVED", "VpcId": "REMOVED"}, "template_url": null, "validate_certs": true}, "module_name": "cloudformation"}, "output": "Stack is already up-to-date.", "stack_outputs": {}, "stack_resources": [{"last_updated_time": null, "logical_resource_id": "AppSecurityGroup", "physical_resource_id": "REMOVED", "resource_type": "AWS::EC2::SecurityGroup", "status": "CREATE_COMPLETE", "status_reason": null}, {"last_updated_time": null, "logical_resource_id": "EIP", "physical_resource_id": "REMOVED", "resource_type": "AWS::EC2::EIP", "status": "CREATE_COMPLETE", "status_reason": null}, {"last_updated_time": null, "logical_resource_id": "EIPAssociation", "physical_resource_id": "REMOVED", "resource_type": "AWS::EC2::EIPAssociation", "status": "CREATE_COMPLETE", "status_reason": null}, {"last_updated_time": null, "logical_resource_id": "Instance", "physical_resource_id": "REMOVED", "resource_type": "AWS::EC2::Instance", "status": "CREATE_COMPLETE", "status_reason": null}, {"last_updated_time": null, "logical_resource_id": "InstanceProfile", "physical_resource_id": "REMOVED", "resource_type": "AWS::IAM::InstanceProfile", "status": "CREATE_COMPLETE", "status_reason": null}, {"last_updated_time": null, "logical_resource_id": "InstanceRole", "physical_resource_id": "REMOVED", "resource_type": "AWS::IAM::Role", "status": "CREATE_COMPLETE", "status_reason": null}, {"last_updated_time": null, "logical_resource_id": "InternalRecordSet", "physical_resource_id": "REMOVED", "resource_type": "AWS::Route53::RecordSet", "status": "CREATE_COMPLETE", "status_reason": null}, {"last_updated_time": null, "logical_resource_id": "OriginRecordSet", "physical_resource_id": "blog-dev-origin.requestexpired.com", "resource_type": "AWS::Route53::RecordSet", "status": "CREATE_COMPLETE", "status_reason": null}]}

```

…core cloudformation module
