### PR TITLE
Fix for pip stripping "-e" from command when local source is not VCS (#3426)

### DIFF
--- a/packaging/language/pip.py
+++ b/packaging/language/pip.py
@@ -361,7 +361,7 @@ def main():
         # Automatically apply -e option to extra_args when source is a VCS url. VCS
         # includes those beginning with svn+, git+, hg+ or bzr+
         has_vcs = bool(name and re.match(r'(svn|git|hg|bzr)\+', name))
-        if has_vcs and module.params['editable']:
+        if has_vcs or module.params['editable']:
             args_list = []  # used if extra_args is not used at all
             if extra_args:
                 args_list = extra_args.split(' ')


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

pip
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel f9c4fdab40) last updated 2016/05/24 08:04:39 (GMT -500)
  lib/ansible/modules/core: (issue_3426 5e6dca9428) last updated 2016/05/24 11:51:38 (GMT -500)
  lib/ansible/modules/extras: (detached HEAD 148a0ddabf) last updated 2016/05/24 08:03:33 (GMT -500)
  config file =
  configured module search path = Default w/o overrides

```
##### SUMMARY

Code checked that `name` contained a VCS extension, AND that `editable: yes`. If one
was false, then the "-e" argument was not applied. I think (and believe this was the
original author's intent based on comments) that "-e" should be applied if either case
was true. This commit changes the boolean check from _AND_ to _OR_.

_Before_

```
ok: [localhost] => {"changed": false, "cmd": "/bin/pip install .", "invocation": {"module_args": {"chdir": "/var/tmp/mock-2.0.0", "editable": true, "executable": null, "extra_args": null, "name": ".", "requirements": null, "state": "present", "umask": null, "use_mirrors": true, "version": null, "virtualenv": null, "virtualenv_command": "virtualenv", "virtualenv_python": null, "virtualenv_site_packages": false}, "module_name": "pip"}, "name": ".", "requirements": null, "state": "present", "stderr": "", "stdout": "Processing /var/tmp/mock-2.0.0\n  Requirement already satisfied (use --upgrade to upgrade): mock==2.0.0 from file:///var/tmp/mock-2.0.0 in /var/tmp/mock-2.0.0\nRequirement already satisfied (use --upgrade to upgrade): pbr>=0.11 in /usr/lib/python2.7/site-packages (from mock==2.0.0)\nRequirement already satisfied (use --upgrade to upgrade): six>=1.9 in /usr/lib/python2.7/site-packages (from mock==2.0.0)\nRequirement already satisfied (use --upgrade to upgrade): funcsigs>=1 in /usr/lib/python2.7/site-packages (from mock==2.0.0)\n", "stdout_lines": ["Processing /var/tmp/mock-2.0.0", "  Requirement already satisfied (use --upgrade to upgrade): mock==2.0.0 from file:///var/tmp/mock-2.0.0 in /var/tmp/mock-2.0.0", "Requirement already satisfied (use --upgrade to upgrade): pbr>=0.11 in /usr/lib/python2.7/site-packages (from mock==2.0.0)", "Requirement already satisfied (use --upgrade to upgrade): six>=1.9 in /usr/lib/python2.7/site-packages (from mock==2.0.0)", "Requirement already satisfied (use --upgrade to upgrade): funcsigs>=1 in /usr/lib/python2.7/site-packages (from mock==2.0.0)"], "version": null, "virtualenv": null}
...
>>> import mock
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: No module named mock
>>>

```

_After_

```
changed: [localhost] => {"changed": true, "cmd": "/bin/pip install -e .", "invocation": {"module_args": {"chdir": "/var/tmp/mock-2.0.0", "editable": true, "executable": null, "extra_args": null, "name": ".", "requirements": null, "state": "present", "umask": null, "use_mirrors": true, "version": null, "virtualenv": null, "virtualenv_command": "virtualenv", "virtualenv_python": null, "virtualenv_site_packages": false}, "module_name": "pip"}, "name": ".", "requirements": null, "state": "present", "stderr": "", "stdout": "Obtaining file:///var/tmp/mock-2.0.0\nRequirement already satisfied (use --upgrade to upgrade): pbr>=0.11 in /usr/lib/python2.7/site-packages (from mock==2.0.0)\nRequirement already satisfied (use --upgrade to upgrade): six>=1.9 in /usr/lib/python2.7/site-packages (from mock==2.0.0)\nRequirement already satisfied (use --upgrade to upgrade): funcsigs>=1 in /usr/lib/python2.7/site-packages (from mock==2.0.0)\nInstalling collected packages: mock\n  Running setup.py develop for mock\nSuccessfully installed mock-2.0.0\n", "stdout_lines": ["Obtaining file:///var/tmp/mock-2.0.0", "Requirement already satisfied (use --upgrade to upgrade): pbr>=0.11 in /usr/lib/python2.7/site-packages (from mock==2.0.0)", "Requirement already satisfied (use --upgrade to upgrade): six>=1.9 in /usr/lib/python2.7/site-packages (from mock==2.0.0)", "Requirement already satisfied (use --upgrade to upgrade): funcsigs>=1 in /usr/lib/python2.7/site-packages (from mock==2.0.0)", "Installing collected packages: mock", "  Running setup.py develop for mock", "Successfully installed mock-2.0.0"], "version": null, "virtualenv": null}
...
>>> import mock
>>>
```
