### PR TITLE
Add an example to delete Route53 alias record set

### DIFF
--- a/cloud/amazon/route53.py
+++ b/cloud/amazon/route53.py
@@ -95,7 +95,7 @@ options:
     description:
       - Have to be specified for Weighted, latency-based and failover resource record sets only. An identifier
         that differentiates among multiple resource record sets that have the
-        same combination of DNS name and type. 
+        same combination of DNS name and type.
     required: false
     default: null
     version_added: "2.0"
@@ -194,7 +194,7 @@ EXAMPLES = '''
       type: "AAAA"
       ttl: "7200"
       value: "::1"
-      
+
 # Add a SRV record with multiple fields for a service on port 22222
 # For more information on SRV records see:
 # https://en.wikipedia.org/wiki/SRV_record
@@ -224,6 +224,25 @@ EXAMPLES = '''
       value="{{ elb_dns_name }}"
       alias=True
       alias_hosted_zone_id="{{ elb_zone_id }}"
+
+# Retrieve the details for elb.foo.com
+- route53:
+      command: get
+      zone: foo.com
+      record: elb.foo.com
+      type: A
+  register: rec
+
+# Delete an alias record using the results from the get command
+- route53:
+      command: delete
+      zone: foo.com
+      record: "{{ rec.set.record }}"
+      ttl: "{{ rec.set.ttl }}"
+      type: "{{ rec.set.type }}"
+      value: "{{ rec.set.value }}"
+      alias: True
+      alias_hosted_zone_id: "{{ rec.set.alias_hosted_zone_id }}"
 
 # Add an alias record that points to an Amazon ELB and evaluates it health:
 - route53:
@@ -556,7 +575,7 @@ def main():
         txt = txt.split("</Message>")[0]
         if "but it already exists" in txt:
                 module.exit_json(changed=False)
-        else:   
+        else:
                 module.fail_json(msg = txt)
     except TimeoutError:
         module.fail_json(msg='Timeout waiting for changes to replicate')


### PR DESCRIPTION
##### ISSUE TYPE

Docs Pull Request
##### COMPONENT NAME

route53
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel c9a5b1c555) last updated 2016/06/02 20:00:01 (GMT +800)
  lib/ansible/modules/core: (detached HEAD ca4365b644) last updated 2016/06/02 20:00:14 (GMT +800)
  lib/ansible/modules/extras: (detached HEAD b0aec50b9a) last updated 2016/06/02 20:00:25 (GMT +800)
  config file = /home/mansun/kdt/logs-elk_stack/elk_stack/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

If we don't assign parameter _alias_ and _alias_hosted_zone_id_ to delete an alias record set, the error message is quit far from the root cause.

Setting:

``` yaml
# Delete an alias record using the results from the get command
- route53:
      command: delete
      zone: foo.com
      record: "{{ rec.set.record }}"
      ttl: "{{ rec.set.ttl }}"
      type: "{{ rec.set.type }}"
      value: "{{ rec.set.value }}"
```

Error message:

``` json
fatal: [localhost -> localhost]: FAILED! => {"changed": false, "failed": true, "msg": "Tried to delete resource record set [name='elb.foo.com', type='A'] but the values provided do not match the current values"}
```

Here we just add an example to avoid users be confused with the unrelated error message. 
