### PR TITLE
Revert "Fix doc strings spacing."

### DIFF
--- a/cloud/docker/docker_service.py
+++ b/cloud/docker/docker_service.py
@@ -146,13 +146,13 @@ options:
       type: bool
       default: false
 
-  extends_documentation_fragment:
-      - docker
+extends_documentation_fragment:
+    - docker
 
-  requirements:
-      - "python >= 2.6"
-      - "docker-compose >= 1.7.0"
-      - "Docker API >= 1.20"
+requirements:
+    - "python >= 2.6"
+    - "docker-compose >= 1.7.0"
+    - "Docker API >= 1.20"
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

docker_service
##### ANSIBLE VERSION

```
v2.2
```
##### SUMMARY

This reverts commit 127d518011224289f7917fd3b2ec8ddf73c7dd17 due to it incorrectly changing spacing on `extends_documentation_fragment` and `requirements` nesting them as they were module options.
