### PR TITLE
ansible-validate-modules part 2: Move import to end

### DIFF
--- a/cloud/amazon/ec2_asg.py
+++ b/cloud/amazon/ec2_asg.py
@@ -203,7 +203,6 @@ to "replace_instances":
 import time
 import logging as log
 
-from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 log.getLogger('boto').setLevel(log.CRITICAL)
 #log.basicConfig(filename='/tmp/ansible_ec2_asg.log',level=log.DEBUG, format='%(asctime)s: %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p')
@@ -827,6 +826,8 @@ def main():
     if create_changed or replace_changed:
         changed = True
     module.exit_json( changed = changed, **asg_properties )
+
+from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/cloud/amazon/ec2_lc.py
+++ b/cloud/amazon/ec2_lc.py
@@ -129,7 +129,6 @@ EXAMPLES = '''
 
 '''
 
-from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
 try:
@@ -306,4 +305,5 @@ def main():
     elif state == 'absent':
         delete_launch_config(connection, module)
 
+from ansible.module_utils.basic import *
 main()

--- a/cloud/amazon/ec2_scaling_policy.py
+++ b/cloud/amazon/ec2_scaling_policy.py
@@ -71,7 +71,6 @@ EXAMPLES = '''
 '''
 
 
-from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
 
 try:
@@ -186,6 +185,7 @@ def main():
     elif state == 'absent':
         delete_scaling_policy(connection, module)
 
+from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/cloud/azure/azure.py
+++ b/cloud/azure/azure.py
@@ -189,7 +189,6 @@ import datetime
 import os
 import time
 from urlparse import urlparse
-from ansible.module_utils.facts import * # TimeoutError
 
 AZURE_LOCATIONS = ['South Central US',
                    'Central US',
@@ -615,5 +614,7 @@ class Wrapper(object):
 
 # import module snippets
 from ansible.module_utils.basic import *
+from ansible.module_utils.facts import * # TimeoutError
+
 if __name__ == '__main__':
     main()

--- a/network/openswitch/ops_template.py
+++ b/network/openswitch/ops_template.py
@@ -240,8 +240,6 @@ from ansible.module_utils.urls import *
 from ansible.module_utils.netcfg import *
 from ansible.module_utils.shell import *
 from ansible.module_utils.openswitch import *
+
 if __name__ == '__main__':
         main()
-
-
-

--- a/packaging/os/rhn_register.py
+++ b/packaging/os/rhn_register.py
@@ -122,10 +122,6 @@ try:
 except ImportError, e:
     module.fail_json(msg="Unable to import up2date_client.  Is 'rhn-client-tools' installed?\n%s" % e)
 
-# INSERT REDHAT SNIPPETS
-from ansible.module_utils.redhat import *
-# INSERT COMMON SNIPPETS
-from ansible.module_utils.basic import *
 
 class Rhn(RegistrationBase):
 
@@ -363,5 +359,9 @@ def main():
 
             module.exit_json(changed=True, msg="System successfully unregistered from %s." % rhn.hostname)
 
+# INSERT REDHAT SNIPPETS
+from ansible.module_utils.redhat import *
+# INSERT COMMON SNIPPETS
+from ansible.module_utils.basic import *
 
 main()

--- a/system/hostname.py
+++ b/system/hostname.py
@@ -46,9 +46,6 @@ EXAMPLES = '''
 import socket
 from distutils.version import LooseVersion
 
-# import module snippets
-from ansible.module_utils.basic import *
-
 
 class UnimplementedStrategy(object):
     def __init__(self, module):
@@ -665,5 +662,7 @@ def main():
                                         ansible_nodename=name,
                                         ansible_fqdn=socket.getfqdn(),
                                         ansible_domain='.'.join(socket.getfqdn().split('.')[1:])))
+
+from ansible.module_utils.basic import *
 
 main()


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

Multiple modules
##### ANSIBLE VERSION

```
ansible 2.0.1.0
  config file = /home/bob/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Part 2 of getting ansible-validate-modules clean on ansible-modules-core. Currently it's only enabled on ansible-modules-extras.

As per http://docs.ansible.com/ansible/developing_modules.html imports
of Ansible code should go at the end.

**Testing**
_Before_

```
ansible-validate-modules  . | grep import
ERROR: ansible.module_utils.basic import not near call to main()
ERROR: ansible.module_utils.basic import not near call to main()
ERROR: ansible.module_utils.basic import not near call to main()
ERROR: ansible.module_utils.facts import not near call to main()
ERROR: ansible.module_utils.basic import not near call to main()
ERROR: ansible.module_utils.basic import not near call to main()

```

_After_

```
ansible-validate-modules  . | grep import

#Nothing
```

This is another step to getting a cleaner ansible-validate-modules run.
Follows on from https://github.com/ansible/ansible-modules-core/pull/3342

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible-modules-core/3343)

<!-- Reviewable:end -->
