### PR TITLE
For ec2_lb make sure we use volume_type like we do everywhere else

### DIFF
--- a/cloud/amazon/ec2_lc.py
+++ b/cloud/amazon/ec2_lc.py
@@ -123,7 +123,7 @@ EXAMPLES = '''
     volumes:
     - device_name: /dev/sda1
       volume_size: 100
-      device_type: io1
+      volume_type: io1
       iops: 3000
       delete_on_termination: true
     - device_name: /dev/sdb
@@ -148,6 +148,15 @@ def create_block_device(module, volume):
     # Not aware of a way to determine this programatically
     # http://aws.amazon.com/about-aws/whats-new/2013/10/09/ebs-provisioned-iops-maximum-iops-gb-ratio-increased-to-30-1/
     MAX_IOPS_TO_SIZE_RATIO = 30
+
+    # device_type has been used historically to represent volume_type,
+    # however ec2_vol uses volume_type, as does the BlockDeviceType, so
+    # we add handling for either/or but not both
+    if all(key in volume for key in ['device_type','volume_type']):
+        module.fail_json(msg = 'device_type is a deprecated name for volume_type. Do not use both device_type and volume_type')
+    # get whichever one is set, or NoneType if neither are set
+    volume_type = volume.get('device_type') or volume.get('volume_type')
+
     if 'snapshot' not in volume and 'ephemeral' not in volume:
         if 'volume_size' not in volume:
             module.fail_json(msg='Size must be specified when creating a new volume or modifying the root volume')
@@ -160,7 +169,7 @@ def create_block_device(module, volume):
     return BlockDeviceType(snapshot_id=volume.get('snapshot'),
                            ephemeral_name=volume.get('ephemeral'),
                            size=volume.get('volume_size'),
-                           volume_type=volume.get('device_type'),
+                           volume_type=volume_type,
                            delete_on_termination=volume.get('delete_on_termination', False),
                            iops=volume.get('iops'))
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

ec2_lb
##### ANSIBLE VERSION

Latest devel
##### SUMMARY

Everywhere else in ec2_vol and ec2 we use volume_type but in ec2_lb we use device_type. This leads to problems because devices come up with the wrong volume type set.

I based this patch on https://github.com/ansible/ansible-modules-core/pull/2124 which was accepted previously.
