### PR TITLE
Syntax error in filter name for is-public

### DIFF
--- a/cloud/amazon/ec2_ami_find.py
+++ b/cloud/amazon/ec2_ami_find.py
@@ -352,8 +352,8 @@ def main():
         filter['architecture'] = architecture
     if hypervisor:
         filter['hypervisor'] = hypervisor
-    if is_public:
-        filter['is_public'] = is_public
+    if is_public is not None:
+        filter['is-public'] = str(is_public).lower()
     if name:
         filter['name'] = name
     if platform:


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

ec2_ami_find.py
##### ANSIBLE VERSION

```
ansible 2.0.0.1
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

The filter parameter to use with boto library to find public AMI images is a string `is-public` and not a boolean `is_public`.
