### PR TITLE
git: with depth only fetch actual version, don't use refs/heads/*

### DIFF
--- a/source_control/git.py
+++ b/source_control/git.py
@@ -522,7 +522,7 @@ def fetch(git_path, module, repo, dest, version, remote, depth, bare, refspec):
         elif version == 'HEAD':
             refspecs.append('HEAD')
         elif is_remote_branch(git_path, module, dest, repo, version):
-            refspecs.append('+refs/heads/'+version+':refs/heads/'+version)
+            refspecs.append(version)
         elif is_remote_tag(git_path, module, dest, repo, version):
             refspecs.append('+refs/tags/'+version+':refs/tags/'+version)
         if refspecs:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

source_control/git.py
##### ANSIBLE VERSION

devel, 2.1.0
##### SUMMARY
- don't use refs/heads/branchname for branches
- for tags it's needed though
- fixes #3456
