### PR TITLE
git reset with branch

### DIFF
--- a/source_control/git.py
+++ b/source_control/git.py
@@ -751,7 +751,7 @@ def switch_version(git_path, module, dest, remote, version, verify_commit, depth
         if rc != 0:
             module.fail_json(msg="Failed to checkout branch %s" % branch,
                              stdout=out, stderr=err, rc=rc)
-        cmd = "%s reset --hard %s" % (git_path, remote)
+        cmd = "%s reset --hard %s/%s" % (git_path, remote, branch)
     else:
         # FIXME check for local_branch first, should have been fetched already
         if is_remote_branch(git_path, module, dest, remote, version):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

`source_control/git.py`
##### ANSIBLE VERSION

master ansible (`03ec71e5af8725c9d16bfecf0a72c658b8175f55`)
##### SUMMARY

`git reset <ref>` can be ambiguous and failed to switch to the correct branch. To avoid it, specify branch.
