### PR TITLE
Fix docker memory_limit type regression

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -1852,7 +1852,7 @@ def main():
             volumes_from    = dict(default=None, type='list'),
             links           = dict(default=None, type='list'),
             devices         = dict(default=None, type='list'),
-            memory_limit    = dict(default=0, type='int'),
+            memory_limit    = dict(default=0),
             memory_swap     = dict(default=0, type='int'),
             cpu_shares      = dict(default=0, type='int'),
             docker_url      = dict(),


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

docker
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fix docker memory_limit type regression introduced by 8dc0276533f2e98d215e752ac09e21b0530b3182

The regression prevents Docker containers to be created using human-readable memory_limits, e.g. 512MB due to a type conversion error:

```
argument memory_limit is of type <type 'str'> and we were unable to convert to int
```

This change corrects that issue by reverting to the previous (type-less) module interface declaration for memory_limit.
