### PR TITLE
ec2_asg: only set default health_check_type when creating new auto scaling group

### DIFF
--- a/cloud/amazon/ec2_asg.py
+++ b/cloud/amazon/ec2_asg.py
@@ -351,7 +351,7 @@ def wait_for_elb(asg_connection, module, group_name):
     as_group = asg_connection.get_all_groups(names=[group_name])[0]
 
     if as_group.load_balancers and as_group.health_check_type == 'ELB':
-        log.debug("Waiting for ELB to consider intances healthy.")
+        log.debug("Waiting for ELB to consider instances healthy.")
         try:
             elb_connection = connect_to_aws(boto.ec2.elb, region, **aws_connect_params)
         except boto.exception.NoAuthHandlerFound, e:
@@ -422,7 +422,7 @@ def create_autoscaling_group(connection, module):
                  connection=connection,
                  tags=asg_tags,
                  health_check_period=health_check_period,
-                 health_check_type=health_check_type,
+                 health_check_type=health_check_type or 'EC2',
                  default_cooldown=default_cooldown,
                  termination_policies=termination_policies)
 
@@ -790,7 +790,7 @@ def main():
             state=dict(default='present', choices=['present', 'absent']),
             tags=dict(type='list', default=[]),
             health_check_period=dict(type='int', default=300),
-            health_check_type=dict(default='EC2', choices=['EC2', 'ELB']),
+            health_check_type=dict(choices=['EC2', 'ELB']),
             default_cooldown=dict(type='int', default=300),
             wait_for_instances=dict(type='bool', default=True),
             termination_policies=dict(type='list', default='Default')


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

ec2_asg
##### ANSIBLE VERSION

```
ansible 2.0.1.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

In the case of running ec2_asg with an existing auto scaling group, say to update the tags, the module resets the health check type to "EC2", even when no health_check_type argument is suppled. This adversely affects existing groups using ELB health checks.

This happens because the default value for the health_check_type argument is "EC2". If you elect not to specify the health_check_type when updating an existing group, the default value is used.

This change removes the default value from the module arguments, and instead applies a default value just before the group is about to be created. When operating on an existing group (i.e. not creating), the health_check_type argument is now ignored when unspecified.

**Task Example**

``` yaml
- name: Create auto scaling group
  ec2_asg:
    region: "{{ region }}"
    name: tom-test
    health_check_type: ELB
    min_size: 0
    max_size: 0
    launch_config_name: my-launch-config
    vpc_zone_identifier:
      - subnet-a81f55cd
    tags:
      - owner: tom
      - test: foo
    state: present

- name: Amend auto scaling group tags
  ec2_asg:
    region: "{{ region }}"
    name: tom-test
    tags:
      - owner: tom
      - test: bar
    state: present
```

**Before this change:**

The first task creates the group with the desired health check type. The second task resets it.

```
PLAY ***************************************************************************

