### PR TITLE
Fix connection to Eucalyptus cloud in ec2_vol module

### DIFF
--- a/cloud/amazon/ec2_vol.py
+++ b/cloud/amazon/ec2_vol.py
@@ -519,15 +519,7 @@ def main():
     # Set changed flag
     changed = False
 
-    region, ec2_url, aws_connect_params = get_aws_connection_info(module)
-
-    if region:
-        try:
-            ec2 = connect_to_aws(boto.ec2, region, **aws_connect_params)
-        except (boto.exception.NoAuthHandlerFound, AnsibleAWSError) as e:
-            module.fail_json(msg=str(e))
-    else:
-        module.fail_json(msg="region must be specified")
+    ec2 = ec2_connect(module)
 
     if state == 'list':
         returned_volumes = []


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

cloud/amazon/ec2_vol.py
##### ANSIBLE VERSION

```
ansible 2.0.1.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

The module ec2_vol is unable to connect Eucalyptus cloud, because it tries to connect to AWS, however the Eucalyptus cloud's url is specified in the ec2_url option, it connects to AWS.

If you check the code, the ec2_url parameter is simply ignored. The `connect_to_aws` method connect to an AWS region using the region parameter, but it can't work with a private Eucalyptus cloud. The `ec2_connect` function from _ansible/module_utils/ec2.py_ does almost the same as the removed code, however it is able to fall back to a connection method using an ec2 endpoint in case no region specified.

Before:

```
root@conf-mgmt:~# ansible-playbook -i ansible/inventory/ec2.py ansible/playbooks/ec2-volume-test.yml -vv
No config file found; using defaults
1 plays in ansible/playbooks/ec2-volume-test.yml

PLAY [Create a test EBS volume] ************************************************

TASK [create and attach a test volume] *****************************************
task path: /root/ansible/playbooks/ec2-volume-test.yml:8
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "region must be specified"}

NO MORE HOSTS LEFT *************************************************************
        to retry, use: --limit @ansible/playbooks/ec2-volume-test.retry

PLAY RECAP *********************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1
```

After the fix:

```
root@conf-mgmt:~# ansible-playbook -i ansible/inventory/ec2.py ansible/playbooks/ec2-volume-test.yml -vv
No config file found; using defaults
1 plays in ansible/playbooks/ec2-volume-test.yml

PLAY [Create a test EBS volume] ************************************************

TASK [create and attach a test volume] *****************************************
task path: /root/ansible/playbooks/ec2-volume-test.yml:8
changed: [localhost] => {"changed": true, "device": null, "volume": {"attachment_set": {"attach_time": null, "device": null, "instance_id": null, "status": null}, "create_time": "2016-04-07T08:46:34.339Z", "encrypted": null, "id": "vol-b80a955b", "iops": null, "size": 1, "snapshot_id": null, "status": "available", "tags": {"Name": "test_volume"}, "type": "standard", "zone": "esclor86_3"}, "volume_id": "vol-b80a955b", "volume_type": "standard"}

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0
```
