### PR TITLE
Fixes issue 3661 where ansible incorrectly raises an error for ftp co…

### DIFF
--- a/network/basics/get_url.py
+++ b/network/basics/get_url.py
@@ -169,39 +169,39 @@ author: "Jan-Piet Mens (@jpmens)"
 
 EXAMPLES='''
 - name: download foo.conf
-  get_url: 
-    url: http://example.com/path/file.conf 
-    dest: /etc/foo.conf 
+  get_url:
+    url: http://example.com/path/file.conf
+    dest: /etc/foo.conf
     mode: 0440
 
 - name: download file and force basic auth
-  get_url: 
-    url: http://example.com/path/file.conf 
-    dest: /etc/foo.conf 
+  get_url:
+    url: http://example.com/path/file.conf
+    dest: /etc/foo.conf
     force_basic_auth: yes
 
 - name: download file with custom HTTP headers
-  get_url: 
-    url: http://example.com/path/file.conf 
-    dest: /etc/foo.conf 
+  get_url:
+    url: http://example.com/path/file.conf
+    dest: /etc/foo.conf
     headers: 'key:value,key:value'
 
 - name: download file with check (sha256)
-  get_url: 
-    url: http://example.com/path/file.conf 
-    dest: /etc/foo.conf 
+  get_url:
+    url: http://example.com/path/file.conf
+    dest: /etc/foo.conf
     checksum: sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c
 
 - name: download file with check (md5)
-  get_url: 
-    url: http://example.com/path/file.conf 
+  get_url:
+    url: http://example.com/path/file.conf
     dest: /etc/foo.conf
     checksum: md5:66dffb5228a211e61d6d7ef4a86f5758
 
 - name: download file from a file path
-  get_url: 
-    url: "file:///tmp/afile.txt" 
-    dest: /tmp/afilecopy.txt  
+  get_url:
+    url: "file:///tmp/afile.txt"
+    dest: /tmp/afilecopy.txt
 '''
 
 from ansible.module_utils.six.moves.urllib.parse import urlsplit
@@ -224,12 +224,15 @@ def url_get(module, url, dest, use_proxy, last_mod_time, force, timeout=10, head
 
     rsp, info = fetch_url(module, url, use_proxy=use_proxy, force=force, last_mod_time=last_mod_time, timeout=timeout, headers=headers)
 
+    # Parse the url so we can check what type of remote connection is being attempted.
+    conn_type = urlparse.urlparse(url).scheme
+
     if info['status'] == 304:
         module.exit_json(url=url, dest=dest, changed=False, msg=info.get('msg', ''))
 
     # create a temporary file and copy content to do checksum-based replacement
-    if info['status'] != 200 and not url.startswith('file:/'):
-        module.fail_json(msg="Request failed", status_code=info['status'], response=info['msg'], url=url, dest=dest)
+    if conn_type != 'ftp' and info['status'] != 200 and not url.startswith('file:/'):
+        module.fail_json(msg="Request failed", status_code=info['status'], response=info['msg'], url=url, dest=dest, conn_type=conn_type)
 
     if tmp_dest != '':
         # tmp_dest should be an existing dir
@@ -414,7 +417,7 @@ def main():
                 if os.path.exists(dest):
                     backup_file = module.backup_local(dest)
             shutil.copyfile(tmpsrc, dest)
-        except Exception: 
+        except Exception:
             err = get_exception()
             os.remove(tmpsrc)
             module.fail_json(msg="failed to copy %s to %s: %s" % (tmpsrc, dest, str(err)))


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel d08fda9320) last updated 2016/05/24 21:03:58 (GMT -700)
  lib/ansible/modules/core: (detached HEAD aa995806b9) last updated 2016/05/24 21:04:04 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD d1a4f703ce) last updated 2016/05/24 21:04:09 (GMT -700)
  config file = /Users/ronnietaylor/Documents/Development/ansible-experiments/vagrants/ubuntu1404/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fixes #3661

This pull requests replaces the following closed pull requests:
https://github.com/ansible/ansible-modules-core/pull/3743
https://github.com/ansible/ansible/pull/15995

Create and make use of new conn_type variable that contains the output from `urlparse.urlparse(url)` (i.e. 'ftp', 'http' or 'https').

This ultimately lets get_url check against something other than just HTTP status codes since successful FTP connections don't return status codes in the response headers like HTTP does. By passing along the connection type we can prevent incorrectly throwing errors for successful FTP connections.

Since the parsing of the url already happens at this level then it seemed best to just capture it once and pass it through to get_url instead of parsing the url again later.

This new variable will contain a string like the following:

```
>>> conn_type
'ftp'
```

… in the get_url module.
