### PR TITLE
Add acl freebsd

### DIFF
--- a/files/acl.py
+++ b/files/acl.py
@@ -258,8 +258,8 @@ def main():
         supports_check_mode=True,
     )
 
-    if get_platform().lower() != 'linux':
-        module.fail_json(msg="The acl module is only available for Linux distributions.")
+    if get_platform().lower() not in ['linux', 'freebsd']:
+        module.fail_json(msg="The acl module is not available on this system.")
 
     path = module.params.get('name')
     entry = module.params.get('entry')

--- a/files/acl.py
+++ b/files/acl.py
@@ -179,7 +179,10 @@ def build_command(module, mode, path, follow, default, recursive, entry=''):
         cmd.append('--recursive')
 
     if not follow:
-        cmd.append('--physical')
+        if get_platform().lower() == 'linux':
+            cmd.append('--physical')
+        elif get_platform().lower() == 'freebsd':
+            cmd.append('-h')
 
     if default:
         if(mode == 'rm'):

--- a/files/acl.py
+++ b/files/acl.py
@@ -171,8 +171,9 @@ def build_command(module, mode, path, follow, default, recursive, entry=''):
     else:  # mode == 'get'
         cmd = [module.get_bin_path('getfacl', True)]
         # prevents absolute path warnings and removes headers
-        cmd.append('--omit-header')
-        cmd.append('--absolute-names')
+        if get_platform().lower() == 'linux':
+            cmd.append('--omit-header')
+            cmd.append('--absolute-names')
 
     if recursive:
         cmd.append('--recursive')

--- a/files/acl.py
+++ b/files/acl.py
@@ -198,6 +198,10 @@ def build_command(module, mode, path, follow, default, recursive, entry=''):
 
 def acl_changed(module, cmd):
     '''Returns true if the provided command affects the existing ACLs, false otherwise.'''
+    # FreeBSD do not have a --test flag, so by default, it is safer to always say "true"
+    if get_platform().lower() == 'freebsd':
+        return True
+
     cmd = cmd[:]  # lists are mutables so cmd would be overriden without this
     cmd.insert(1, '--test')
     lines = run_acl(module, cmd)

--- a/files/acl.py
+++ b/files/acl.py
@@ -220,7 +220,11 @@ def run_acl(module, cmd, check_rc=True):
         e = get_exception()
         module.fail_json(msg=e.strerror)
 
-    lines = out.splitlines()
+    lines = []
+    for l in out.splitlines():
+        if not l.startswith('#'):
+            lines.append(l.strip())
+
     if lines and not lines[-1].split():
         # trim last line only when it is empty
         return lines[:-1]


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

acl
##### SUMMARY

posix acl have been in freebsd since 5.0, so this patch add support for it. However, on zfs, it seems that nfsv4 acl are used rather than posix, so I pushed that as well. 
