### PR TITLE
Fix S3 unavailable region error

### DIFF
--- a/cloud/amazon/s3.py
+++ b/cloud/amazon/s3.py
@@ -460,9 +460,10 @@ def main():
             s3 = boto.connect_walrus(walrus, **aws_connect_kwargs)
         else:
             aws_connect_kwargs['is_secure'] = True
-            s3 = connect_to_aws(boto.s3, location, **aws_connect_kwargs)
-            # use this as fallback because connect_to_region seems to fail in boto + non 'classic' aws accounts in some cases
-            if s3 is None:
+            try:
+                s3 = connect_to_aws(boto.s3, location, **aws_connect_kwargs)
+            except AnsibleAWSError:
+                # use this as fallback because connect_to_region seems to fail in boto + non 'classic' aws accounts in some cases
                 s3 = boto.connect_s3(**aws_connect_kwargs)
 
     except boto.exception.NoAuthHandlerFound, e:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

```
cloud/amazon/s3.py
```
##### ANSIBLE VERSION

```
ansible 2.1.0
  config file = /Users/aluce/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

This addresses the error:

```
  fatal: [site]: FAILED! => {"changed": false, "failed": true, "msg": "Failed to connect to S3: Region  does not seem to be available for awsmodule boto.s3. If the region definitely exists, you may need to upgrade boto or extend with endpoints_path"}
```

Commit 0dd58e9 changed the logic so an exception is thrown (by `connect_to_aws`) before the `s3 is None` check is performed. This change changese the `None` check to a catch so the old logic can compensate.
