### PR TITLE
Optionally remove prepending of linode ID, added private networking support

### DIFF
--- a/cloud/linode/linode.py
+++ b/cloud/linode/linode.py
@@ -41,11 +41,13 @@ options:
     - prepend the linode ID to the name
     default: True
     type: bool
+    version_added: "2.2"
   name_id_separator:
     description:
     - The separator to use when automatically adding an ID.
     default: '_'
     type: string
+    version_added: "2.2"
   linode_id:
     description:
      - Unique ID of a linode server
@@ -93,6 +95,7 @@ options:
      - "Bool, add an additional, private network interface to instance for inter-node communication"
     default: "no"
     choices: [ "yes", "no" ]
+    version_added: "2.2"
   wait:
     description:
      - wait for the instance to be in state 'running' before returning
@@ -228,8 +231,9 @@ def getInstanceDetails(api, server):
                                         'ip_id': ip['IPADDRESSID']})
     return instance
 
-def linodeServers(module, api, state, name, name_add_id, name_id_separator, plan, distribution,
-                  datacenter, private_networking, linode_id, payment_term, password, ssh_pub_key, swap, wait, wait_timeout):
+def linodeServers(module, api, state, name, name_add_id, name_id_separator, plan,
+                  distribution, datacenter, private_networking, linode_id, payment_term,
+                  password, ssh_pub_key, swap, wait, wait_timeout):
     instances = []
     changed = False
     new_server = False


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

cloud/linode
##### ANSIBLE VERSION

```
ansible 2.1.0 (devel 54acdd7ead) last updated 2016/04/11 11:16:30 (GMT +000)
  lib/ansible/modules/core: (detached HEAD c52f475c64) last updated 2016/04/11 11:16:45 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD 5abb914315) last updated 2016/04/11 11:16:53 (GMT +000)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

This PR merges a few pre-`ansible-modules-core` issues (see https://github.com/ansible/ansible/pull/7223), regarding prepending the ID to the name, which makes idempotent operation impossible. An instance is now also looked up by it's name if the new `name_add_id` option is set to `False`.

Some additional features were added, like the ability to select the separator used between the ID and the name you choose. By default, `_` is used, which is the same default as before.

There is now also a `private_networking` option which will add a static IP to an instance. Note that this will only be applied on creation.

The default behavior of the module remains the same, unless configured otherwise to maintain backward compatability.
