### PR TITLE
Fix for os_server module when specifying region

### DIFF
--- a/cloud/openstack/os_server.py
+++ b/cloud/openstack/os_server.py
@@ -443,7 +443,7 @@ def _create_server(module, cloud):
         config_drive=module.params['config_drive'],
     )
     for optional_param in (
-            'region_name', 'key_name', 'availability_zone', 'network',
+            'key_name', 'availability_zone', 'network',
             'volume_size', 'volumes'):
         if module.params[optional_param]:
             bootkwargs[optional_param] = module.params[optional_param]


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

cloud/openstack/os_server.py
##### ANSIBLE VERSION

2.0
##### SUMMARY

Fix the OpenStack os_server module for when region_name is specified.
This should not be passed through to the shade create_server() call
as it's only used with the auth parameters.

Fixes bug: https://github.com/ansible/ansible-modules-core/issues/2797
