### PR TITLE
Removing double definition in postgresql_user module

### DIFF
--- a/database/postgresql/postgresql_user.py
+++ b/database/postgresql/postgresql_user.py
@@ -449,9 +449,6 @@ def grant_privileges(cursor, user, privs):
     grant_funcs = dict(table=grant_table_privileges, database=grant_database_privileges)
     check_funcs = dict(table=has_table_privileges, database=has_database_privileges)
 
-    grant_funcs = dict(table=grant_table_privileges, database=grant_database_privileges)
-    check_funcs = dict(table=has_table_privileges, database=has_database_privileges)
-
     changed = False
     for type_ in privs:
         for name, privileges in privs[type_].iteritems():


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

postgresql_user
##### ANSIBLE VERSION

```
ansible 2.0.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

This commit is removing double definition of variables in the `grant_privileges` function of the `postgresql_user` module. This change doesn't change the behaviour of the module, it just cleans up the code a bit.
