### PR TITLE
fixes dns type in docker module

### DIFF
--- a/cloud/docker/_docker.py
+++ b/cloud/docker/_docker.py
@@ -1872,7 +1872,7 @@ def main():
             domainname      = dict(default=None),
             env             = dict(type='dict'),
             env_file        = dict(default=None),
-            dns             = dict(),
+            dns             = dict(default=None, type='list'),
             detach          = dict(default=True, type='bool'),
             state           = dict(default='started', choices=['present', 'started', 'reloaded', 'restarted', 'stopped', 'killed', 'absent', 'running']),
             signal          = dict(default=None),


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

cloud/docker
##### ANSIBLE VERSION

```
ansible 2.1.0 (devel f24f895e04) last updated 2016/04/24 17:49:48 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 36755e5fe2) last updated 2016/04/24 17:51:25 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD de22b721db) last updated 2016/04/23 22:55:04 (GMT +200)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

pass a list instead of a string in dns parameter

```
Before : 
fatal: [XXX]: FAILED! => {"changed": false, "failed": true, "msg": "Docker API Error: json: cannot unmarshal string into Go value of type []string"}

After : 
changed: [XXX]
```
