### PR TITLE
Fix docker ulimit error

### DIFF
--- a/cloud/docker/docker_container.py
+++ b/cloud/docker/docker_container.py
@@ -336,7 +336,7 @@ options:
       - always
       - no
       - on-failure
-      - unless-stopped 
+      - unless-stopped
     default: on-failure
     required: false
   restart_retries:
@@ -1465,7 +1465,7 @@ class Container(DockerBaseClass):
         if isinstance(config_ulimits[0], Ulimit):
             for limit in config_ulimits:
                 if limit.hard:
-                    results.append("%s:%s" % (limit.name, limit.soft, limit.hard))
+                    results.append("%s:%s" % (limit.name, limit.hard))
                 else:
                     results.append("%s:%s" % (limit.name, limit.soft))
         else:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

docker_container
##### ANSIBLE VERSION

```
ansible 2.1.0.0
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

When using `ulimits` parameter with docker_container module, it will complain about `not all arguments converted during string formatting`

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

```
"module_stdout"
: "\u001b[?25h\u001b[0G\u001b[K\u001b[?25h\u001b[0G\u001b[KBECOME-SUCCESS-mflvcvigamunbqepczunyootsuwqznch\r\nTraceback (most recent call last):\r\n  File \"/tmp/ansible_19T1QE/ansible_module_docker_conta
iner.py\", line 1641, in <module>\r\n    main()\r\n  File \"/tmp/ansible_19T1QE/ansible_module_docker_container.py\", line 1634, in main\r\n    cm = ContainerManager(client)\r\n  File \"/tmp/ansible_19T1Q
E/ansible_module_docker_container.py\", line 1345, in __init__\r\n    self.present(state)\r\n  File \"/tmp/ansible_19T1QE/ansible_module_docker_container.py\", line 1380, in present\r\n    different, diff
erences = container.has_different_configuration(image)\r\n  File \"/tmp/ansible_19T1QE/ansible_module_docker_container.py\", line 968, in has_different_configuration\r\n    self.parameters.expected_ulimit
s = self._get_expected_ulimits(self.parameters.ulimits)\r\n  File \"/tmp/ansible_19T1QE/ansible_module_docker_container.py\", line 1297, in _get_expected_ulimits\r\n    results.append(\"%s:%s\" % (limit.n
ame, limit.soft, limit.hard))\r\nTypeError: not all arguments converted during string formatting\r\n", "msg": "MODULE FAILURE", "parsed": false}
```
