### PR TITLE
Fixes ansible/ansible#15922

### DIFF
--- a/commands/command.py
+++ b/commands/command.py
@@ -195,7 +195,6 @@ def main():
                 cmd=args,
                 stdout="skipped, since %s exists" % v,
                 changed=False,
-                stderr=False,
                 rc=0
             )
 
@@ -209,7 +208,6 @@ def main():
                 cmd=args,
                 stdout="skipped, since %s does not exist" % v,
                 changed=False,
-                stderr=False,
                 rc=0
             )
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

command
##### SUMMARY

Fixes ansible/ansible#15922.
Apparently handing over `False` in the `stderr` argument triggers an error.
I think it can be simply omitted, so I tried to fix that.
