### PR TITLE
Added docs on using list. Also added examples

### DIFF
--- a/packaging/os/yum.py
+++ b/packaging/os/yum.py
@@ -58,8 +58,9 @@ options:
     default: null
   list:
     description:
-      - Various (non-idempotent) commands for usage with C(/usr/bin/ansible) and I(not) playbooks. See examples.
+      - Use yum utils to see C(installed), C(available), or C(updates) to packages. You can also see a list of available C(repos).
     required: false
+    choices: ["installed", "updates", "available", "repos"]
     default: null
   state:
     description:
@@ -181,6 +182,12 @@ EXAMPLES = '''
 
 - name: install the 'Gnome desktop' environment group
   yum: name="@^gnome-desktop-environment" state=present
+
+- name: list all installed packages
+  yum: list=installed
+
+- name: list updates available for installed packages
+  yum: list=updates
 '''
 
 # 64k.  Number of bytes to read at a time when manually downloading pkgs via a url


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Docs Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task  -->

yum
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 6a0a366746) last updated 2016/05/26 14:54:57 (GMT -400)
  lib/ansible/modules/core: (yum_doc_fix 7ac29a2c57) last updated 2016/05/27 16:40:43 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 0e4a023a7e) last updated 2016/05/26 13:10:34 (GMT -400)
  config file = 
  configured module search path = Default w/o overrides

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

In response to #2232

Adds examples to the yum documentation for how to use list. Also presents the choices possible when using list. 

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Added 

```
  list:
    description:
      - Use yum utils to see C(installed), C(available), or C(updates) to packages. You can also see a list of available C(repos).
    required: false
    choices: ["installed", "updates", "available", "repos"]
    default: null
```

 and examples

```
- name: list all installed packages
  yum: list=installed

- name: list updates available for installed packages
  yum: list=updates
```
