### PR TITLE
rax_dns_record: overwrite option was added for 2.1

### DIFF
--- a/cloud/rackspace/rax_dns_record.py
+++ b/cloud/rackspace/rax_dns_record.py
@@ -50,6 +50,7 @@ options:
         record with matching name. If there are already multiple records with
         matching name and overwrite=true, this module will fail.
     default: true
+    version_added: 2.1
   priority:
     description:
       - Required for MX and SRV records, but forbidden for other record types.


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

rax_dns_record
##### ANSIBLE VERSION

```
v2.1
```
##### SUMMARY

Missing `version_added` on new argument.
