### PR TITLE
Bugfix: git reset on version not on remote

### DIFF
--- a/source_control/git.py
+++ b/source_control/git.py
@@ -659,7 +659,7 @@ def switch_version(git_path, module, dest, remote, version, verify_commit):
         (rc, out, err) = module.run_command("%s checkout --force %s" % (git_path, branch), cwd=dest)
         if rc != 0:
             module.fail_json(msg="Failed to checkout branch %s" % branch)
-        cmd = "%s reset --hard %s" % (git_path, remote)
+        cmd = "%s reset --hard %s" % (git_path, version)
     (rc, out1, err1) = module.run_command(cmd, cwd=dest)
     if rc != 0:
         if version != 'HEAD':

--- a/source_control/git.py
+++ b/source_control/git.py
@@ -659,7 +659,7 @@ def switch_version(git_path, module, dest, remote, version, verify_commit):
         (rc, out, err) = module.run_command("%s checkout --force %s" % (git_path, branch), cwd=dest)
         if rc != 0:
             module.fail_json(msg="Failed to checkout branch %s" % branch)
-        cmd = "%s reset --hard %s" % (git_path, version)
+        cmd = "%s reset --hard %s" % (git_path, branch)
     (rc, out1, err1) = module.run_command(cmd, cwd=dest)
     if rc != 0:
         if version != 'HEAD':


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

git
##### ANSIBLE VERSION

```
ansible 1.7.1
```
##### SUMMARY

It seems that a wrong param has been given to the git cmd. git reset --hard expects a commit-Identifier not a name of a remote repository

```
before change
[...]
failed: [hostname] => {"failed": true}
msg: Failed to checkout branch: master
[...]

after change:
[...]
ok: [hostname] => {"after": "1ae6b55420f7b4b61600be713b4a9ef14aa79b6b", "before": "1ae6b55420f7b4b61600be713b4a9ef14aa79b6b", "changed": false} 
[...]                                                                                                                            
```
