### PR TITLE
Be able to find all contents of a directory

### DIFF
--- a/files/find.py
+++ b/files/find.py
@@ -66,7 +66,7 @@ options:
         required: false
         description:
             - Type of file to select
-        choices: [ "file", "directory", "link" ]
+        choices: [ "file", "directory", "link", "any" ]
         default: "file"
     recurse:
         required: false
@@ -275,7 +275,7 @@ def main():
             paths         = dict(required=True, aliases=['name','path'], type='list'),
             patterns      = dict(default=['*'], type='list', aliases=['pattern']),
             contains      = dict(default=None, type='str'),
-            file_type     = dict(default="file", choices=['file', 'directory', 'link'], type='str'),
+            file_type     = dict(default="file", choices=['file', 'directory', 'link', 'any'], type='str'),
             age           = dict(default=None, type='str'),
             age_stamp     = dict(default="mtime", choices=['atime','mtime','ctime'], type='str'),
             size          = dict(default=None, type='str'),
@@ -337,7 +337,11 @@ def main():
                         continue
 
                     r = {'path': fsname}
-                    if stat.S_ISDIR(st.st_mode) and params['file_type'] == 'directory':
+                    if params['file_type'] == 'any':
+                        if pfilter(fsobj, params['patterns'], params['use_regex']) and agefilter(st, now, age, params['age_stamp']):
+                            r.update(statinfo(st))
+                            filelist.append(r)
+                    elif stat.S_ISDIR(st.st_mode) and params['file_type'] == 'directory':
                         if pfilter(fsobj, params['patterns'], params['use_regex']) and agefilter(st, now, age, params['age_stamp']):
 
                             r.update(statinfo(st))


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

find
##### ANSIBLE VERSION

```
<!--- Paste verbatim output from “ansible --version” between quotes -->
ansible 2.0.2.0
  config file = /root/ansible-boulder/ansible.cfg
  configured module search path = /usr/share/ansible/
```
##### SUMMARY

I want to be able to remove all of the contents of a directory, files and directories.  The only method I've found is:

```
- find: paths="/var/cache/conda/pkgs" file_type=any
  register: conda_cache
- file: path={{ item.path }} state=absent
  with_items: "{{conda_cache.files}}"
```

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

```
TASK [science-runtime : find] **************************************************
Thursday 19 May 2016  12:09:50 -0600 (0:00:00.101)       0:00:04.723 **********
ok: [barry.cora.nwra.com]

TASK [science-runtime : Clean conda cache] *************************************
Thursday 19 May 2016  12:09:50 -0600 (0:00:00.582)       0:00:05.305 **********
changed: [barry.cora.nwra.com] => (item={u'uid': 0, u'woth': False, u'mtime': 1463681373.171626, u'inode': 813090536, u'isgid': False, u'size': 0, u'roth': True, u'isuid': False, u'isreg': True, u'gid': 0, u'ischr': False, u'wusr': True, u'xoth': False, u'rusr': True, u'nlink': 1, u'issock': False, u'rgrp': True, u'path': u'/var/cache/conda/pkgs/blah', u'xusr': False, u'atime': 1463681373.171626, u'isdir': False, u'ctime': 1463681373.171626, u'isblk': False, u'xgrp': False, u'dev': 2050, u'wgrp': False, u'isfifo': False, u'mode': u'0644', u'islnk': False})
changed: [barry.cora.nwra.com] => (item={u'uid': 0, u'woth': False, u'mtime': 1463681377.9396195, u'inode': 540898840, u'isgid': False, u'size': 6, u'roth': True, u'isuid': False, u'isreg': False, u'gid': 0, u'ischr': False, u'wusr': True, u'xoth': True, u'rusr': True, u'nlink': 2, u'issock': False, u'rgrp': True, u'path': u'/var/cache/conda/pkgs/blah2', u'xusr': True, u'atime': 1463681377.9396195, u'isdir': True, u'ctime': 1463681377.9396195, u'isblk': False, u'xgrp': True, u'dev': 2050, u'wgrp': False, u'isfifo': False, u'mode': u'0755', u'islnk': False})
```

Output is rather ugly.
