### PR TITLE
fix Ansible Modules Core 3105 (change formatting to avoid smart quotes)

### DIFF
--- a/windows/win_template.py
+++ b/windows/win_template.py
@@ -47,7 +47,7 @@ notes:
   - "templates are loaded with C(trim_blocks=True)."
   - By default, windows line endings are not created in the generated file.
   - "In order to ensure windows line endings are in the generated file, add the following header
-    as the first line of your template: #jinja2: newline_sequence:'\\\\r\\\\n' and ensure each line
+    as the first line of your template: ``#jinja2: newline_sequence:'\\r\\n'`` and ensure each line
     of the template ends with \\\\r\\\\n"
   - Beware fetching files from windows machines when creating templates
     because certain tools, such as Powershell ISE,  and regedit's export facility


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

win_template 
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 119baba6b1) last updated 2016/05/13 18:28:32 (GMT +100)
  lib/ansible/modules/core: (fix_amc_3105 057a137523) last updated 2016/05/17 07:58:15 (GMT +100)
  lib/ansible/modules/extras: (devel 735c1b6219) last updated 2016/05/17 07:53:13 (GMT +100)
  config file = 
  configured module search path = Default w/o overrides

```
##### SUMMARY

Documentation fix.

This PR avoids smart quotes being generated in the jinja2 template header which is useful for generating templated files which have windows style line endings.

This lets user copy and paste from the web docs, which they can't at the moment.

Fixes https://github.com/ansible/ansible-modules-core/issues/3105
