### PR TITLE
Fix for #3783 - command returns not found or does not exist.

### DIFF
--- a/cloud/docker/docker_container.py
+++ b/cloud/docker/docker_container.py
@@ -1309,11 +1309,7 @@ class Container(DockerBaseClass):
         self.log('_get_expected_cmd')
         if not self.parameters.command:
             return None
-        # expected_commands = []
-        # commands = self.parameters.command
-        # for cmd in commands:
-        #     expected_commands = expected_commands + shlex.split(cmd)
-        return self.parameters.command
+        return shlex.split(self.parameters.command)
 
     def _convert_simple_dict_to_list(self, param_name, join_with=':'):
         if getattr(self.parameters, param_name, None) is None:
@@ -1559,7 +1555,7 @@ def main():
     argument_spec = dict(
         blkio_weight=dict(type='int'),
         capabilities=dict(type='list'),
-        command=dict(type='list'),
+        command=dict(type='str'),
         cpu_period=dict(type='int'),
         cpu_quota=dict(type='int'),
         cpuset_cpus=dict(type='str'),


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

docker_container.py 
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel d81b9ca29e) last updated 2016/05/29 06:21:45 (GMT -400)
  lib/ansible/modules/core: (fix_container f4d3acb637) last updated 2016/05/29 06:51:20 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 0e4a023a7e) last updated 2016/05/26 21:17:07 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Change _command_ parameter from type list to type str list. Fix comparison of _command_ between desired config and existing container config.