TASK [Create auto scaling group] ***********************************************
task path: /home/ubuntu/tom/infrastructure/ansible/asg-test.yml:9
ESTABLISH LOCAL CONNECTION FOR USER: ubuntu
localhost EXEC /bin/sh -c '( umask 22 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1463185593.93-209871610896887 `" && echo "` echo $HOME/.ansible/tmp/ansible-tmp-1463185593.93-209871610896887 `" )'
localhost PUT /tmp/tmpGKJIHx TO /home/ubuntu/.ansible/tmp/ansible-tmp-1463185593.93-209871610896887/ec2_asg
localhost EXEC /bin/sh -c 'LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/python /home/ubuntu/.ansible/tmp/ansible-tmp-1463185593.93-209871610896887/ec2_asg; rm -rf "/home/ubuntu/.ansible/tmp/ansible-tmp-1463185593.93-209871610896887/" > /dev/null 2>&1'
changed: [localhost] => {"availability_zones": ["us-west-2b"], "changed": true, "default_cooldown": 300, "desired_capacity": 0, "health_check_period": 300, "health_check_type": "ELB", "healthy_instances": 0, "in_service_instances": 0, "instance_facts": {}, "invocation": {"module_args": {"availability_zones": null, "aws_access_key": null, "aws_secret_key": null, "default_cooldown": 300, "desired_capacity": null, "ec2_url": null, "health_check_period": 300, "health_check_type": "ELB", "launch_config_name": "my-launch-config", "lc_check": true, "load_balancers": null, "max_size": 0, "min_size": 0, "name": "tom-test", "profile": null, "region": "us-west-2", "replace_all_instances": false, "replace_batch_size": 1, "replace_instances": [], "security_token": null, "state": "present", "tags": [{"owner": "tom"}, {"test": "foo"}], "termination_policies": ["Default"], "validate_certs": true, "vpc_zone_identifier": ["subnet-a81f55cd"], "wait_for_instances": true, "wait_timeout": 300}, "module_name": "ec2_asg"}, "launch_config_name": "my-launch-config", "load_balancers": [], "max_size": 0, "min_size": 0, "name": "tom-test", "pending_instances": 0, "placement_group": null, "tags": {"owner": "tom", "test": "foo"}, "terminating_instances": 0, "termination_policies": ["Default"], "unhealthy_instances": 0, "viable_instances": 0, "vpc_zone_identifier": "subnet-a81f55cd"}

TASK [Amend auto scaling group tags] *******************************************
task path: /home/ubuntu/tom/infrastructure/ansible/asg-test.yml:24
ESTABLISH LOCAL CONNECTION FOR USER: ubuntu
localhost EXEC /bin/sh -c '( umask 22 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1463185594.7-179196219086022 `" && echo "` echo $HOME/.ansible/tmp/ansible-tmp-1463185594.7-179196219086022 `" )'
localhost PUT /tmp/tmpeIEW6H TO /home/ubuntu/.ansible/tmp/ansible-tmp-1463185594.7-179196219086022/ec2_asg
localhost EXEC /bin/sh -c 'LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/python /home/ubuntu/.ansible/tmp/ansible-tmp-1463185594.7-179196219086022/ec2_asg; rm -rf "/home/ubuntu/.ansible/tmp/ansible-tmp-1463185594.7-179196219086022/" > /dev/null 2>&1'
changed: [localhost] => {"availability_zones": ["us-west-2b"], "changed": true, "default_cooldown": 300, "desired_capacity": 0, "health_check_period": 300, "health_check_type": "EC2", "healthy_instances": 0, "in_service_instances": 0, "instance_facts": {}, "invocation": {"module_args": {"availability_zones": null, "aws_access_key": null, "aws_secret_key": null, "default_cooldown": 300, "desired_capacity": null, "ec2_url": null, "health_check_period": 300, "health_check_type": "EC2", "launch_config_name": null, "lc_check": true, "load_balancers": null, "max_size": null, "min_size": null, "name": "tom-test", "profile": null, "region": "us-west-2", "replace_all_instances": false, "replace_batch_size": 1, "replace_instances": [], "security_token": null, "state": "present", "tags": [{"owner": "tom"}, {"test": "bar"}], "termination_policies": ["Default"], "validate_certs": true, "vpc_zone_identifier": null, "wait_for_instances": true, "wait_timeout": 300}, "module_name": "ec2_asg"}, "launch_config_name": "my-launch-config", "load_balancers": [], "max_size": 0, "min_size": 0, "name": "tom-test", "pending_instances": 0, "placement_group": null, "tags": {"owner": "tom", "test": "bar"}, "terminating_instances": 0, "termination_policies": ["Default"], "unhealthy_instances": 0, "viable_instances": 0, "vpc_zone_identifier": "subnet-a81f55cd"}

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=2    unreachable=0    failed=0
```

**After this change:**

The first task creates the group with the specified health check type. The second task doesn't reset it.

```
PLAY ***************************************************************************

