### PR TITLE
Set type on floating_ip_pools in os_server

### DIFF
--- a/cloud/openstack/os_server.py
+++ b/cloud/openstack/os_server.py
@@ -555,7 +555,7 @@ def main():
         config_drive                    = dict(default=False, type='bool'),
         auto_ip                         = dict(default=True, type='bool', aliases=['auto_floating_ip', 'public_ip']),
         floating_ips                    = dict(default=None, type='list'),
-        floating_ip_pools               = dict(default=None),
+        floating_ip_pools               = dict(default=None, type='list'),
         volume_size                     = dict(default=False, type='int'),
         boot_from_volume                = dict(default=False, type='bool'),
         boot_volume                     = dict(default=None, aliases=['root_volume']),


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

cloud/openstack/os_server.py
##### ANSIBLE VERSION

2.1
##### SUMMARY

This has been expected as a list, so let's be explicit about it so it will work correctly in 2.1 release.
