### PR TITLE
Fixing a typo, floating-ips has been used instead of floating_ips

### DIFF
--- a/cloud/openstack/_nova_compute.py
+++ b/cloud/openstack/_nova_compute.py
@@ -238,7 +238,7 @@ EXAMPLES = '''
       key_name: test
       wait_for: 200
       flavor_id: 101
-      floating-ips:
+      floating_ips:
         - 12.34.56.79
 
 # Creates a new VM with 4G of RAM on Ubuntu Trusty, ignoring deprecated images

--- a/cloud/openstack/os_server.py
+++ b/cloud/openstack/os_server.py
@@ -243,7 +243,7 @@ EXAMPLES = '''
       key_name: test
       timeout: 200
       flavor: 101
-      floating-ips:
+      floating_ips:
         - 12.34.56.79
 
 # Creates a new instance with 4G of RAM on Ubuntu Trusty, ignoring


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Docs Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task  -->
- cloud/openstack/_nova_compute
- cloud/openstack/os_server
##### ANSIBLE VERSION

```
<!--- Paste verbatim output from “ansible --version” between quotes -->
"2.0.2.0"
...

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
Doc enhancement, the examples using pre-defined static ips had a typo: floating-ips was used instead of floating_ips
-->

```

<!--- Paste verbatim command output here, e.g. before and after your change -->

```
```
