### PR TITLE
Fix mount's handling of passno

### DIFF
--- a/system/mount.py
+++ b/system/mount.py
@@ -268,7 +268,7 @@ def main():
             state  = dict(required=True, choices=['present', 'absent', 'mounted', 'unmounted']),
             name   = dict(required=True),
             opts   = dict(default=None),
-            passno = dict(default=None),
+            passno = dict(default=None, type='str'),
             dump   = dict(default=None),
             src    = dict(required=True),
             fstype = dict(required=True),


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

mount
##### ANSIBLE VERSION

```
devel branch
```
##### SUMMARY

Ansible was trying to treat an integer value as a string. This tells Ansible to stringify the integer before it tries string operations on it.

Before

```
failed: [mailserver-b.kugler.localdomain] => (item={u'owner': u'dovecot', u'src': u'vmserver-b.kugler.localdomain:/email', u'type': u'glusterfs', u'name': u'/srv/mail', u'group': u'dovecot'}) => {"failed": true, "item": {"group": "dovecot", "name": "/srv/mail", "owner": "dovecot", "src": "vmserver-b.kugler.localdomain:/email", "type": "glusterfs"}, "module_stderr": "", "module_stdout": "Traceback (most recent call last):\r\n  File \"/root/.ansible/tmp/ansible-tmp-1460499077.36-260940671230822/mount\", line 2346, in <module>\r\n    main()\r\n  File \"/root/.ansible/tmp/ansible-tmp-1460499077.36-260940671230822/mount\", line 354, in main\r\n    name, changed = set_mount(module, **args)\r\n  File \"/root/.ansible/tmp/ansible-tmp-1460499077.36-260940671230822/mount\", line 134, in set_mount\r\n    escaped_args = dict([(k, _escape_fstab(v)) for k, v in args.iteritems()])\r\n  File \"/root/.ansible/tmp/ansible-tmp-1460499077.36-260940671230822/mount\", line 110, in _escape_fstab\r\n    return v.replace('\\\\', '\\\\134').replace(' ', '\\\\040').replace('&', '\\\\046')\r\nAttributeError: 'int' object has no attribute 'replace'\r\n", "msg": "MODULE FAILURE", "parsed": false}               
failed: [mailserver-b.kugler.localdomain] => (item={u'owner': u'dovecot', u'src': u'vmserver-b.kugler.localdomain:/list_archive', u'type': u'glusterfs', u'name': u'/srv/list_archive', u'group': u'dovecot'}) => {"failed": true, "item": {"group": "dovecot", "name": "/srv/list_archive", "owner": "dovecot", "src": "vmserver-b.kugler.localdomain:/list_archive", "type": "glusterfs"}, "module_stderr": "", "module_stdout": "Traceback (most recent call last):\r\n  File \"/root/.ansible/tmp/ansible-tmp-1460499077.57-14858274682093/mount\", line 2346, in <module>\r\n    main()\r\n  File \"/root/.ansible/tmp/ansible-tmp-1460499077.57-14858274682093/mount\", line 354, in main\r\n    name, changed = set_mount(module, **args)\r\n  File \"/root/.ansible/tmp/ansible-tmp-1460499077.57-14858274682093/mount\", line 134, in set_mount\r\n    escaped_args = dict([(k, _escape_fstab(v)) for k, v in args.iteritems()])\r\n  File \"/root/.ansible/tmp/ansible-tmp-1460499077.57-14858274682093/mount\", line 110, in _escape_fstab\r\n    return v.replace('\\\\', '\\\\134').replace(' ', '\\\\040').replace('&', '\\\\046')\r\nAttributeError: 'int' object has no attribute 'replace'\r\n", "msg": "MODULE FAILURE", "parsed": false}
```

After:

```
changed: [mailserver-a.kugler.localdomain] => (item={u'owner': u'dovecot', u'src': u'vmserver-a.kugler.localdomain:/email', u'type': u'glusterfs', u'name': u'/srv/mail', u'group': u'dovecot'})
changed: [mailserver-a.kugler.localdomain] => (item={u'owner': u'dovecot', u'src': u'vmserver-a.kugler.localdomain:/list_archive', u'type': u'glusterfs', u'name': u'/srv/list_archive', u'group': u'dovecot'})
```
