### PR TITLE
Fix unarchive bug when unzipping an archive that has one or more file (#3792)

### DIFF
--- a/files/unarchive.py
+++ b/files/unarchive.py
@@ -309,6 +309,10 @@ class ZipArchive(object):
                 pass
             fut_gid = run_gid
 
+        # Remove header and footer of zipinfo output
+        lines.pop(0)
+        lines.pop(len(lines) - 1)
+
         for line in old_out.splitlines():
             change = False
 
@@ -320,7 +324,11 @@ class ZipArchive(object):
             version = pcs[0][1]
             ostype = pcs[0][2]
             size = int(pcs[3])
-            path = pcs[7]
+
+            # determine the full path by removing other pieces of the line (since the path can contain spaces)
+            copiedpcs = list(pcs)
+            copiedpcs[0:7] = []
+            path = ' '.join(map(str, copiedpcs))
 
             # Skip excluded files
             if path in self.excludes:

--- a/files/unarchive.py
+++ b/files/unarchive.py
@@ -317,7 +317,6 @@ class ZipArchive(object):
             change = False
 
             pcs = line.split()
-            if len(pcs) != 8: continue
 
             ztype = pcs[0][0]
             permstr = pcs[0][1:10]


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->

Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task  -->

unarchive
##### ANSIBLE VERSION

```
ansible 2.1.0.0
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Fixes #3792 

In the unarchive module within the ZipArchive class, there is an issue with the method `is_unarchived`. It is parsing the output of `unzip -ZT <source>` and breaking on files that have a space in them. The current method is to split each line at the space character and if the length of the array is not 8, it will assume it is the header or footer of the command's output. Instead, I removed the header and footer explicitly so we know each line represents a file in the archive. Furthermore, the final path is determined by removing the elements before it in the array, which will retain any spaces in the path.
