### PR TITLE
Add support to ec2_eip to associate with a secondary ip address

### DIFF
--- a/cloud/amazon/ec2_eip.py
+++ b/cloud/amazon/ec2_eip.py
@@ -61,6 +61,12 @@ options:
     required: false
     default: false
     version_added: "2.0"
+  private_ip_address:
+    description:
+      - The primary or secondary private IP address to associate with the Elastic IP address.
+    required: False
+    default: None
+    version_added: "2.3"
 extends_documentation_fragment:
     - aws
     - ec2
@@ -78,6 +84,8 @@ notes:
 '''
 
 EXAMPLES = '''
+# Note: These examples do not set authentication details, see the AWS Guide for details.
+
 - name: associate an elastic IP with an instance
   ec2_eip:
     device_id: i-1212f003
@@ -105,7 +113,8 @@ EXAMPLES = '''
     device_id: i-1212f003
 
 - name: allocate a new elastic IP without associating it to anything
-  action: ec2_eip
+  ec2_eip:
+    state: present
   register: eip
 
 - name: output the IP
@@ -153,7 +162,7 @@ class EIPException(Exception):
     pass
 
 
-def associate_ip_and_device(ec2, address, device_id, check_mode, isinstance=True):
+def associate_ip_and_device(ec2, address, private_ip_address, device_id, check_mode, isinstance=True):
     if address_is_associated_with_device(ec2, address, device_id, isinstance):
         return {'changed': False}
 
@@ -161,11 +170,11 @@ def associate_ip_and_device(ec2, address, device_id, check_mode, isinstance=True
     if not check_mode:
         if isinstance:
             if address.domain == "vpc":
-                res = ec2.associate_address(device_id, allocation_id=address.allocation_id)
+                res = ec2.associate_address(device_id, allocation_id=address.allocation_id, private_ip_address=private_ip_address)
             else:
-                res = ec2.associate_address(device_id, public_ip=address.public_ip)
+                res = ec2.associate_address(device_id, public_ip=address.public_ip, private_ip_address=private_ip_address)
         else:
-            res = ec2.associate_address(network_interface_id=device_id, allocation_id=address.allocation_id)
+            res = ec2.associate_address(network_interface_id=device_id, allocation_id=address.allocation_id, private_ip_address=private_ip_address)
         if not res:
             raise EIPException('association failed')
 
@@ -282,7 +291,7 @@ def find_device(ec2, module, device_id, isinstance=True):
     raise EIPException("could not find instance" + device_id)
 
 
-def ensure_present(ec2, module, domain, address, device_id,
+def ensure_present(ec2, module, domain, address, private_ip_address, device_id,
                    reuse_existing_ip_allowed, check_mode, isinstance=True):
     changed = False
 
@@ -302,12 +311,12 @@ def ensure_present(ec2, module, domain, address, device_id,
                 if len(instance.vpc_id) > 0 and domain is None:
                     raise EIPException("You must set 'in_vpc' to true to associate an instance with an existing ip in a vpc")
             # Associate address object (provided or allocated) with instance
-            assoc_result = associate_ip_and_device(ec2, address, device_id,
+            assoc_result = associate_ip_and_device(ec2, address, private_ip_address, device_id,
                                                  check_mode)
         else:
             instance = find_device(ec2, module, device_id, isinstance=False)
             # Associate address object (provided or allocated) with instance
-            assoc_result = associate_ip_and_device(ec2, address, device_id,
+            assoc_result = associate_ip_and_device(ec2, address, private_ip_address, device_id,
                                                  check_mode, isinstance=False)
 
         if instance.vpc_id:
@@ -347,11 +356,15 @@ def main():
                                        default=False),
         release_on_disassociation=dict(required=False, type='bool', default=False),
         wait_timeout=dict(default=300),
+        private_ip_address=dict(required=False, default=None, type='str')
     ))
 
     module = AnsibleModule(
         argument_spec=argument_spec,
-        supports_check_mode=True
+        supports_check_mode=True,
+        required_together=[
+            ('device_id', 'private_ip_address'),
+        ]
     )
 
     if not HAS_BOTO:
@@ -362,6 +375,7 @@ def main():
     device_id = module.params.get('device_id')
     instance_id = module.params.get('instance_id')
     public_ip = module.params.get('public_ip')
+    private_ip_address = module.params.get('private_ip_address')
     state = module.params.get('state')
     in_vpc = module.params.get('in_vpc')
     domain = 'vpc' if in_vpc else None
@@ -386,9 +400,8 @@ def main():
 
         if state == 'present':
             if device_id:
-                result = ensure_present(ec2, module, domain, address, device_id,
-                                    reuse_existing_ip_allowed,
-                                    module.check_mode, isinstance=is_instance)
+                result = ensure_present(ec2, module, domain, address, private_ip_address, device_id,
+                                    reuse_existing_ip_allowed, module.check_mode, isinstance=is_instance)
             else:
                 address = allocate_address(ec2, domain, reuse_existing_ip_allowed)
                 result = {'changed': True, 'public_ip': address.public_ip, 'allocation_id': address.allocation_id}


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

ec2_eip
##### ANSIBLE VERSION

Tested for 2.2
##### SUMMARY

Allow an EIP to be associated with a specified IP address.  This means you can assign to a secondary address of an interface, which the ec2_eni module now supports.

This removes the need for the following module which is current in PR - https://github.com/ansible/ansible-modules-extras/pull/1272

Also updated the examples to YAML type to make them clearer
