### PR TITLE
Fix missing key error when updating existing virtual network.

### DIFF
--- a/cloud/azure/azure_rm_virtualnetwork.py
+++ b/cloud/azure/azure_rm_virtualnetwork.py
@@ -333,7 +333,7 @@ class AzureRMVirtualNetwork(AzureRMModuleBase):
                         ),
                         tags=results['tags']
                     )
-                    if results['dns_servers']:
+                    if results.get('dns_servers'):
                         vnet.dhcp_options = DhcpOptions(
                             dns_servers=results['dns_servers']
                         )


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

azure_rm_virtualnetwork.py
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 329c62e914) last updated 2016/05/26 11:44:47 (GMT -400)
  lib/ansible/modules/core: (devel aa995806b9) last updated 2016/05/25 07:16:20 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD d1a4f703ce) last updated 2016/05/25 06:29:58 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Attempting to update an existing virtual network by changing the address space and receiving a key error.

```
TASK [azure_virtualnetwork : azure_rm_virtualnetwork] **************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: KeyError: 'dns_servers'
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Traceback (most recent call last):\n  File \"/var/folders/g_/mr68c1yn1rl4b7qh6pntbmmm0000gn/T/ansible_U4n5gW/ansible_module_azure_rm_virtualnetwork.py\", line 369, in <module>\n    main()\n  File \"/var/folders/g_/mr68c1yn1rl4b7qh6pntbmmm0000gn/T/ansible_U4n5gW/ansible_module_azure_rm_virtualnetwork.py\", line 366, in main\n    AzureRMVirtualNetwork()\n  File \"/var/folders/g_/mr68c1yn1rl4b7qh6pntbmmm0000gn/T/ansible_U4n5gW/ansible_module_azure_rm_virtualnetwork.py\", line 217, in __init__\n    supports_check_mode=True)\n  File \"/var/folders/g_/mr68c1yn1rl4b7qh6pntbmmm0000gn/T/ansible_U4n5gW/ansible_modlib.zip/ansible/module_utils/azure_rm_common.py\", line 178, in __init__\n  File \"/var/folders/g_/mr68c1yn1rl4b7qh6pntbmmm0000gn/T/ansible_U4n5gW/ansible_module_azure_rm_virtualnetwork.py\", line 336, in exec_module\n    if results['dns_servers']:\nKeyError: 'dns_servers'\n", "module_stdout": "", "msg": "MODULE FAILURE", "parsed": false}
```
