### PR TITLE
Network exception reorganization

### DIFF
--- a/network/nxos/nxos_command.py
+++ b/network/nxos/nxos_command.py
@@ -157,12 +157,8 @@ def main():
         kwargs['command_type'] = 'cli_show'
 
     while retries > 0:
-        try:
-            response = module.execute(commands, **kwargs)
-            result['stdout'] = response
-        except ShellError, exc:
-            module.fail_json(msg='failed to run commands', exc=exc.message,
-                    command=exc.command)
+        response = module.execute(commands, **kwargs)
+        result['stdout'] = response
 
         for index, cmd in enumerate(commands):
             if cmd.endswith('json'):


### PR DESCRIPTION
##### COMPONENT NAME

junos_command, nxos_command
##### ANSIBLE VERSION

```
2.1
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Along with ansible/ansible#15507, reorganizing the use of exceptions in the network modules. Exceptions generated by a transport are now handled in the transports directly.
