### PR TITLE
Fix broken link for issue template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Please see [this web page](http://docs.ansible.com/community.html) for informati
 If you'd like to file a bug
 ===========================
 
-I'd also read the community page above, but in particular, make sure you copy [this issue template](https://github.com/ansible/ansible-modules-core/blob/devel/ISSUE_TEMPLATE.md) into your ticket description.  We have a friendly neighborhood bot that will remind you if you forget :)  This template helps us organize tickets faster and prevents asking some repeated questions, so it's very helpful to us and we appreciate your help with it.
+I'd also read the community page above, but in particular, make sure you copy [this issue template](https://github.com/ansible/ansible-modules-core/blob/devel/.github/ISSUE_TEMPLATE.md) into your ticket description.  We have a friendly neighborhood bot that will remind you if you forget :)  This template helps us organize tickets faster and prevents asking some repeated questions, so it's very helpful to us and we appreciate your help with it.
 
 Also please make sure you are testing on the latest released version of Ansible or the development branch.
 


### PR DESCRIPTION
##### ISSUE TYPE
- Documentation Report
##### COMPONENT NAME

Issue template
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 7cb7132b24) last updated 2016/05/17 13:42:20 (GMT +000)
  lib/ansible/modules/core: (detached HEAD 127d518011) last updated 2016/05/17 13:42:30 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD f953d5dc0c) last updated 2016/05/17 13:42:40 (GMT +000)
  config file = 
  configured module search path = Default w/o overrides

```
##### CONFIGURATION

None
##### OS / ENVIRONMENT

Fedora release 23
##### SUMMARY

Fixed a broken link for issue template
##### EXPECTED RESULTS

Correct link - https://github.com/ansible/ansible-modules-core/blob/devel/.github/ISSUE_TEMPLATE.md
