### PR TITLE
Add unpack results to error output, for debugging purposes on failure

### DIFF
--- a/files/unarchive.py
+++ b/files/unarchive.py
@@ -732,7 +732,7 @@ def main():
             if res_args['extract_results']['rc'] != 0:
                 module.fail_json(msg="failed to unpack %s to %s" % (src, dest), **res_args)
         except IOError:
-            module.fail_json(msg="failed to unpack %s to %s" % (src, dest))
+            module.fail_json(msg="failed to unpack %s to %s" % (src, dest), **res_args)
         else:
             res_args['changed'] = True
 
@@ -747,7 +747,7 @@ def main():
             try:
                 res_args['changed'] = module.set_fs_attributes_if_different(file_args, res_args['changed'])
             except (IOError, OSError), e:
-                module.fail_json(msg="Unexpected error when accessing exploded file: %s" % str(e))
+                module.fail_json(msg="Unexpected error when accessing exploded file: %s" % str(e), **res_args)
 
     if module.params['list_files']:
         res_args['files'] = handler.files_in_archive


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

unarchive
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

When there are issues during or after unpacking the archive, also dump the actual unpack results, just like we do as part of the unpack routine.

This may help understand what is going on with #3631, but regardless is the sensible thing to do.
