### PR TITLE
Update delete notes for Synrhconize docs

### DIFF
--- a/files/synchronize.py
+++ b/files/synchronize.py
@@ -72,7 +72,7 @@ options:
     version_added: "1.5"
   delete:
     description:
-      - Delete files that don't exist (after transfer, not before) in the C(src) path. This option requires C(recursive=yes).
+      - Delete files in C(dest) that don't exist (after transfer, not before) in the C(src) path. This option requires C(recursive=yes).
     choices: [ 'yes', 'no' ]
     default: 'no'
     required: false
@@ -234,7 +234,7 @@ synchronize:
 delegate_to: "{{ inventory_hostname }}"
 
 # Synchronize and delete files in dest on the remote host that are not found in src of localhost.
-synchronize: src=some/relative/path dest=/some/absolute/path delete=yes
+synchronize: src=some/relative/path dest=/some/absolute/path delete=yes recursive=yes
 
 # Synchronize using an alternate rsync command
 # This specific command is granted su privileges on the destination


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

synchronize
##### ANSIBLE VERSION

```
2.0.1.0
```
##### SUMMARY

The docs for synchronize need some updates about the delete=yes option.

The example for delete=yes does not specify recursive although it is
required. In addition, the wording for the delete option is confusing
about from where files are really deleted. This should clarify that.
