### PR TITLE
Fix "ansbile_facts" typo in docker_container module

### DIFF
--- a/cloud/docker/docker_container.py
+++ b/cloud/docker/docker_container.py
@@ -1356,7 +1356,7 @@ class ContainerManager(DockerBaseClass):
             self.results['diff'] = self.diff
 
         if self.facts:
-            self.results['ansbile_facts'] = {'ansible_docker_container': self.facts}
+            self.results['ansible_facts'] = {'ansible_docker_container': self.facts}
 
     def present(self, state):
         container = self._get_container(self.parameters.name)


### PR DESCRIPTION
##### SUMMARY

One-liner: fixes a typo in the docker_container module. `self.facts` was storing container data under a top-level "ansbile_facts" key, which is a typo. This PR corrects the key to "ansible_facts".
- Type: Bugfix Pull Request
- Module: docker_container module
- Version: 2.1.0.0
