### PR TITLE
gce_net: Add ability to create new-style networks on Google Cloud

### DIFF
--- a/cloud/google/gce_net.py
+++ b/cloud/google/gce_net.py
@@ -206,6 +206,9 @@ def main():
             credentials_file = dict(),
             project_id = dict(),
             mode = dict(default='legacy', choices=['legacy', 'auto', 'custom']),
+            subnet_name = dict(),
+            subnet_region = dict(),
+            subnet_desc = dict(),
         )
     )
 
@@ -223,16 +226,25 @@ def main():
     target_tags = module.params.get('target_tags')
     state = module.params.get('state')
     mode = module.params.get('mode')
+    subnet_name = module.params.get('subnet_name')
+    subnet_region = module.params.get('subnet_region')
+    subnet_desc = module.params.get('subnet_desc')
 
     changed = False
     json_output = {'state': state}
 
     if state in ['active', 'present']:
         network = None
+        subnet = None
         try:
             network = gce.ex_get_network(name)
             json_output['name'] = name
-            json_output['ipv4_range'] = network.cidr
+            if mode == 'legacy':
+                json_output['ipv4_range'] = network.cidr
+            if network and mode == 'custom' and subnet_name:
+                subnet = gce.ex_get_subnetwork(subnet_name, region=subnet_region)
+                json_output['subnet_name'] = subnet_name
+                json_output['ipv4_range'] = subnet.cidr
         except ResourceNotFoundError:
             pass
         except Exception as e:
@@ -241,22 +253,36 @@ def main():
         # user wants to create a new network that doesn't yet exist
         if name and not network:
             if not ipv4_range and mode != 'auto':
-                module.fail_json(msg="Network '" + name + "' is not found. To create network in legacy mode, 'ipv4_range' parameter is required",
+                module.fail_json(msg="Network '" + name + "' is not found. To create network in legacy or custom mode, 'ipv4_range' parameter is required",
                     changed=False)
-            if mode == 'legacy':
-                kwargs = {}
-            else:
-                kwargs = {'mode': mode}
+            args = [ipv4_range if mode =='legacy' else None]
+            kwargs = {}
+            if mode != 'legacy':
+                kwargs['mode'] = mode
 
             try:
-                network = gce.ex_create_network(name, ipv4_range, **kwargs)
+                network = gce.ex_create_network(name, *args, **kwargs)
                 json_output['name'] = name
                 json_output['ipv4_range'] = ipv4_range
                 changed = True
             except TypeError:
-                module.fail_json(msg="Update libcloud to a more recent version (1.0+) that supports network 'mode' parameter", changed=False)
+                module.fail_json(msg="Update libcloud to a more recent version (>1.0) that supports network 'mode' parameter", changed=False)
             except Exception as e:
                 module.fail_json(msg=unexpected_error_msg(e), changed=False)
+
+        if (subnet_name or ipv4_range) and not subnet and mode == 'custom':
+            if not hasattr(gce, 'ex_create_subnetwork'):
+                module.fail_json(msg='Update libcloud to a more recent version (>1.0) that supports subnetwork creation', changed=changed)
+            if not subnet_name or not ipv4_range or not subnet_region:
+                module.fail_json(msg="subnet_name, ipv4_range, and subnet_region required for custom mode", changed=changed)
+
+            try:
+                subnet = gce.ex_create_subnetwork(subnet_name, cidr=ipv4_range, network=name, region=subnet_region, description=subnet_desc)
+                json_output['subnet_name'] = subnet_name
+                json_output['ipv4_range'] = ipv4_range
+                changed = True
+            except Exception, e:
+                module.fail_json(msg=unexpected_error_msg(e), changed=changed)
 
         if fwname:
             # user creating a firewall rule
@@ -351,6 +377,18 @@ def main():
                 module.fail_json(msg=unexpected_error_msg(e), changed=False)
             if fw:
                 gce.ex_destroy_firewall(fw)
+                changed = True
+        elif subnet_name:
+            json_output['name'] = subnet_name
+            subnet = None
+            try:
+                subnet = gce.ex_get_subnetwork(subnet_name, region=subnet_region)
+            except ResourceNotFoundError:
+                pass
+            except Exception, e:
+                module.fail_json(msg=unexpected_error_msg(e), changed=False)
+            if subnet:
+                gce.ex_destroy_subnetwork(subnet)
                 changed = True
         elif name:
             json_output['name'] = name

--- a/cloud/google/gce_net.py
+++ b/cloud/google/gce_net.py
@@ -114,7 +114,11 @@ options:
   mode:
     version_added: "2.2"
     description:
-      - network mode supporting subnets introduced into Google Cloud
+      - network mode for Google Cloud
+        "legacy" indicates a network with an IP address range
+        "auto" automatically generates subnetworks in different regions
+        "custom" uses networks to group subnets of user specified IP address ranges
+        https://cloud.google.com/compute/docs/networking#network_types
     required: false
     default: "legacy"
     choices: ["legacy", "auto", "custom"]
@@ -161,6 +165,21 @@ EXAMPLES = '''
     fwname: all-web-webproxy
     allowed: tcp:80,8080
     src_tags: ["web", "proxy"]
+
+# Simple example of creating a new auto network
+- local_action:
+    module: gce_net
+    name: privatenet
+    mode: auto
+
+# Simple example of creating a new custom subnet
+- local_action:
+    module: gce_net
+    name: privatenet
+    mode: custom
+    subnet_name: subnet_example
+    subnet_region: us-central1
+    ipv4_range: 10.0.0.0/16
 
 '''
 

--- a/cloud/google/gce_net.py
+++ b/cloud/google/gce_net.py
@@ -111,6 +111,14 @@ options:
     required: false
     default: null
     aliases: []
+  mode:
+    version_added: TBD
+    description:
+      - network mode supporting subnets introduced into Google Cloud
+    required: false
+    default: "legacy"
+    choices: ["legacy", "auto", "custom"]
+    aliases: []
 
 requirements:
     - "python >= 2.6"
@@ -197,6 +205,7 @@ def main():
             pem_file = dict(),
             credentials_file = dict(),
             project_id = dict(),
+            mode = dict(default='legacy', choices=['legacy', 'auto', 'custom']),
         )
     )
 
