### PR TITLE
Pass wait/timeout parameters to floating IP APIs in os_server

### DIFF
--- a/cloud/openstack/os_server.py
+++ b/cloud/openstack/os_server.py
@@ -498,6 +498,8 @@ def _check_floating_ips(module, cloud, server):
                 auto_ip=auto_ip,
                 ips=floating_ips,
                 ip_pool=floating_ip_pools,
+                wait=module.params['wait'],
+                timeout=module.params['timeout'],
             )
             changed = True
         elif floating_ips:
@@ -508,7 +510,9 @@ def _check_floating_ips(module, cloud, server):
                 if ip not in ips:
                     missing_ips.append(ip)
             if missing_ips:
-                server = cloud.add_ip_list(server, missing_ips)
+                server = cloud.add_ip_list(server, missing_ips,
+                                           wait=module.params['wait'],
+                                           timeout=module.params['timeout'])
                 changed = True
             extra_ips = []
             for ip in ips:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

cloud/openstack/os_server.py
##### ANSIBLE VERSION

This would affect both 2.0 and 2.1.
##### SUMMARY

If a server already exists when os_server is run, but a floating
IP was not assigned to the server when one was requested, the
module will attempt to add an IP to the existing server. But it
would not pass the wait/timeout params to the floating IP APIs.
If wait was True, you could get back a server dict that did not
show the floating IP because it did not wait.
