### PR TITLE
Fix for issue #3775 - env config comparison

### DIFF
--- a/cloud/docker/docker_container.py
+++ b/cloud/docker/docker_container.py
@@ -1278,7 +1278,8 @@ class Container(DockerBaseClass):
             for env_var in image['ContainerConfig']['Env']:
                 parts = env_var.split('=')
                 expected_env[parts[0]] = parts[1]
-        expected_env.update(self.parameters.env)
+        if self.parameters.env:
+            expected_env.update(self.parameters.env)
         param_env = []
         for key, value in expected_env.items():
             param_env.append("%s=%s" % (key, value))

--- a/cloud/docker/docker_container.py
+++ b/cloud/docker/docker_container.py
@@ -1273,10 +1273,15 @@ class Container(DockerBaseClass):
 
     def _get_expected_env(self, image):
         self.log('_get_expected_env')
-        param_env = (self._convert_simple_dict_to_list('env', '=') or [])
+        expected_env = dict()
         if image and image['ContainerConfig'].get('Env'):
-            image_env = image['ContainerConfig'].get('Env')
-            param_env = list(set(param_env + image_env))
+            for env_var in image['ContainerConfig']['Env']:
+                parts = env_var.split('=')
+                expected_env[parts[0]] = parts[1]
+        expected_env.update(self.parameters.env)
+        param_env = []
+        for key, value in expected_env.items():
+            param_env.append("%s=%s" % (key, value))
         return param_env
 
     def _get_expected_exposed(self, image):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

docker_container.py 
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel d81b9ca29e) last updated 2016/05/29 06:21:45 (GMT -400)
  lib/ansible/modules/core: (fix_container f4d3acb637) last updated 2016/05/29 06:51:20 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 0e4a023a7e) last updated 2016/05/26 21:17:07 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fix for issue #3775. Fix config comparison for _env_. Now creates the expected config using a dict, rather than set. Starts with image env and then updates with requested config. 
