### PR TITLE
fixes docstring format in junos_command

### DIFF
--- a/network/junos/junos_command.py
+++ b/network/junos/junos_command.py
@@ -41,7 +41,7 @@ options:
     default: null
   rpcs:
     description:
-      - The O(rpcs) argument accepts a list of RPCs to be executed
+      - The C(rpcs) argument accepts a list of RPCs to be executed
         over a netconf session and the results from the RPC execution
         is return to the playbook via the modules results dictionary.
     required: false


### PR DESCRIPTION
docstring was using the wrong formatting functions
