### PR TITLE
Update redhat_subscriptions 'server_insecure' docs

### DIFF
--- a/packaging/os/redhat_subscription.py
+++ b/packaging/os/redhat_subscription.py
@@ -36,7 +36,7 @@ options:
         default: Current value from C(/etc/rhsm/rhsm.conf) is the default
     server_insecure:
         description:
-            - Allow traffic over insecure http
+            - Enable or disable https server certificate verification when connecting to C(server_hostname)
         required: False
         default: Current value from C(/etc/rhsm/rhsm.conf) is the default
     rhsm_baseurl:


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

package/os/redhat_subscriptions
##### ANSIBLE VERSION

```
ansible 2.1.0 (devel 03300e99ac) last updated 2016/03/16 15:42:07 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 345d9cbca8) last updated 2016/03/18 12:14:26 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD f9b96b9a8a) last updated 2016/04/06 13:43:38 (GMT -400)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Docs description for 'server_insecure' was inaccurate.

'server_insecure' maps to the subscription-manager config
(/etc/rhsm/rhsm.conf) value for 'insecure' key in the
'server' stanza. The 'insecure' configures if the https connection
to 'server_hostname' is verified as having been issued by
a CA in 'ca_cert_dir' trust store.

Previous documentation indicating it disables https and
enables http was inaccurate. Connection to server_hostname
always uses https.
