### PR TITLE
Fixed files/project_files naming. Correct name is files.

### DIFF
--- a/cloud/docker/docker_service.py
+++ b/cloud/docker/docker_service.py
@@ -85,7 +85,7 @@ options:
   definition:
       description:
         - Provide docker-compose yaml describing one or more services, networks and volumes.
-        - Mutually exclusive with project_src and project_files
+        - Mutually exclusive with C(project_src) and C(project_files).
       type: complex
       required: false
   hostname_check:
@@ -430,7 +430,7 @@ class ContainerManager(DockerBaseClass):
 
         self.client = client
         self.project_src = None
-        self.project_files = None
+        self.files = None
         self.project_name = None
         self.state = None
         self.definition = None
@@ -463,8 +463,8 @@ class ContainerManager(DockerBaseClass):
         if self.project_name:
             self.options[u'--project-name'] = self.project_name
 
-        if self.project_files:
-            self.options[u'--file'] = self.project_files
+        if self.files:
+            self.options[u'--file'] = self.files
 
         if not HAS_COMPOSE:
             self.client.fail("Unable to load docker-compose. Try `pip install docker-compose`. Error: %s" % HAS_COMPOSE_EXC)
@@ -734,7 +734,6 @@ def main():
     )
 
     mutually_exclusive = [
-        ('force_recreate', 'no_recreate'),
         ('definition', 'project_src'),
         ('definition', 'files')
     ]


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

docker_service.py
##### ANSIBLE VERSION

``````
ansible 2.2.0 (docker_container fca5ba153e) last updated 2016/05/06 23:42:16 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 1f5cf669dd) last updated 2016/05/06 23:40:41 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 431591c2b4) last updated 2016/05/06 23:40:44 (GMT -400)
  config file =
  configured module search path = Default w/o overrides```

##### SUMMARY
Fix parameter name issue with files/project_files. Correct name is files.
``````
