### PR TITLE
Fix cursor.execute requiring an iterable

### DIFF
--- a/database/mysql/mysql_user.py
+++ b/database/mysql/mysql_user.py
@@ -213,7 +213,7 @@ def get_mode(cursor):
 
 def user_exists(cursor, user, host, host_all):
     if host_all:
-        cursor.execute("SELECT count(*) FROM user WHERE user = %s", user)
+        cursor.execute("SELECT count(*) FROM user WHERE user = %s", (user,))
     else:
         cursor.execute("SELECT count(*) FROM user WHERE user = %s AND host = %s", (user,host))
 
@@ -352,7 +352,7 @@ def user_delete(cursor, user, host, host_all, check_mode):
     return True
 
 def user_get_hostnames(cursor, user):
-    cursor.execute("SELECT Host FROM mysql.user WHERE user = %s", user)
+    cursor.execute("SELECT Host FROM mysql.user WHERE user = %s", (user,))
     hostnames_raw = cursor.fetchall()
     hostnames = []
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

ansible_module_mysql_user
##### ANSIBLE VERSION

ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
##### SUMMARY

This fixes the error I got when using host_all:

An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_7Rvlhp/ansible_module_mysql_user.py", line 582, in <module>
    main()
  File "/tmp/ansible_7Rvlhp/ansible_module_mysql_user.py", line 571, in main
    if user_exists(cursor, user, host, host_all):
  File "/tmp/ansible_7Rvlhp/ansible_module_mysql_user.py", line 216, in user_exists
    cursor.execute("SELECT count(*) FROM user WHERE user = %s", user)
  File "/usr/lib/python2.7/dist-packages/MySQLdb/cursors.py", line 198, in execute
    query = query % args
TypeError: not all arguments converted during string formatting
