### PR TITLE
ansible-validate-modules part 3: Add copyright notice for Barnaby Court (@barnabycourt)

### DIFF
--- a/packaging/os/redhat_subscription.py
+++ b/packaging/os/redhat_subscription.py
@@ -1,5 +1,20 @@
 #!/usr/bin/python
 
+# James Laska (jlaska@redhat.com)
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
 DOCUMENTATION = '''
 ---
 module: redhat_subscription


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

redhat_subscription
##### ANSIBLE VERSION

```
ansible 2.0.1.0
  config file = /home/bob/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Part 3 of getting ansible-validate-modules clean on ansible-modules-core. Currently it's only enabled on ansible-modules-extras.

As per http://docs.ansible.com/ansible/developing_modules.html copyright notice is needed

The following now doesn't error about missing GPL message
`ansible-validate-modules packaging/`

**NOTE: This shouldn't be merged or given s h i p i t s without approval from @barnabycourt.**

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible-modules-core/3352)

<!-- Reviewable:end -->
