### PR TITLE
git: fix status to use porcelain, ignore user configuration

### DIFF
--- a/source_control/git.py
+++ b/source_control/git.py
@@ -356,7 +356,7 @@ def has_local_mods(module, git_path, dest, bare):
     if bare:
         return False
 
-    cmd = "%s status -s" % (git_path)
+    cmd = "%s status --porcelain" % (git_path)
     rc, stdout, stderr = module.run_command(cmd, cwd=dest)
     lines = stdout.splitlines()
     lines = filter(lambda c: not re.search('^\\?\\?.*$', c), lines)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

source_control/git.py
##### ANSIBLE VERSION

```
2.0
```
##### SUMMARY

From the git status doc:

```
--porcelain

    Give the output in an easy-to-parse format for scripts. This is similar to the short output, but will remain stable across Git versions and regardless of user configuration. See below for details.
```

User configuration can break the git module from working as expected.

Fixes the problem described in #3416 in a reliable way. Closes #3416
