### PR TITLE
Allow an empty password when adding a new MySQL user.

### DIFF
--- a/database/mysql/mysql_user.py
+++ b/database/mysql/mysql_user.py
@@ -32,7 +32,7 @@ options:
     required: true
   password:
     description:
-      - set the user's password. (Required when adding a user)
+      - set the user's password.
     required: false
     default: null
   encrypted:
@@ -232,6 +232,8 @@ def user_add(cursor, user, host, host_all, password, encrypted, new_priv, check_
         cursor.execute("CREATE USER %s@%s IDENTIFIED BY PASSWORD %s", (user,host,password))
     elif password and not encrypted:
         cursor.execute("CREATE USER %s@%s IDENTIFIED BY %s", (user,host,password))
+    else:
+        cursor.execute("CREATE USER %s@%s", (user,host))
 
     if new_priv is not None:
         for db_table, priv in new_priv.iteritems():
@@ -259,13 +261,13 @@ def user_mod(cursor, user, host, host_all, password, encrypted, new_priv, append
         if bool(password):
             # Determine what user management method server uses
             old_user_mgmt = server_version_check(cursor)
-    
+
             if old_user_mgmt:
                 cursor.execute("SELECT password FROM user WHERE user = %s AND host = %s", (user,host))
             else:
                 cursor.execute("SELECT authentication_string FROM user WHERE user = %s AND host = %s", (user,host))
             current_pass_hash = cursor.fetchone()
-    
+
             if encrypted:
                 encrypted_string = (password)
                 if is_hash(password):
@@ -293,7 +295,7 @@ def user_mod(cursor, user, host, host_all, password, encrypted, new_priv, append
                     else:
                         cursor.execute("ALTER USER %s@%s IDENTIFIED BY %s", (user, host, password))
                     changed = True
-    
+
         # Handle privileges
         if new_priv is not None:
             curr_priv = privileges_get(cursor, user,host)
@@ -559,8 +561,6 @@ def main():
             except (SQLParseError, InvalidPrivsError, MySQLdb.Error), e:
                 module.fail_json(msg=str(e))
         else:
-            if password is None:
-                module.fail_json(msg="password parameter required when adding a user")
             if host_all:
                 module.fail_json(msg="host_all parameter cannot be used when adding a user")
             try:


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

database/mysql/mysql_user
##### ANSIBLE VERSION

```
ansible 2.0.1.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

It is currently impossible to add a mysql user without a password. This small patch fixes this.

While generally it is unwise not to use a password, in my opinion Ansible should not force a password to be used. For example, the haproxy mysql-check, requires an empty password.
