### PR TITLE
Added single_transaction and quick to db_dump

### DIFF
--- a/database/mysql/mysql_db.py
+++ b/database/mysql/mysql_db.py
@@ -313,7 +313,7 @@ def main():
             else:
                 rc, stdout, stderr = db_dump(module, login_host, login_user,
                                             login_password, db, target, all_databases,
-                                            login_port, config_file, socket, ssl_cert, ssl_key, ssl_ca)
+                                            login_port, config_file, socket, ssl_cert, ssl_key, ssl_ca, single_transaction, quick)
                 if rc != 0:
                     module.fail_json(msg="%s" % stderr)
                 else:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

/database/mysql/mysql_db.py
##### ANSIBLE VERSION

2.1
##### SUMMARY

With the current code, db_dump would never get the single_transaction and quick parameter. 
I just added the parameters the one place where db_dump is called. 

Before:
- mysql_db: state=dump single_transaction=yes quick=yes name=all target=/tmp/{{ inventory_hostname }}.sql
  would result in: mysqldump without --single-transaction and --quick parameter

After:
- mysql_db: state=dump single_transaction=yes quick=yes name=all target=/tmp/{{ inventory_hostname }}.sql
  would result in: mysqldump WITH --single-transaction and --quick parameter
