### PR TITLE
Update gc_storage.py

### DIFF
--- a/cloud/google/gc_storage.py
+++ b/cloud/google/gc_storage.py
@@ -69,12 +69,12 @@ options:
     required: true
     default: null
     choices: [ 'get', 'put', 'get_url', 'get_str', 'delete', 'create' ]
-  gcs_secret_key:
+  gc_secret_key:
     description:
       - GCS secret key. If not set then the value of the GCS_SECRET_KEY environment variable is used.
     required: true
     default: null
-  gcs_access_key:
+  gc_access_key:
     description:
       - GCS access key. If not set then the value of the GCS_ACCESS_KEY environment variable is used.
     required: true


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

gc_storage
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file = /www/ambisafe-ansible/keyserver-saas/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fix _gs_secret_key_ and _gs_access_key_ parameter names in documentation.
