### PR TITLE
Prevent ec2group from deleting sgs during check_mode runs

### DIFF
--- a/cloud/amazon/ec2_group.py
+++ b/cloud/amazon/ec2_group.py
@@ -285,7 +285,8 @@ def main():
         if group:
             '''found a match, delete it'''
             try:
-                group.delete()
+                if not module.check_mode:
+                    group.delete()
             except Exception as e:
                 module.fail_json(msg="Unable to delete security group '%s' - %s" % (group, e))
             else:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

ec2_group module
##### ANSIBLE VERSION

```
ansible 1.9.4
```
##### SUMMARY

The ec2_group module supports check mode, but given `state: absent` actually attempts to remove security groups, even during check mode runs. This produces nonsense results and is just generally bad - this PR simply adds an if statement that prevents this specific failure mode.

(I walked through the rest of the code to see if there are any similar failure modes and didn't see any, for the record.)
