### PR TITLE
adds new junos_facts module

### DIFF
--- a/network/junos/junos_facts.py
+++ b/network/junos/junos_facts.py
@@ -1,0 +1,98 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+DOCUMENTATION = """
+---
+module: junos_facts
+version_added: "2.1"
+author: "Peter Sprygada (@privateip)"
+short_description: Collect facts from remove device running Junos
+description:
+  - Collects fact information from a remote device running the Junos
+    operating system.  By default, the module will collect basic fact
+    information from the device to be included with the hostvars.
+    Additional fact information can be collected based on the
+    configured set of arguments.
+extends_documentation_fragment: junos
+options:
+  config:
+    description:
+      - The O(config) argument instructs the fact module to collect
+        the device configuration.  The device configuration is
+        stored in the I(config) key in the hostvars dictionary.
+    required: true
+    default: false
+    choices: ['true', 'false']
+requirements:
+  - junos-eznc
+notes:
+  - This module requires the netconf system service be enabled on
+    the remote device being managed
+"""
+
+EXAMPLES = """
+# the required set of connection arguments have been purposely left off
+# the examples for brevity
+
+- name: collect default set of facts
+  junos_facts:
+
+- name: collect default set of facts and configuration
+  junos_facts:
+    config: yes
+"""
+
+RETURN = """
+ansible_facts:
+  descrption: Returns the facts collect from the device
+  returned: always
+  type: dict
+"""
+
+def main():
+    """ Main entry point for AnsibleModule
+    """
+    spec = dict(
+        config=dict(default=False, type='bool'),
+        transport=dict(default='netconf', choices=['netconf'])
+    )
+
+    module = get_module(argument_spec=spec,
+                        supports_check_mode=True)
+
+    result = dict(changed=False)
+
+    facts = module.get_facts()
+
+    if '2RE' in facts:
+        facts['has_2RE'] = facts['2RE']
+        del facts['2RE']
+
+    facts['version_info'] = dict(facts['version_info'])
+
+    if module.params['config']:
+        facts['config'] = module.get_config()
+
+    result['ansible_facts'] = facts
+    module.exit_json(**result)
+
+from ansible.module_utils.basic import *
+from ansible.module_utils.junos import *
+
+if __name__ == '__main__':
+    main()

--- a/network/junos/junos_facts.py
+++ b/network/junos/junos_facts.py
@@ -32,12 +32,23 @@ extends_documentation_fragment: junos
 options:
   config:
     description:
-      - The O(config) argument instructs the fact module to collect
-        the device configuration.  The device configuration is
-        stored in the I(config) key in the hostvars dictionary.
-        if the configuration is returned in xml, it will also be converted
-        to json and save into the I(config_json) key in the hostvars dictionary.
+      - The C(config) argument instructs the fact module to collect
+        the configuration from the remote device.  The configuration
+        is then included in return facts.  By default, the configuration
+        is returned as text.  The C(config_format) can be used to return
+        different Junos configuration formats.
+    required: true
+    default: false
+  config_format:
+    description:
+      - The C(config_format) argument is used to specify the desired
+        format of the configuration file.  Devices support three
+        configuration file formats.  By default, the configuration
+        from the device is returned as text.  The other options include
+        set and xml.  If the xml option is choosen, the configuration file
+        is returned as both xml and json.
     required: false
+    default: text
     choices: ['xml', 'text', 'set']
 requirements:
   - junos-eznc
@@ -55,15 +66,17 @@ EXAMPLES = """
 
 - name: collect default set of facts and configuration
   junos_facts:
-    config: text
+    config: yes
 
 - name: collect default set of facts and configuration in set format
   junos_facts:
-    config: set
+    config: yes
+    config_format: set
 
 - name: collect default set of facts and configuration in XML and JSON format
   junos_facts:
-    config: xml
+    config: yes
+    config_format: xml
 """
 
 RETURN = """
@@ -77,7 +90,8 @@ def main():
     """ Main entry point for AnsibleModule
     """
     spec = dict(
-        config=dict(choices=['xml', 'set', 'text']),
+        config=dict(required=True, type='bool'),
+        config_format=dict(default='text', choices=['xml', 'set', 'text']),
         transport=dict(default='netconf', choices=['netconf'])
     )
 
@@ -95,11 +109,12 @@ def main():
     facts['version_info'] = dict(facts['version_info'])
 
     if module.params['config']:
-        resp_config = module.get_config( config_format=module.params['config'])
+        config_format = module.params['config_format']
+        resp_config = module.get_config( config_format=config_format)
 
-        if module.params['config'] == "text" or module.params['config'] == "set":
+        if config_format in ['text', 'set']:
            facts['config'] = resp_config
-        elif module.params['config'] == "xml":
+        elif config_format == "xml":
            facts['config'] = xml_to_string(resp_config)
            facts['config_json'] = xml_to_json(resp_config)
 


### PR DESCRIPTION
##### ISSUE TYPE
- New Module Pull Request
##### COMPONENT NAME

network/junos/junos_facts
##### ANSIBLE VERSION

```
ansible 2.1.0 (local_action_junos_config edbdf0d955) last updated 2016/04/22 15:49:41 (GMT -400)
  lib/ansible/modules/core: (working b1ab9b93b7) last updated 2016/04/22 15:37:32 (GMT -400)
  lib/ansible/modules/extras: (working 6962f8af62) last updated 2016/03/27 22:50:50 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

The junos_facts module will collect basic system inforamtion about remote
devices running the Junos operating system
