### PR TITLE
command: Correct suggestion of non-existant module apt-get

### DIFF
--- a/commands/command.py
+++ b/commands/command.py
@@ -139,7 +139,7 @@ def check_command(commandline):
                   'rmdir': 'state=absent', 'rm': 'state=absent', 'touch': 'state=touch' }
     commands  = { 'git': 'git', 'hg': 'hg', 'curl': 'get_url or uri', 'wget': 'get_url or uri',
                   'svn': 'subversion', 'service': 'service',
-                  'mount': 'mount', 'rpm': 'yum, dnf or zypper', 'yum': 'yum', 'apt-get': 'apt-get',
+                  'mount': 'mount', 'rpm': 'yum, dnf or zypper', 'yum': 'yum', 'apt-get': 'apt',
                   'tar': 'unarchive', 'unzip': 'unarchive', 'sed': 'template or lineinfile',
                   'rsync': 'synchronize', 'dnf': 'dnf', 'zypper': 'zypper' }
     become   = [ 'sudo', 'su', 'pbrun', 'pfexec', 'runas' ]


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

command
##### ANSIBLE VERSION

```
ansible 2.0.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

But exists in HEAD.
##### SUMMARY

Minor fix:  the command.py checks to recommend using ansible modules mention the old name for the apt module (i.e., [WARNING]: Consider using apt-get module rather than running apt-get).  This patch just corrects the name.
