### PR TITLE
Fixed ec2_eip.py when assigning a standard elastic IP.

### DIFF
--- a/cloud/amazon/ec2_eip.py
+++ b/cloud/amazon/ec2_eip.py
@@ -263,7 +263,7 @@ def ensure_present(ec2, domain, address, device_id,
         if isinstance:
             instance = find_device(ec2, device_id)
             if reuse_existing_ip_allowed:
-                if len(instance.vpc_id) > 0 and domain is None:
+                if instance.vpc_id and len(instance.vpc_id) > 0 and domain is None:
                     raise EIPException("You must set 'in_vpc' to true to associate an instance with an existing ip in a vpc")
             # Associate address object (provided or allocated) with instance
             assoc_result = associate_ip_and_device(ec2, address, device_id,


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

ec2_eip.py
##### ANSIBLE VERSION

```
ansible 2.0.2.0
  config file = /home/ivan/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

The ec2_eip module was failing when assigning a standard elastic IP (not a VPC one). It was used as a part of a role (if you're curious):

```

---
- name: Create EC2 Group
  ec2_group:
    name: "{{ security_group_name }}"
    region: "{{ region }}"
    description: "{{ security_group_description }}"
    rules:
      - proto: tcp
        from_port: 22
        to_port: 22
        cidr_ip: 0.0.0.0/0

- name: Launch instances
  ec2:
    key_name: "{{ key_name }}"
    instance_type: "{{ instance }}"
    ebs_optimized: "{{ ebs_optimized | default(false)  }}"
    image: "{{ ami_version }}"
    wait: yes
    region: "{{ region }}"
    group: "{{ security_group_name }}"
    count: 1
  register: ec2

- name: Add tags to the newly created instances
  ec2_tag: resource={{ item.id }} region={{ region }} state=present
  with_items: ec2.instances
  args:
    tags:
      Name: "{{ instance_tag_name }}"

- name: Assign elastic IP
  ec2_eip: instance_id={{ item.id }} public_ip={{ elastic_ip }} reuse_existing_ip_allowed=yes region={{ region }} state=present in_vpc=no
  with_items: ec2.instances

- name: Add the new instances to a hostname group
  add_host: hostname={{ elastic_ip }} groupname={{ host_group_name }}
            public_ip={{ elastic_ip }} public_dns={{ item.public_dns_name }}
            private_ip={{ item.private_ip }} host_id={{ item.id }}
  with_items: ec2.instances

- name: Wait for SSH to be available...
  wait_for: host={{ elastic_ip }} port=22 delay=60 timeout=320 state=started
  with_items: ec2.instances
```

The output before the fix was:

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: object of type 'NoneType' has no len()
failed: [127.0.0.1] (item={u'kernel': u'aki-52a34525', u'root_device_type': u'ebs', u'private_dns_name': u'ip-10-37-181-251.eu-west-1.compute.internal', u'public_ip': u'54.74.248.81', u'private_ip': u'10.37.181.251', u'id': u'i-b5e1803f', u'ebs_optimized': False, u'state': u'running', u'virtualization_type': u'paravirtual', u'architecture': u'x86_64', u'ramdisk': None, u'block_device_mapping': {u'/dev/sda1': {u'status': u'attached', u'delete_on_termination': True, u'volume_id': u'vol-104924e2'}}, u'key_name': u'awskey', u'image_id': u'ami-be5cf7cd', u'tenancy': u'default', u'groups': {u'sg-2f58aa59': u'dangermouse_ci_staging_security'}, u'public_dns_name': u'ec2-54-74-248-81.eu-west-1.compute.amazonaws.com', u'state_code': 16, u'tags': {}, u'placement': u'eu-west-1a', u'ami_launch_index': u'0', u'dns_name': u'ec2-54-74-248-81.eu-west-1.compute.amazonaws.com', u'region': u'eu-west-1', u'launch_time': u'2016-04-26T08:56:23.000Z', u'instance_type': u'm1.large', u'root_device_name': u'/dev/sda1', u'hypervisor': u'xen'}) => {"failed": true, "item": {"ami_launch_index": "0", "architecture": "x86_64", "block_device_mapping": {"/dev/sda1": {"delete_on_termination": true, "status": "attached", "volume_id": "vol-104924e2"}}, "dns_name": "ec2-54-74-248-81.eu-west-1.compute.amazonaws.com", "ebs_optimized": false, "groups": {"sg-2f58aa59": "dangermouse_ci_staging_security"}, "hypervisor": "xen", "id": "i-b5e1803f", "image_id": "ami-be5cf7cd", "instance_type": "m1.large", "kernel": "aki-52a34525", "key_name": "awskey", "launch_time": "2016-04-26T08:56:23.000Z", "placement": "eu-west-1a", "private_dns_name": "ip-10-37-181-251.eu-west-1.compute.internal", "private_ip": "10.37.181.251", "public_dns_name": "ec2-54-74-248-81.eu-west-1.compute.amazonaws.com", "public_ip": "54.74.248.81", "ramdisk": null, "region": "eu-west-1", "root_device_name": "/dev/sda1", "root_device_type": "ebs", "state": "running", "state_code": 16, "tags": {}, "tenancy": "default", "virtualization_type": "paravirtual"}, "module_stderr": "Traceback (most recent call last):\n  File \"/home/ivan/.ansible/tmp/ansible-tmp-1461661004.22-199349937218698/ec2_eip\", line 2591, in <module>\n    main()\n  File \"/home/ivan/.ansible/tmp/ansible-tmp-1461661004.22-199349937218698/ec2_eip\", line 356, in main\n    module.check_mode, isinstance=is_instance)\n  File \"/home/ivan/.ansible/tmp/ansible-tmp-1461661004.22-199349937218698/ec2_eip\", line 267, in ensure_present\n    if len(instance.vpc_id) > 0 and domain is None:\nTypeError: object of type 'NoneType' has no len()\n", "module_stdout": "", "msg": "MODULE FAILURE", "parsed": false}
```

After the fix it works!
