### PR TITLE
Add option to make RDS param groups for the MySQL 5.7 engine family.

### DIFF
--- a/cloud/amazon/rds_param_group.py
+++ b/cloud/amazon/rds_param_group.py
@@ -47,7 +47,7 @@ options:
     required: false
     default: null
     aliases: []
-    choices: [ 'aurora5.6', 'mariadb10.0', 'mysql5.1', 'mysql5.5', 'mysql5.6', 'oracle-ee-11.2', 'oracle-ee-12.1', 'oracle-se-11.2', 'oracle-se-12.1', 'oracle-se1-11.2', 'oracle-se1-12.1', 'postgres9.3', 'postgres9.4', 'sqlserver-ee-10.5', 'sqlserver-ee-11.0', 'sqlserver-ex-10.5', 'sqlserver-ex-11.0', 'sqlserver-ex-12.0', 'sqlserver-se-10.5', 'sqlserver-se-11.0', 'sqlserver-se-12.0', 'sqlserver-web-10.5', 'sqlserver-web-11.0', 'sqlserver-web-12.0' ]
+    choices: [ 'aurora5.6', 'mariadb10.0', 'mysql5.1', 'mysql5.5', 'mysql5.6', 'mysql5.7', 'oracle-ee-11.2', 'oracle-ee-12.1', 'oracle-se-11.2', 'oracle-se-12.1', 'oracle-se1-11.2', 'oracle-se1-12.1', 'postgres9.3', 'postgres9.4', 'sqlserver-ee-10.5', 'sqlserver-ee-11.0', 'sqlserver-ex-10.5', 'sqlserver-ex-11.0', 'sqlserver-ex-12.0', 'sqlserver-se-10.5', 'sqlserver-se-11.0', 'sqlserver-se-12.0', 'sqlserver-web-10.5', 'sqlserver-web-11.0', 'sqlserver-web-12.0' ]
   immediate:
     description:
       - Whether to apply the changes immediately, or after the next reboot of any associated instances.
@@ -88,6 +88,7 @@ VALID_ENGINES = [
     'mysql5.1',
     'mysql5.5',
     'mysql5.6',
+    'mysql5.7',
     'oracle-ee-11.2',
     'oracle-ee-12.1',
     'oracle-se-11.2',


### PR DESCRIPTION
Hi Ansible team,

AWS now supports MySQL 5.7, so I wanted the ability to make MySQL 5.7 parameter groups with this module. Here's a two-line PR if you want the option in the module! cc/ @tastychutney, who's listed as the maintainer.
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

the rds_param_group module
##### ANSIBLE VERSION

```
ukch-ofclt2473:ansible-modules-core nbailey$ ansible --version
ansible 2.0.2.0
  config file = /Users/nbailey/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Adding a new option to the VALID_ENGINES list, since it's now supported by the AWS RDS API.

Now 'mysql5.7' is a valid parameter for rds_param_group.engine:

```
- rds_param_group:
      state: present
      name: norwegian_blue
      description: 'My Fancy Ex Parrot Group'
      engine: 'mysql5.7'
      params:
          auto_increment_increment: "42K"
```

Thanks for your time!
Nikki
