### PR TITLE
network/*/*_config.py: Correct typo.

### DIFF
--- a/network/eos/eos_config.py
+++ b/network/eos/eos_config.py
@@ -34,7 +34,7 @@ options:
       - The ordered set of commands that should be configured in the
         section.  The commands must be the exact same commands as found
         in the device running-config.  Be sure to note the configuration
-        command syntanx as some commands are automatically modified by the
+        command syntax as some commands are automatically modified by the
         device config parser.
     required: true
   parents:

--- a/network/ios/ios_config.py
+++ b/network/ios/ios_config.py
@@ -34,7 +34,7 @@ options:
       - The ordered set of commands that should be configured in the
         section.  The commands must be the exact same commands as found
         in the device running-config.  Be sure to note the configuration
-        command syntanx as some commands are automatically modified by the
+        command syntax as some commands are automatically modified by the
         device config parser.
     required: true
   parents:

--- a/network/iosxr/iosxr_config.py
+++ b/network/iosxr/iosxr_config.py
@@ -35,7 +35,7 @@ options:
       - The ordered set of commands that should be configured in the
         section.  The commands must be the exact same commands as found
         in the device running-config.  Be sure to note the configuration
-        command syntanx as some commands are automatically modified by the
+        command syntax as some commands are automatically modified by the
         device config parser.
     required: true
   parents:

--- a/network/nxos/nxos_config.py
+++ b/network/nxos/nxos_config.py
@@ -35,7 +35,7 @@ options:
       - The ordered set of commands that should be configured in the
         section.  The commands must be the exact same commands as found
         in the device running-config.  Be sure to note the configuration
-        command syntanx as some commands are automatically modified by the
+        command syntax as some commands are automatically modified by the
         device config parser.
     required: true
   parents:

--- a/network/openswitch/ops_config.py
+++ b/network/openswitch/ops_config.py
@@ -34,7 +34,7 @@ options:
       - The ordered set of commands that should be configured in the
         section.  The commands must be the exact same commands as found
         in the device running-config.  Be sure to note the configuration
-        command syntanx as some commands are automatically modified by the
+        command syntax as some commands are automatically modified by the
         device config parser.
     required: true
   parents:


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

network modules:
- eos
- ios
- iosxr
- nxos
- openswitch
##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.0.1.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Docs change - fix a typo in all network/_/__config.py files concerned.
"syntanx" should have been "syntax".
- Replace syntanx with syntax in all things network.
