### PR TITLE
Fix documentation example, missing ")"

### DIFF
--- a/network/ios/ios_config.py
+++ b/network/ios/ios_config.py
@@ -133,7 +133,7 @@ EXAMPLES = """
     replace: block
 
 - ios_config:
-    commands: "{{lookup('file', 'datcenter1.txt'}}"
+    commands: "{{lookup('file', 'datcenter1.txt')}}"
     parents: ['ip access-list test']
     before: ['no ip access-list test']
     replace: block
@@ -222,4 +222,3 @@ from ansible.module_utils.netcfg import *
 from ansible.module_utils.ios import *
 if __name__ == '__main__':
     main()
-

--- a/network/iosxr/iosxr_config.py
+++ b/network/iosxr/iosxr_config.py
@@ -119,7 +119,7 @@ EXAMPLES = """
     parents: ['interface GigabitEthernet0/0/0/0']
 
 - iosxr_config:
-    commands: "{{lookup('file', 'datcenter1.txt'}}"
+    commands: "{{lookup('file', 'datcenter1.txt')}}"
     parents: ['ipv4 access-list test']
     before: ['no ip access-listv4 test']
     replace: block
@@ -211,4 +211,3 @@ from ansible.module_utils.netcfg import *
 from ansible.module_utils.iosxr import *
 if __name__ == '__main__':
     main()
-

--- a/network/nxos/nxos_config.py
+++ b/network/nxos/nxos_config.py
@@ -134,7 +134,7 @@ EXAMPLES = """
     replace: block
 
 - nxos_config:
-    lines: "{{lookup('file', 'datcenter1.txt'}}"
+    lines: "{{lookup('file', 'datcenter1.txt')}}"
     parents: ['ip access-list test']
     before: ['no ip access-list test']
     replace: block
@@ -227,4 +227,3 @@ from ansible.module_utils.netcfg import *
 from ansible.module_utils.nxos import *
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

cisco_config modules
##### ANSIBLE VERSION

```
2.1
```
##### SUMMARY

The example is missing a closing parentheses. So the example doesn't work.

(This example still won't be idempotent though as the file will be read as a long string and would have to be split by linebreaks first.)
