### PR TITLE
GCE : Add support for subnet networks

### DIFF
--- a/cloud/google/gce.py
+++ b/cloud/google/gce.py
@@ -600,7 +600,7 @@ def main():
                          changed=False)
 
     if subnetwork is not None and not hasattr(gce, 'ex_get_subnetwork'):
-        module.fail_json(msg="Your Apache Libcloud is not recent enough to enable support for subnetworks",
+        module.fail_json(msg="Apache Libcloud 1.0.0+ is required to use 'subnetwork' option",
                          changed=False)
 
     json_output = {'zone': zone}

--- a/cloud/google/gce.py
+++ b/cloud/google/gce.py
@@ -96,6 +96,11 @@ options:
       - name of the network, 'default' will be used if not specified
     required: false
     default: "default"
+  subnetwork:
+    description:
+      - name of the subnetwork in which the instance should be created
+    required: false
+    default: null
   persistent_boot_disk:
     description:
       - if set, create the instance with a persistent boot disk
@@ -285,6 +290,10 @@ def get_instance_info(inst):
         netname = inst.extra['networkInterfaces'][0]['network'].split('/')[-1]
     except:
         netname = None
+    try:
+        subnetname = inst.extra['networkInterfaces'][0]['subnetwork'].split('/')[-1]
+    except:
+        subnetname = None
     if 'disks' in inst.extra:
         disk_names = [disk_info['source'].split('/')[-1]
                       for disk_info
@@ -305,6 +314,7 @@ def get_instance_info(inst):
         'metadata': metadata,
         'name': inst.name,
         'network': netname,
+        'subnetwork': subnetname,
         'private_ip': inst.private_ips[0],
         'public_ip': public_ip,
         'status': ('status' in inst.extra) and inst.extra['status'] or None,
@@ -330,6 +340,7 @@ def create_instances(module, gce, instance_names):
     machine_type = module.params.get('machine_type')
     metadata = module.params.get('metadata')
     network = module.params.get('network')
+    subnetwork = module.params.get('subnetwork')
     persistent_boot_disk = module.params.get('persistent_boot_disk')
     disks = module.params.get('disks')
     state = module.params.get('state')
@@ -441,6 +452,8 @@ def create_instances(module, gce, instance_names):
         )
         if preemptible is not None:
             gce_args['ex_preemptible'] = preemptible
+        if subnetwork is not None:
+            gce_args['ex_subnetwork'] = subnetwork
 
         inst = None
         try:
@@ -527,6 +540,7 @@ def main():
             metadata = dict(),
             name = dict(),
             network = dict(default='default'),
+            subnetwork = dict(),
             persistent_boot_disk = dict(type='bool', default=False),
             disks = dict(type='list'),
             state = dict(choices=['active', 'present', 'absent', 'deleted'],
@@ -558,6 +572,7 @@ def main():
     metadata = module.params.get('metadata')
     name = module.params.get('name')
     network = module.params.get('network')
+    subnetwork = module.params.get('subnetwork')
     persistent_boot_disk = module.params.get('persistent_boot_disk')
     state = module.params.get('state')
     tags = module.params.get('tags')
@@ -581,6 +596,10 @@ def main():
 
     if preemptible is not None and hasattr(libcloud, '__version__') and libcloud.__version__ < '0.20':
         module.fail_json(msg="Apache Libcloud 0.20.0+ is required to use 'preemptible' option",
+                         changed=False)
+
+    if subnetwork is not None and not hasattr(gce, 'ex_get_subnetwork'):
+        module.fail_json(msg="Your Apache Libcloud is not recent enough to enable support for subnetworks",
                          changed=False)
 
     json_output = {'zone': zone}

--- a/cloud/google/gce.py
+++ b/cloud/google/gce.py
@@ -101,6 +101,7 @@ options:
       - name of the subnetwork in which the instance should be created
     required: false
     default: null
+    version_added: "2.2"
   persistent_boot_disk:
     description:
       - if set, create the instance with a persistent boot disk


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

gce
##### ANSIBLE VERSION

```
ansible 2.2.0
```
##### SUMMARY

Google has recently introduced a concept of per-region subnetworks, and has created a new style of networks called 'subnet network' to support that.
Old-style networks are now considered as legacy.
For more information see here : https://cloud.google.com/compute/docs/networking#legacy_non-subnet_network

As a consequence, creating a gce instance on a subnet network requires an explicit subnetwork name to be specified too.
The aim of this pull request is to be able to optionally pass a subnetwork name to libcloud, by introducing a new subnetwork option to the ansible gce module.
If the subnetwork option is used, libcloud will be explicitely checked for subnetwork support, and if too old, the instance creation will fail.
If the subnetwork option is not used, nothing changes, and you can keep your old libcloud :)

Currently, a fairly recent libcloud is needed, as no release contain the necessary change yet.
