### PR TITLE
Docker Binds - cannot unmarshal array into Go value of type string

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -713,7 +713,7 @@ class DockerManager(object):
                             self.module.fail_json(msg='invalid bind mode ' + parts[2])
                         else:
                             mode = parts[2]
-                    self.binds.append((parts[0], {'bind': parts[1], 'mode': mode}))
+                    self.binds.append("%s:%s:%s" % (parts[0], parts[1], mode))
                 else:
                     self.module.fail_json(msg='volumes support 1 to 3 arguments')
 
@@ -1366,14 +1366,8 @@ class DockerManager(object):
 
             expected_binds = set()
             if self.binds:
-                for host_path, config in self.binds:
-                    if isinstance(config, dict):
-                        container_path = config['bind']
-                        mode = config['mode']
-                    else:
-                        container_path = config
-                        mode = 'rw'
-                    expected_binds.add("{0}:{1}:{2}".format(host_path, container_path, mode))
+                for bind in self.binds:
+                    expected_binds.add(bind)
 
             actual_binds = set()
             for bind in (container['HostConfig']['Binds'] or []):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

cloud/docker/docker
##### ANSIBLE VERSION

```
devel
```
##### SUMMARY

`HostConfig > Binds` are send in invalid format to Docker API, i.e.:

```
  "HostConfig":{
    "Binds":[
      [
        "/tmp/intouch/registry/config",
        {
          "bind":"/home/intouch/config",
          "mode":"rw"
        }
      ]
    ]
```

instead of, as [documented](https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/#create-a-container), just simply:

```
  "HostConfig":{
    "Binds":[
      [ "/tmp/intouch/registry/config:/home/intouch/config:rw" ]
    ]
```

This causes an error from Docker Deamon:

```
Handler for POST /v1.22/containers/create returned error: json: cannot unmarshal array into Go value of type string
```

and, as a result, Ansible module error like this:

```
fatal: [machine]: FAILED! => {"changed": false, "failed": true, "invocation": {"module_args": {"cap_add": null, "cap_drop": null, "command": null, "count": 1, "cpu_set": null, "cpu_shares": 0, "debug": false, "detach": true, "devices": null, "dns": null, "docker_api_version": "1.22", "docker_url": null, "docker_user": null, "domainname": null, "email": null, "entrypoint": null, "env": {"LOCAL_USER_ID": "1000 "}, "env_file": null, "expose": ["8765"], "extra_hosts": {}, "hostname": "", "image": "tds/intouch-registry:latest", "insecure_registry": false, "labels": {"intouch-name": "intouch-registry"}, "links": [], "log_driver": null, "log_opt": null, "lxc_conf": null, "memory_limit": "0", "memory_swap": "0", "name": "intouch-registry", "net": "default", "password": null, "pid": null, "ports": ["8765:8765"], "privileged": false, "publish_all_ports": false, "pull": "missing", "read_only": null, "registry": null, "restart_policy": null, "restart_policy_retry": 0, "signal": null, "state": "reloaded", "stdin_open": false, "stop_timeout": 10, "timeout": 60, "tls_ca_cert": null, "tls_client_cert": null, "tls_client_key": null, "tls_hostname": null, "tty": false, "ulimits": null, "use_tls": null, "username": null, "volumes": ["/tmp/intouch/registry/config:/home/intouch/config:rw"], "volumes_from": null}, "module_name": "docker"}, "msg": "Docker API Error: json: cannot unmarshal array into Go value of type string"}
```

This pull request fixes this error by sending `HostConfig > Binds` in format specified in API documentation.
