### PR TITLE
Accept 'compress' state to file module

### DIFF
--- a/files/file.py
+++ b/files/file.py
@@ -300,8 +300,11 @@ def main():
                 # Decompress
                 if compression == 'gzip':
                     try:
-                        with gzip.open(compress_path) as f_in, open(path, 'w') as f_out:
-                            shutil.copyfileobj(f_in, f_out) 
+                        f_in = gzip.open(compress_path)
+                        f_out = open(path, 'w')
+                        shutil.copyfileobj(f_in, f_out)
+                        f_in.close()
+                        f_out.close()
                     except OSError:
                         e = get_exception
                         module.fail_json(path=path, msg='Unable to write to compressed file: %s' % str(e))
@@ -484,8 +487,11 @@ def main():
                 # Compress the file
                 if compression == 'gzip':
                     try:
-                        with open(path) as f_in, gzip.open(compress_path, 'w') as f_out:
-                            shutil.copyfileobj(f_in, f_out) 
+                        f_in = open(path)
+                        f_out = gzip.open(compress_path, 'w')
+                        shutil.copyfileobj(f_in, f_out)
+                        f_in.close()
+                        f_out.close()
                     except OSError:
                         e = get_exception()
                         module.fail_json(path=path, msg='Error, could not write compressed file: %s' % str(e))


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

file
##### ANSIBLE VERSION

```
ansible 2.2.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

There is no obvious way to ensure a file is compressed. For my particular use case, I want to keep a sql dump file on hand, but make sure it's always compressed because they are eminently compressible and should be maintained that way.

Addresses #3734, filed earlier.

Sample playbook:

``` yaml

---
- hosts: all
  tasks:
  - name: Test file compress
    file: path=/Users/bendoh/vc/ansible-tests/myfile state=compress
```

``` sh
% ls -l ~/vc/ansible-tests/files
total 16
-rw-r--r-- 1 bendoh staff 12324 May 24 22:44 myfile

% ansible-playbook -i localhost, playbook.yml

PLAY [all] *********************************************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [Test file compress] ******************************************************
changed: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0

% ls -l ~/vc/ansible-tests/files
total 4
-rw-r--r-- 1 bendoh staff 119 May 24 22:56 myfile.gz

% ansible-playbook -i localhost, playbook.yml

PLAY [all] *********************************************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [Test file compress] ******************************************************
ok: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0

```
