### PR TITLE
Fix cursor.execute statements that have only one argument

### DIFF
--- a/database/mysql/mysql_user.py
+++ b/database/mysql/mysql_user.py
@@ -214,7 +214,7 @@ def get_mode(cursor):
 
 def user_exists(cursor, user, host, host_all):
     if host_all:
-        cursor.execute("SELECT count(*) FROM user WHERE user = %s", ([user]))
+        cursor.execute("SELECT count(*) FROM user WHERE user = %s", (user,))
     else:
         cursor.execute("SELECT count(*) FROM user WHERE user = %s AND host = %s", (user,host))
 
@@ -252,7 +252,7 @@ def user_mod(cursor, user, host, host_all, password, encrypted, new_priv, append
     grant_option = False
 
     if host_all:
-        hostnames = user_get_hostnames(cursor, [user])
+        hostnames = user_get_hostnames(cursor, user)
     else:
         hostnames = [host]
 
@@ -342,7 +342,7 @@ def user_delete(cursor, user, host, host_all, check_mode):
         return True
 
     if host_all:
-        hostnames = user_get_hostnames(cursor, [user])
+        hostnames = user_get_hostnames(cursor, user)
 
         for hostname in hostnames:
             cursor.execute("DROP USER %s@%s", (user, hostname))
@@ -352,7 +352,7 @@ def user_delete(cursor, user, host, host_all, check_mode):
     return True
 
 def user_get_hostnames(cursor, user):
-    cursor.execute("SELECT Host FROM mysql.user WHERE user = %s", user)
+    cursor.execute("SELECT Host FROM mysql.user WHERE user = %s", (user,))
     hostnames_raw = cursor.fetchall()
     hostnames = []
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

database/mysql/mysql_user
##### ANSIBLE VERSION

```
ansible 2.1.0
  config file = /Users/olivier/Exo/ansible.cfg
  configured module search path = ['./library']
```
##### SUMMARY

There are two `cursor.execute` lines that cause a `TypeError: not all arguments converted during string formatting` because the single argument is not a tuple. It’s happening to me on Ubuntu 16 with python `2.7.11` and  python-mysqldb `1.3.7-1build2`.
