### PR TITLE
Fail gracefully when build path is not found.

### DIFF
--- a/cloud/docker/docker_image.py
+++ b/cloud/docker/docker_image.py
@@ -259,6 +259,8 @@ class ImageManager(DockerBaseClass):
         if not image or self.force:
             if self.path:
                 # Build the image
+                if not os.path.isdir(self.path):
+                    self.fail("Requested build path %s could not be found or you do not have access." % self.path)
                 image_name = self.name
                 if self.tag:
                     image_name = "%s:%s" % (self.name, self.tag)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

docker_image.py
##### ANSIBLE VERSION

```
ansible 2.1.0.0 (stable-2.1 1968bc5952) last updated 2016/05/12 23:39:18 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 4212513be4) last updated 2016/05/12 23:40:05 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 7d8de02258) last updated 2016/05/12 23:40:05 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fail gracefully when build path not found.
