### PR TITLE
fix postgres disconnect sessions on drop database

### DIFF
--- a/database/postgresql/postgresql_db.py
+++ b/database/postgresql/postgresql_db.py
@@ -147,14 +147,25 @@ def get_db_info(cursor, db):
     return cursor.fetchone()
 
 def db_exists(cursor, db):
-    query = "SELECT * FROM pg_database WHERE datname=%(db)s"
+    query = "SELECT * FROM pg_database WHERE datname = '%s'" % db
     cursor.execute(query, {'db': db})
     return cursor.rowcount == 1
 
+def db_sessions_exist(cursor, db):
+    query = "SELECT * FROM pg_stat_activity WHERE datname = '%s'" % db
+    cursor.execute(query, {'db': db})
+    return cursor.rowcount > 0
+
 def db_delete(cursor, db):
     if db_exists(cursor, db):
-        query = "DROP DATABASE %s" % pg_quote_identifier(db, 'database')
-        cursor.execute(query)
+        if db_sessions_exist(cursor, db):
+            query_disconnect = "SELECT pg_terminate_backend(pg_stat_activity.pid) \
+                                FROM pg_stat_activity \
+                                WHERE pg_stat_activity.datname = '%s' \
+                                AND pid <> pg_backend_pid()" % db
+            cursor.execute(query_disconnect)
+        query_drop = "DROP DATABASE %s" % pg_quote_identifier(db, 'database')
+        cursor.execute(query_drop)
         return True
     else:
         return False


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

database/postgresql/postgresl_db
##### ANSIBLE VERSION

```
ansible 1.9.5
```
##### SUMMARY

currently, module does not disconnect sessions to the database being deleted.

with this PR, if sessions are detected, they are first terminated, and then the db is dropped.
