### PR TITLE
Fix restart_poicy

### DIFF
--- a/cloud/docker/docker_container.py
+++ b/cloud/docker/docker_container.py
@@ -305,10 +305,12 @@ options:
     required: false
   restart_policy:
     description:
-      - Container restart policy.
+      - Container restart policy. Place quotes around I(no) option.
     choices:
-      - on-failure
       - always
+      - no
+      - on-failure
+      - unless-stopped 
     default: on-failure
     required: false
   restart_retries:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

docker_container.py
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel d81b9ca29e) last updated 2016/05/29 06:21:45 (GMT -400)
  lib/ansible/modules/core: (fix_container f4d3acb637) last updated 2016/05/29 06:51:20 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 0e4a023a7e) last updated 2016/05/26 21:17:07 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Parameter _restart_policy_ was not being handled and compared as a string. Additionally, added 'no', and 'unless-stopped'.