TASK [Create auto scaling group] ***********************************************
task path: /home/ubuntu/tom/infrastructure/ansible/asg-test.yml:9
ESTABLISH LOCAL CONNECTION FOR USER: ubuntu
localhost EXEC /bin/sh -c '( umask 22 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1463185806.6-11983594856979 `" && echo "` echo $HOME/.ansible/tmp/ansible-tmp-1463185806.6-11983594856979 `" )'
localhost PUT /tmp/tmpn7fbpi TO /home/ubuntu/.ansible/tmp/ansible-tmp-1463185806.6-11983594856979/ec2_asg
localhost EXEC /bin/sh -c 'LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/python /home/ubuntu/.ansible/tmp/ansible-tmp-1463185806.6-11983594856979/ec2_asg; rm -rf "/home/ubuntu/.ansible/tmp/ansible-tmp-1463185806.6-11983594856979/" > /dev/null 2>&1'
changed: [localhost] => {"availability_zones": ["us-west-2b"], "changed": true, "default_cooldown": 300, "desired_capacity": 0, "health_check_period": 300, "health_check_type": "ELB", "healthy_instances": 0, "in_service_instances": 0, "instance_facts": {}, "invocation": {"module_args": {"availability_zones": null, "aws_access_key": null, "aws_secret_key": null, "default_cooldown": 300, "desired_capacity": null, "ec2_url": null, "health_check_period": 300, "health_check_type": "ELB", "launch_config_name": "my-launch-config", "lc_check": true, "load_balancers": null, "max_size": 0, "min_size": 0, "name": "tom-test", "profile": null, "region": "us-west-2", "replace_all_instances": false, "replace_batch_size": 1, "replace_instances": [], "security_token": null, "state": "present", "tags": [{"owner": "tom"}, {"test": "foo"}], "termination_policies": ["Default"], "validate_certs": true, "vpc_zone_identifier": ["subnet-a81f55cd"], "wait_for_instances": true, "wait_timeout": 300}, "module_name": "ec2_asg"}, "launch_config_name": "my-launch-config", "load_balancers": [], "max_size": 0, "min_size": 0, "name": "tom-test", "pending_instances": 0, "placement_group": null, "tags": {"owner": "tom", "test": "foo"}, "terminating_instances": 0, "termination_policies": ["Default"], "unhealthy_instances": 0, "viable_instances": 0, "vpc_zone_identifier": "subnet-a81f55cd"}

TASK [Amend auto scaling group tags] *******************************************
task path: /home/ubuntu/tom/infrastructure/ansible/asg-test.yml:24
ESTABLISH LOCAL CONNECTION FOR USER: ubuntu
localhost EXEC /bin/sh -c '( umask 22 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1463185807.44-225226882940899 `" && echo "` echo $HOME/.ansible/tmp/ansible-tmp-1463185807.44-225226882940899 `" )'
localhost PUT /tmp/tmpOW4GdK TO /home/ubuntu/.ansible/tmp/ansible-tmp-1463185807.44-225226882940899/ec2_asg
localhost EXEC /bin/sh -c 'LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/python /home/ubuntu/.ansible/tmp/ansible-tmp-1463185807.44-225226882940899/ec2_asg; rm -rf "/home/ubuntu/.ansible/tmp/ansible-tmp-1463185807.44-225226882940899/" > /dev/null 2>&1'
changed: [localhost] => {"availability_zones": ["us-west-2b"], "changed": true, "default_cooldown": 300, "desired_capacity": 0, "health_check_period": 300, "health_check_type": "ELB", "healthy_instances": 0, "in_service_instances": 0, "instance_facts": {}, "invocation": {"module_args": {"availability_zones": null, "aws_access_key": null, "aws_secret_key": null, "default_cooldown": 300, "desired_capacity": null, "ec2_url": null, "health_check_period": 300, "health_check_type": null, "launch_config_name": null, "lc_check": true, "load_balancers": null, "max_size": null, "min_size": null, "name": "tom-test", "profile": null, "region": "us-west-2", "replace_all_instances": false, "replace_batch_size": 1, "replace_instances": [], "security_token": null, "state": "present", "tags": [{"owner": "tom"}, {"test": "bar"}], "termination_policies": ["Default"], "validate_certs": true, "vpc_zone_identifier": null, "wait_for_instances": true, "wait_timeout": 300}, "module_name": "ec2_asg"}, "launch_config_name": "my-launch-config", "load_balancers": [], "max_size": 0, "min_size": 0, "name": "tom-test", "pending_instances": 0, "placement_group": null, "tags": {"owner": "tom", "test": "bar"}, "terminating_instances": 0, "termination_policies": ["Default"], "unhealthy_instances": 0, "viable_instances": 0, "vpc_zone_identifier": "subnet-a81f55cd"}

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=2    unreachable=0    failed=0
```

**After this change, creating a group and not specifying the health check type:**

The effective default value of "EC2" is still used when creating a new group.

``` yaml
- name: Create auto scaling group
  ec2_asg:
    region: "{{ region }}"
    name: tom-test
    min_size: 0
    max_size: 0
    launch_config_name: my-launch-config
    vpc_zone_identifier:
      - subnet-a81f55cd
    tags:
      - owner: tom
      - test: foo
    state: present
