### PR TITLE
ansible-validate-modules part 1: Correct documentation

### DIFF
--- a/cloud/linode/linode.py
+++ b/cloud/linode/linode.py
@@ -40,7 +40,7 @@ options:
   linode_id:
     description:
      - Unique ID of a linode server
-    aliases: lid
+    aliases: [ 'lid' ]
     default: null
     type: integer
   plan:

--- a/cloud/openstack/os_router.py
+++ b/cloud/openstack/os_router.py
@@ -54,10 +54,9 @@ options:
    network:
      description:
         - Unique name or ID of the external gateway network.
-        - required I(interfaces) or I(enable_snat) are provided,
+        - required I(interfaces) or I(enable_snat) are provided.
      type: string
      required: false
-               false otherwise.
      default: None
    external_fixed_ips:
      description:

--- a/network/ios/ios_template.py
+++ b/network/ios/ios_template.py
@@ -47,7 +47,7 @@ options:
         without first checking if already configured.
     required: false
     default: false
-    choices: BOOLEANS
+    choices: [ "true", "false" ]
   include_defaults:
     description:
       - The module, by default, will collect the current device
@@ -58,7 +58,7 @@ options:
         does not support such a flag, this argument is silently ignored.
     required: false
     default: false
-    choices: BOOLEANS
+    choices: [ "true", "false" ]
   backup:
     description:
       - When this argument is configured true, the module will backup
@@ -67,7 +67,7 @@ options:
         the root of the playbook directory.
     required: false
     default: false
-    choices: BOOLEANS
+    choices: [ "true", "false" ]
   config:
     description:
       - The module, by default, will connect to the remote device and

--- a/network/iosxr/iosxr_config.py
+++ b/network/iosxr/iosxr_config.py
@@ -93,7 +93,7 @@ options:
         without first checking if already configured.
     required: false
     default: false
-    choices: BOOLEANS
+    choices: [ "true", "false" ]
   config:
     description:
       - The module, by default, will connect to the remote device and

--- a/network/iosxr/iosxr_template.py
+++ b/network/iosxr/iosxr_template.py
@@ -47,7 +47,7 @@ options:
         without first checking if already configured.
     required: false
     default: false
-    choices: BOOLEANS
+    choices: [ "true", "false" ]
   backup:
     description:
       - When this argument is configured true, the module will backup
@@ -56,7 +56,7 @@ options:
         the root of the playbook directory.
     required: false
     default: false
-    choices: BOOLEANS
+    choices: [ "true", "false" ]
   config:
     description:
       - The module, by default, will connect to the remote device and

--- a/network/nxos/nxos_config.py
+++ b/network/nxos/nxos_config.py
@@ -93,7 +93,7 @@ options:
         without first checking if already configured.
     required: false
     default: false
-    choices: BOOLEANS
+    choices: [ "true", "false" ]
   config:
     description:
       - The module, by default, will connect to the remote device and

--- a/network/nxos/nxos_template.py
+++ b/network/nxos/nxos_template.py
@@ -46,7 +46,7 @@ options:
         without first checking if already configured.
     required: false
     default: false
-    choices: BOOLEANS
+    choices: [ "true", "false" ]
   include_defaults:
     description:
       - The module, by default, will collect the current device
@@ -56,7 +56,7 @@ options:
         device settings.
     required: false
     default: false
-    choices: BOOLEANS
+    choices: [ "true", "false" ]
   backup:
     description:
       - When this argument is configured true, the module will backup
@@ -65,7 +65,7 @@ options:
         the root of the playbook directory.
     required: false
     default: false
-    choices: BOOLEANS
+    choices: [ "true", "false" ]
   config:
     description:
       - The module, by default, will connect to the remote device and


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

Multiple modules in core
##### ANSIBLE VERSION

```
ansible 2.0.1.0
  config file = /home/bob/.ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

Part 1 of getting ansible-validate-modules clean on ansible-modules-core. Currently it's only enabled on ansible-modules-extras.

This fixes the following types of bugs:
a) Documentation for requires incorrectly displayed as "true"
http://docs.ansible.com/ansible/elasticache_module.html
Notice "cache_subnet_group" is listed as a required option, when it isn't

b) Strings being treated as lists
http://docs.ansible.com/ansible/linode_module.html linode_id aliases: l, i, d, rather than "lid"
or
http://docs.ansible.com/ansible/ios_template_module.html
stating choices B,O,O,L,E,A,N,S

Mostly fixes in options.
Web help was previously stating required: true for "false unless
state=present"

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible-modules-core/3342)

<!-- Reviewable:end -->
