### PR TITLE
apt_repository: Fix the default mode, should be 0644, not 0420

### DIFF
--- a/packaging/os/apt_repository.py
+++ b/packaging/os/apt_repository.py
@@ -452,7 +452,7 @@ def main():
         argument_spec=dict(
             repo=dict(required=True),
             state=dict(choices=['present', 'absent'], default='present'),
-            mode=dict(required=False, default=int('0644',8)),
+            mode=dict(required=False, default='0644'),
             update_cache = dict(aliases=['update-cache'], type='bool', default='yes'),
             filename=dict(required=False, default=None),
             # this should not be needed, but exists as a failsafe


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

apt_repository
##### ANSIBLE VERSION

2.1.0.0
##### SUMMARY

New APT repositories are created with the mode of 0420, instead of the expected 0644.

The mode parameter is a string and when it was given 0644 (octal) as the int default, it was converted to the string '420'. In set_mode_if_different that was converted to int as 0420 (octal).