```

```
PLAY ***************************************************************************

TASK [Create auto scaling group] ***********************************************
task path: /home/ubuntu/tom/infrastructure/ansible/asg-test.yml:9
ESTABLISH LOCAL CONNECTION FOR USER: ubuntu
localhost EXEC /bin/sh -c '( umask 22 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1463186017.12-57245407019118 `" && echo "` echo $HOME/.ansible/tmp/ansible-tmp-1463186017.12-57245407019118 `" )'
localhost PUT /tmp/tmpXJsvf_ TO /home/ubuntu/.ansible/tmp/ansible-tmp-1463186017.12-57245407019118/ec2_asg
localhost EXEC /bin/sh -c 'LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/python /home/ubuntu/.ansible/tmp/ansible-tmp-1463186017.12-57245407019118/ec2_asg; rm -rf "/home/ubuntu/.ansible/tmp/ansible-tmp-1463186017.12-57245407019118/" > /dev/null 2>&1'
changed: [localhost] => {"availability_zones": ["us-west-2b"], "changed": true, "default_cooldown": 300, "desired_capacity": 0, "health_check_period": 300, "health_check_type": "EC2", "healthy_instances": 0, "in_service_instances": 0, "instance_facts": {}, "invocation": {"module_args": {"availability_zones": null, "aws_access_key": null, "aws_secret_key": null, "default_cooldown": 300, "desired_capacity": null, "ec2_url": null, "health_check_period": 300, "health_check_type": null, "launch_config_name": "my-launch-config", "lc_check": true, "load_balancers": null, "max_size": 0, "min_size": 0, "name": "tom-test", "profile": null, "region": "us-west-2", "replace_all_instances": false, "replace_batch_size": 1, "replace_instances": [], "security_token": null, "state": "present", "tags": [{"owner": "tom"}, {"test": "foo"}], "termination_policies": ["Default"], "validate_certs": true, "vpc_zone_identifier": ["subnet-a81f55cd"], "wait_for_instances": true, "wait_timeout": 300}, "module_name": "ec2_asg"}, "launch_config_name": "my-launch-config", "load_balancers": [], "max_size": 0, "min_size": 0, "name": "tom-test", "pending_instances": 0, "placement_group": null, "tags": {"owner": "tom", "test": "foo"}, "terminating_instances": 0, "termination_policies": ["Default"], "unhealthy_instances": 0, "viable_instances": 0, "vpc_zone_identifier": "subnet-a81f55cd"}

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0
```
