### PR TITLE
yum module checks nvra for local rpms: fixes #3807

### DIFF
--- a/packaging/os/yum.py
+++ b/packaging/os/yum.py
@@ -573,9 +573,9 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
                 res['msg'] += "No Package file matching '%s' found on system" % spec
                 module.fail_json(**res)
 
-            pkg_name = local_name(module, spec)
+            nvra = local_nvra(module, spec)
             # look for them in the rpmdb
-            if is_installed(module, repoq, pkg_name, conf_file, en_repos=en_repos, dis_repos=dis_repos):
+            if is_installed(module, repoq, nvra, conf_file, en_repos=en_repos, dis_repos=dis_repos):
                 # if they are there, skip it
                 continue
             pkg = spec


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

yum
##### ANSIBLE VERSION

```
ansible 2.1.0.0
```
##### SUMMARY

Fixes #3807 by checking the nvra when installing a local RPM and thus not skipping a local RPM install if only the name matches.  Matching on only the name was causing version upgrades to be ignored when using local RPMs.
