### PR TITLE
ops_template.py: Change integer key into stirng

### DIFF
--- a/network/openswitch/ops_template.py
+++ b/network/openswitch/ops_template.py
@@ -195,7 +195,7 @@ def main():
         updates = dict()
         for path, key, new_value, old_value in changeset:
             path = '%s.%s' % ('.'.join(path), key)
-            updates[path] = new_value
+            updates[path] = str(new_value)
         result['updates'] = updates
 
         if changeset:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

ops_template
##### ANSIBLE VERSION

```
ansible-playbook 2.2.0
  config file = /usr/local/git/dc-on-docker/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

ops.dc.read(), which is called by openswitch.py, returns the current OVSDB state in Python dictionary
format.  Due to some keys in our schema defined as integer, we use "integer" type for those of the
keys. e.g. BGP AS number as shown in our schema, line number #864:

https://github.com/open-switch/ops/blob/master/schema/vswitch.extschema#L864

Without this fix, we get exception inside ops_template, when we convert python dictionary into
JSON format, as JSON's keys are string.  We can fix the issue in ops.dc() side to convert all
the key index to string, but fixing inside ops_template.py will minimize the impact at this stage.

We can come back if we need to fix it either openswitch.py or ops.dc() itself, later.

Here is the simple test, with the latest ansible with success:

https://travis-ci.org/keinohguchi/ops-bgp-role/jobs/131008821

This fix passing the update variable to the str()
so that it avoids the exception when ops.dc.read()
returns a dictionary which contains non-string keys.

This is due to the fact that some of the key types in
OpenSwitch schema are actually defined as integer
and ops.dc declerative config module encode those
in integer inside the dictionary.  This could be
the right encoding from the schema point of view
but someone needs to convert it to the string
somewhere, as JSON key should be string.
