### PR TITLE
Fix how the module counts healthy instances when ASG has multiple ELBs attached.

### DIFF
--- a/cloud/amazon/ec2_asg.py
+++ b/cloud/amazon/ec2_asg.py
@@ -367,7 +367,7 @@ def wait_for_elb(asg_connection, module, group_name):
         while healthy_instances < as_group.min_size and wait_timeout > time.time():
             healthy_instances = elb_healthy(asg_connection, elb_connection, module, group_name)
             log.debug("ELB thinks {0} instances are healthy.".format(healthy_instances))
-            time.sleep(60)
+            time.sleep(10)
         if wait_timeout <= time.time():
             # waiting took too long
             module.fail_json(msg = "Waited too long for ELB instances to be healthy. %s" % time.asctime())


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

ec2_asg
##### ANSIBLE VERSION

```
ansible 2.1.0 (devel ca8261ed31) last updated 2016/01/20 12:03:06 (GMT +1300)
  lib/ansible/modules/core: (detached HEAD ffea58ee86) last updated 2016/01/20 12:03:24 (GMT +1300)
  lib/ansible/modules/extras: (detached HEAD e9450df878) last updated 2016/01/20 12:03:34 (GMT +1300)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

When an ASG has multiple load balancers attached with the same instance in service in each load balancer it will count the same instance multiple times behind each load balancer. This means, when doing a blue/green deploy and cycling two new instances behind two load balancers for example, that the ASG will wait for four healthy instances, but will see four healthy instances straight away as it doubles up the count of the existing two old instances. It will therefore move on and take those old instances out of service before the new instances are healthy and in service.
