### PR TITLE
2 Module fixes

### DIFF
--- a/cloud/azure/azure_rm_virtualmachine.py
+++ b/cloud/azure/azure_rm_virtualmachine.py
@@ -520,7 +520,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
             changed=False,
             actions=[],
             powerstate_change=None,
-            ansible_facts=dict('azure_rm_vm')
+            ansible_facts=dict(azure_rm_vm=None)
         )
 
         super(AzureRMVirtualMachine, self).__init__(derived_arg_spec=self.module_arg_spec,


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

```
rhn_register.py
azure_rm_virtualmachine.py
```
##### ANSIBLE VERSION

```
devel
```
##### SUMMARY

`rhn_register` would not fail gracefully when rhn-client-tools was missing

`azure_rm_virtualmachine` had a syntax error in creating a dict
