### PR TITLE
Make FreeBSD subclass respect the sleep option.

### DIFF
--- a/system/service.py
+++ b/system/service.py
@@ -1003,7 +1003,12 @@ class FreeBsdService(Service):
         if self.action == "reload":
             self.action = "onereload"
 
-        return self.execute_command("%s %s %s %s" % (self.svc_cmd, self.name, self.action, self.arguments))
+        ret = self.execute_command("%s %s %s %s" % (self.svc_cmd, self.name, self.action, self.arguments))
+
+        if self.sleep:
+            time.sleep(self.sleep)
+
+        return ret
 
 # ===========================================
 # Subclass: OpenBSD


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

system/service module
##### ANSIBLE VERSION

```
ansible 2.0.2.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

As subject states this change makes the FreeBSD subclass aware of the sleep option.

I had problems managing the ntpd service on a FreeBSD machine, running 11.0. 

The service would start but die just after ansible disconnected. The ntpd startup script included in FreeBSD recently gained functionality and is quite complex.

Adding a small sleep fixes it.

The change just makes the module sleep the requested seconds after running the command.

(no output change)
