### PR TITLE
Add new EBS volume types

### DIFF
--- a/cloud/amazon/ec2_vol.py
+++ b/cloud/amazon/ec2_vol.py
@@ -480,7 +480,7 @@ def main():
             id = dict(),
             name = dict(),
             volume_size = dict(),
-            volume_type = dict(choices=['standard', 'gp2', 'io1'], default='standard'),
+            volume_type = dict(choices=['standard', 'gp2', 'io1', 'st1', 'sc1'], default='standard'),
             iops = dict(),
             encrypted = dict(type='bool', default=False),
             device_name = dict(),


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

ec2_vol
##### ANSIBLE VERSION

ansible 2.0.0.2
##### SUMMARY

Add new volume types

AWS offers now two new EBS types st1 and sc1. http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html
