### PR TITLE
add check_mode support to ec2_vpc_net module

### DIFF
--- a/cloud/amazon/ec2_vpc_net.py
+++ b/cloud/amazon/ec2_vpc_net.py
@@ -144,12 +144,16 @@ def update_vpc_tags(vpc, module, vpc_obj, tags, name):
 
     tags.update({'Name': name})
     try:
-        current_tags = dict((t.name, t.value) for t in vpc.get_all_tags(filters={'resource-id': vpc_obj.id}))
-        if cmp(tags, current_tags):
-            vpc.create_tags(vpc_obj.id, tags)
-            return True
-        else:
-            return False
+        if vpc_obj:
+            current_tags = dict((t.name, t.value) for t in vpc.get_all_tags(filters={'resource-id': vpc_obj.id}))
+            if cmp(tags, current_tags):
+                if not module.check_mode:
+                    vpc.create_tags(vpc_obj.id, tags)
+                else:
+                    vpc_obj.tags = tags
+                return True
+            else:
+                return False
     except Exception, e:
         e_msg=boto_exception(e)
         module.fail_json(msg=e_msg)
@@ -157,8 +161,11 @@ def update_vpc_tags(vpc, module, vpc_obj, tags, name):
 
 def update_dhcp_opts(connection, module, vpc_obj, dhcp_id):
 
-    if vpc_obj.dhcp_options_id != dhcp_id:
-        connection.associate_dhcp_options(dhcp_id, vpc_obj.id)
+    if vpc_obj and vpc_obj.dhcp_options_id != dhcp_id:
+        if not module.check_mode:
+            connection.associate_dhcp_options(dhcp_id, vpc_obj.id)
+        elif dhcp_id:
+            vpc_obj.dhcp_options_id = dhcp_id
         return True
     else:
         return False
@@ -194,6 +201,7 @@ def main():
 
     module = AnsibleModule(
         argument_spec=argument_spec,
+        supports_check_mode=True,
     )
 
     if not HAS_BOTO:
@@ -231,7 +239,8 @@ def main():
 
         if vpc_obj is None:
             try:
-                vpc_obj = connection.create_vpc(cidr_block, instance_tenancy=tenancy)
+                if not module.check_mode:
+                    vpc_obj = connection.create_vpc(cidr_block, instance_tenancy=tenancy)
                 changed = True
             except BotoServerError, e:
                 module.fail_json(msg=e)
@@ -254,15 +263,17 @@ def main():
         # which is needed in order to detect the current status of DNS options. For now we just update
         # the attribute each time and is not used as a changed-factor.
         try:
-            connection.modify_vpc_attribute(vpc_obj.id, enable_dns_support=dns_support)
-            connection.modify_vpc_attribute(vpc_obj.id, enable_dns_hostnames=dns_hostnames)
+            if not module.check_mode:
+                connection.modify_vpc_attribute(vpc_obj.id, enable_dns_support=dns_support)
+                connection.modify_vpc_attribute(vpc_obj.id, enable_dns_hostnames=dns_hostnames)
         except BotoServerError, e:
             e_msg=boto_exception(e)
             module.fail_json(msg=e_msg)
 
         # get the vpc obj again in case it has changed
         try:
-            vpc_obj = connection.get_all_vpcs(vpc_obj.id)[0]
+            if not module.check_mode:
+                vpc_obj = connection.get_all_vpcs(vpc_obj.id)[0]
         except BotoServerError, e:
             e_msg=boto_exception(e)
             module.fail_json(msg=e_msg)
@@ -276,7 +287,8 @@ def main():
 
         if vpc_obj is not None:
             try:
-                connection.delete_vpc(vpc_obj.id)
+                if not module.check_mode:
+                    connection.delete_vpc(vpc_obj.id)
                 vpc_obj = None
                 changed = True
             except BotoServerError, e:


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

ec2_vpc_net
##### ANSIBLE VERSION

```
ansible 2.0.2.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Adds check_mode support (`--check`) to ec2_vpc_net module.

_BEFORE_

``` shell
$ ansible-playbook vpc-check.yml -i inventory/local -vvv --check
PLAYBOOK: vpc-check.yml ********************************************************
1 plays in vpc-check.yml

PLAY [VPC Check] ***************************************************************

TASK [ec2_vpc_net] *************************************************************
task path: vpc-check.yml:7
ESTABLISH LOCAL CONNECTION FOR USER: robb
localhost EXEC /bin/sh -c 'LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/python'
skipping: [localhost] => {"changed": false, "invocation": {"module_args": {"cidr_block": "192.168.254.0/24", "dns_hostnames": true, "dns_support": true, "name": "ansible-ec2-vpc-net-c
heck", "region": "us-east-1", "state": "present", "tags": {"Name": "ansible-ec2-vpc-net-check", "owner": "@robbwagoner"}, "tenancy": "default"}, "module_name": "ec2_vpc_net"}, "msg": "
remote module does not support check mode", "skipped": true}

TASK [debug] *******************************************************************
task path: vpc-check.yml:20
ok: [localhost] => {
    "vpc_details": {
        "changed": false,
        "msg": "remote module does not support check mode",
        "skipped": true
    }
}

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0
```

_AFTER_
_for an existing VPC_

``` shell
$ ansible-playbook.sh vpc-check.yml -i inventory/local -vvv --check 
PLAYBOOK: vpc-check.yml ********************************************************
1 plays in vpc-check.yml

PLAY [VPC Check] ***************************************************************

TASK [ec2_vpc_net] *************************************************************
task path: vpc-check.yml:7
ESTABLISH LOCAL CONNECTION FOR USER: robb
localhost EXEC /bin/sh -c 'LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/python'
changed: [localhost] => {"changed": true, "invocation": {"module_args": {"aws_access_key": null, "aws_secret_key": null, "cidr_block": "192.168.254.0/24", "dhcp_opts_id": null, "dns_h
ostnames": true, "dns_support": true, "ec2_url": null, "multi_ok": false, "name": "ansible-ec2-vpc-net-check", "profile": null, "region": "us-east-1", "security_token": null, "state":
 "present", "tags": {"Name": "ansible-ec2-vpc-net-check", "owner": "@robbwagoner"}, "tenancy": "default", "validate_certs": true}, "module_name": "ec2_vpc_net"}, "vpc": {"cidr_block":
 "192.168.254.0/24", "classic_link_enabled": null, "dhcp_options_id": "dopt-1001f575", "id": "vpc-5fb25938", "instance_tenancy": "default", "is_default": false, "state": "available",
"tags": {"Name": "ansible-ec2-vpc-net-check", "owner": "@robbwagoner"}}}

TASK [debug] *******************************************************************
task path: vpc-check.yml:20
ok: [localhost] => {
    "vpc_details": {
        "changed": true,
        "vpc": {
            "cidr_block": "192.168.254.0/24",
            "classic_link_enabled": null,
            "dhcp_options_id": "dopt-1001f575",
            "id": "vpc-6ea15938",
            "instance_tenancy": "default",
            "is_default": false,
            "state": "available",
            "tags": {
                "Name": "ansible-ec2-vpc-net-check",
                "owner": "@robbwagoner"
            }
        }
    }
}

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0
```
