### PR TITLE
Allow mount module to take integer passno

### DIFF
--- a/system/mount.py
+++ b/system/mount.py
@@ -286,7 +286,7 @@ def main():
         'fstype': module.params['fstype']
     }
     if module.params['passno'] is not None:
-        args['passno'] = module.params['passno']
+        args['passno'] = str(module.params['passno'])
     if module.params['opts'] is not None:
         args['opts'] = module.params['opts']
     if module.params['dump'] is not None:


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
- New Module Pull Request
- Bugfix Pull Request
- Docs Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task  -->
##### ANSIBLE VERSION

```
<!--- Paste verbatim output from “ansible --version” between quotes -->
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

```
<!--- Paste verbatim command output here, e.g. before and after your change -->
```

Set the passno value to a string, since the docs imply you can pass in an integer. However, passing in an integer results in a module failure since integers don't have a .replace() method.
