### PR TITLE
Allow async to not need an args file since new-style modules have args embedded

### DIFF
--- a/utilities/logic/async_wrapper.py
+++ b/utilities/logic/async_wrapper.py
@@ -122,8 +122,11 @@ if __name__ == '__main__':
     jid = "%s.%d" % (sys.argv[1], os.getpid())
     time_limit = sys.argv[2]
     wrapped_module = sys.argv[3]
-    argsfile = sys.argv[4]
-    cmd = "%s %s" % (wrapped_module, argsfile)
+    if len(sys.argv) >= 5:
+        argsfile = sys.argv[4]
+        cmd = "%s %s" % (wrapped_module, argsfile)
+    else:
+        cmd = wrapped_module
     step = 5
 
     # setup job output directory


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

async_wrapper
##### SUMMARY

async_wrapper was trying to cover all the bases by passing an arguments file all the time.  This is not necessary for new-style modules.  Removing hte need for the argument file means we can stop sending an arguments file always which will make async slightly faster.  (and will let the new ziploader debug stuff work as well).