@@ -213,6 +222,7 @@ def main():
     src_tags = module.params.get('src_tags')
     target_tags = module.params.get('target_tags')
     state = module.params.get('state')
+    mode = module.params.get('mode')
 
     changed = False
     json_output = {'state': state}
@@ -235,7 +245,7 @@ def main():
                     changed=False)
 
             try:
-                network = gce.ex_create_network(name, ipv4_range)
+                network = gce.ex_create_network(name, ipv4_range, mode=mode)
                 json_output['name'] = name
                 json_output['ipv4_range'] = ipv4_range
                 changed = True

--- a/cloud/google/gce_net.py
+++ b/cloud/google/gce_net.py
@@ -112,12 +112,33 @@ options:
     default: null
     aliases: []
   mode:
-    version_added: TBD
+    version_added: "2.2"
     description:
       - network mode supporting subnets introduced into Google Cloud
     required: false
     default: "legacy"
     choices: ["legacy", "auto", "custom"]
+    aliases: []
+  subnet_name:
+    version_added: "2.2"
+    description:
+      - name of subnet to create
+    required: false
+    default: null
+    aliases: []
+  subnet_region:
+    version_added: "2.2"
+    description:
+      - region of subnet to create
+    required: false
+    default: null
+    aliases: []
+  subnet_desc:
+    version_added: "2.2"
+    description:
+      - description of subnet to create
+    required: false
+    default: null
     aliases: []
 
 requirements:

--- a/cloud/google/gce_net.py
+++ b/cloud/google/gce_net.py
@@ -253,6 +253,8 @@ def main():
                 json_output['name'] = name
                 json_output['ipv4_range'] = ipv4_range
                 changed = True
+            except TypeError:
+                module.fail_json(msg="Update libcloud to a more recent version (1.0+) that supports network 'mode' parameter", changed=False)
             except Exception as e:
                 module.fail_json(msg=unexpected_error_msg(e), changed=False)
 

--- a/cloud/google/gce_net.py
+++ b/cloud/google/gce_net.py
@@ -305,7 +305,7 @@ def main():
                 json_output['subnet_name'] = subnet_name
                 json_output['ipv4_range'] = ipv4_range
                 changed = True
-            except Exception, e:
+            except Exception as e:
                 module.fail_json(msg=unexpected_error_msg(e), changed=changed)
 
         if fwname:
@@ -411,7 +411,7 @@ def main():
                 subnet = gce.ex_get_subnetwork(subnet_name, region=subnet_region)
             except ResourceNotFoundError:
                 pass
-            except Exception, e:
+            except Exception as e:
                 module.fail_json(msg=unexpected_error_msg(e), changed=False)
             if subnet:
                 gce.ex_destroy_subnetwork(subnet)
@@ -430,7 +430,7 @@ def main():
 #                json_output['d4'] = 'deleting %s' % name
                 try:
                     gce.ex_destroy_network(network)
-                except Exception, e:
+                except Exception as e:
                     module.fail_json(msg=unexpected_error_msg(e), changed=False)
 #                json_output['d5'] = 'deleted %s' % name
                 changed = True

--- a/cloud/google/gce_net.py
+++ b/cloud/google/gce_net.py
@@ -240,12 +240,16 @@ def main():
 
         # user wants to create a new network that doesn't yet exist
         if name and not network:
-            if not ipv4_range:
-                module.fail_json(msg="Network '" + name + "' is not found. To create network, 'ipv4_range' parameter is required",
+            if not ipv4_range and mode != 'auto':
+                module.fail_json(msg="Network '" + name + "' is not found. To create network in legacy mode, 'ipv4_range' parameter is required",
                     changed=False)
+            if mode == 'legacy':
+                kwargs = {}
+            else:
+                kwargs = {'mode': mode}
 
             try:
-                network = gce.ex_create_network(name, ipv4_range, mode=mode)
+                network = gce.ex_create_network(name, ipv4_range, **kwargs)
                 json_output['name'] = name
                 json_output['ipv4_range'] = ipv4_range
                 changed = True


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task  -->

gce_net
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

This will allow access to Google's new cloud networking capabilities. Currently ansible only supports legacy mode and not subnets which are provided by Google's other modes, auto and custom. This will provide the ability to create and delete subnets as well as auto and custom networks. The use of args and kwargs is for backwards compatibility and these changes will notify the user if libcloud is not recent enough to provide these features. Extra error handling has been added on ex_destroy_network to avoid an exception if a subnetwork is active on a custom network.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

```
***********************************
PARSED OUTPUT
{
    "changed": false, 
    "invocation": {
        "module_args": {
            "allowed": null, 
            "credentials_file": [CREDENTIALS], 
            "fwname": null, 
            "ipv4_range": null, 
            "mode": "custom", 
            "name": "testing-subnet-module", 
            "pem_file": null, 
            "project_id": [ID], 
            "service_account_email": [EMAIL], 
            "src_range": null, 
            "src_tags": null, 
            "state": "active", 
            "subnet_desc": null, 
            "subnet_name": "testingthis", 
            "subnet_region": "us-east1", 
            "target_tags": null
        }
    }, 
    "ipv4_range": "10.0.10.0/24", 
    "name": "testing-subnet-module", 
    "state": "active", 
    "subnet_name": "testingthis"
}

```
