### PR TITLE
Remove file extension from policy names

### DIFF
--- a/cloud/amazon/ec2_elb_lb.py
+++ b/cloud/amazon/ec2_elb_lb.py
@@ -976,7 +976,7 @@ class ElbManager(object):
             self.elb_conn.modify_lb_attribute(self.name, 'ConnectingSettings', attributes.connecting_settings)
 
     def _policy_name(self, policy_type):
-        return __file__.split('/')[-1].replace('_', '-')  + '-' + policy_type
+        return __file__.split('/')[-1].split('.')[0].replace('_', '-')  + '-' + policy_type
 
     def _create_policy(self, policy_param, policy_meth, policy):
         getattr(self.elb_conn, policy_meth )(policy_param, self.elb.name, policy)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

ec2_elb_lb
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file = /home/lyle/projects/prima_cm/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fixes #3804.

Prevents `__file__` from contributing ".", which is an illegal character in ELB policy names. ELBs are created with correct stickiness policies.
