### PR TITLE
Fix is_public type on os_image

### DIFF
--- a/cloud/openstack/os_image.py
+++ b/cloud/openstack/os_image.py
@@ -127,7 +127,7 @@ def main():
         owner             = dict(default=None),
         min_disk          = dict(type='int', default=0),
         min_ram           = dict(type='int', default=0),
-        is_public         = dict(default=False),
+        is_public         = dict(type='bool', default=False),
         filename          = dict(default=None),
         ramdisk           = dict(default=None),
         kernel            = dict(default=None),


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

os_image
##### ANSIBLE VERSION

```
ubuntu@ansible-control-machine:~$ ansible --version
ansible 2.1.0 (devel 0cabef19ad) last updated 2016/03/23 16:42:48 (GMT +000)
  lib/ansible/modules/core: (fix_os_image_is_public_casting 6e6817ce18) last updated 2016/03/29 11:39:35 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD 7f9cdc0350) last updated 2016/03/23 16:42:55 (GMT +000)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Without this fix, the is_public value is a string and the shade
call handling the module does not evaluate correctly when
passing is_public: no

```
ubuntu@ansible-control-machine:~$ cat test_os_image.yml 

---
- hosts: localhost
  connection: local
  gather_facts: false
  tasks:
  - os_image:
      cloud: yaycloud
      name: ubuntu
      filename: /home/ubuntu/trusty-server-cloudimg-amd64-disk1.img
      is_public: no

WITHOUT PR FIX:

ubuntu@ansible-control-machine:~$ ansible-playbook -i 'localhost,' test_os_image.yml -vvv
No config file found; using defaults

PLAYBOOK: test_os_image.yml ****************************************************
1 plays in test_os_image.yml

PLAY [localhost] ***************************************************************

TASK [os_image] ****************************************************************
task path: /home/ubuntu/test_os_image.yml:6
ESTABLISH LOCAL CONNECTION FOR USER: ubuntu
localhost EXEC /bin/sh -c '( umask 22 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1459251273.95-25879337167127 `" && echo "` echo $HOME/.ansible/tmp/ansible-tmp-1459251273.95-25879337167127 `" )'
localhost PUT /tmp/tmpZYV_eZ TO /home/ubuntu/.ansible/tmp/ansible-tmp-1459251273.95-25879337167127/os_image
localhost EXEC /bin/sh -c 'LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/python /home/ubuntu/.ansible/tmp/ansible-tmp-1459251273.95-25879337167127/os_image; rm -rf "/home/ubuntu/.ansible/tmp/ansible-tmp-1459251273.95-25879337167127/" > /dev/null 2>&1'
fatal: [localhost]: FAILED! => {"changed": false, "extra_data": null, "failed": true, "invocation": {"module_args": {"api_timeout": null, "auth": null, "auth_type": null, "availability_zone": null, "cacert": null, "cert": null, "cloud": "yaycloud", "container_format": "bare", "disk_format": "qcow2", "endpoint_type": "public", "filename": "/home/ubuntu/trusty-server-cloudimg-amd64-disk1.img", "is_public": "False", "kernel": null, "key": null, "min_disk": 0, "min_ram": 0, "name": "ubuntu", "owner": null, "properties": {}, "ramdisk": null, "region_name": null, "state": "present", "timeout": 180, "verify": true, "wait": true}, "module_name": "os_image"}, "msg": "Image creation failed: 403 Forbidden: You are not authorized to complete this action. (HTTP 403)"}

NO MORE HOSTS LEFT *************************************************************
        to retry, use: --limit @test_os_image.retry

PLAY RECAP *********************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1   

WITH PR FIX:

ubuntu@ansible-control-machine:~$ ansible-playbook -i 'localhost,' test_os_image.yml -vvv
No config file found; using defaults

PLAYBOOK: test_os_image.yml ****************************************************
1 plays in test_os_image.yml

PLAY [localhost] ***************************************************************

TASK [os_image] ****************************************************************
task path: /home/ubuntu/test_os_image.yml:6
ESTABLISH LOCAL CONNECTION FOR USER: ubuntu
localhost EXEC /bin/sh -c '( umask 22 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1459251350.96-38946487802854 `" && echo "` echo $HOME/.ansible/tmp/ansible-tmp-1459251350.96-38946487802854 `" )'
localhost PUT /tmp/tmpEeTMk1 TO /home/ubuntu/.ansible/tmp/ansible-tmp-1459251350.96-38946487802854/os_image
localhost EXEC /bin/sh -c 'LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/python /home/ubuntu/.ansible/tmp/ansible-tmp-1459251350.96-38946487802854/os_image; rm -rf "/home/ubuntu/.ansible/tmp/ansible-tmp-1459251350.96-38946487802854/" > /dev/null 2>&1'
changed: [localhost] => {"changed": true, "id": "300b7f45-b4f3-4b5a-b7d1-9146ce3f2883", "image": {"checksum": "d92daae4763710be5a4bdddeffe34d4e", "container_format": "bare", "created_at": "2016-03-29T11:35:55Z", "disk_format": "qcow2", "file": "/v2/images/300b7f45-b4f3-4b5a-b7d1-9146ce3f2883/file", "id": "300b7f45-b4f3-4b5a-b7d1-9146ce3f2883", "min_disk": 0, "min_ram": 0, "name": "ubuntu", "owner": "2c1259a3983440bd9b3357ee8e3d1404", "owner_specified.shade.md5": "d92daae4763710be5a4bdddeffe34d4e", "owner_specified.shade.sha256": "79eb0ff0a1768216599eea8beeb3385772eeef558b54ab3d6824e1faa1754cbd", "protected": false, "schema": "/v2/schemas/image", "size": 259260928, "status": "active", "tags": [], "updated_at": "2016-03-29T11:35:59Z", "virtual_size": null, "visibility": "private"}, "invocation": {"module_args": {"api_timeout": null, "auth": null, "auth_type": null, "availability_zone": null, "cacert": null, "cert": null, "cloud": "yaycloud", "container_format": "bare", "disk_format": "qcow2", "endpoint_type": "public", "filename": "/home/ubuntu/trusty-server-cloudimg-amd64-disk1.img", "is_public": false, "kernel": null, "key": null, "min_disk": 0, "min_ram": 0, "name": "ubuntu", "owner": null, "properties": {}, "ramdisk": null, "region_name": null, "state": "present", "timeout": 180, "verify": true, "wait": true}, "module_name": "os_image"}}

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0   

```
