### PR TITLE
Use integers as ip-version in os_subnet

### DIFF
--- a/cloud/openstack/os_subnet.py
+++ b/cloud/openstack/os_subnet.py
@@ -229,7 +229,7 @@ def main():
         name=dict(required=True),
         network_name=dict(default=None),
         cidr=dict(default=None),
-        ip_version=dict(default='4', choices=['4', '6']),
+        ip_version=dict(default=4, choices=[4, 6], type='int'),
         enable_dhcp=dict(default='true', type='bool'),
         gateway_ip=dict(default=None),
         dns_nameservers=dict(default=None, type='list'),


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

cloud/openstack/os_subnet
##### ANSIBLE VERSION

```
ansible 2.0.2.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

os_subnet module expects "4" or "6" as ip-version in playbooks BUT OpenStack Network API expects integers (4 or 6) as ip-version[1] which is a bit confusing. Moreover os_subnet uses these strings in subnet create http requests so it doesn't respect Network API 

Remark: it's currently working only because Neutron implementation is more permissive (it transforms string into intergers) than OpenStack Network API.

[1] http://developer.openstack.org/api-ref-networking-v2.html#createSubnet
