### PR TITLE
Remove unused method in ContainerManager

### DIFF
--- a/cloud/docker/docker_container.py
+++ b/cloud/docker/docker_container.py
@@ -1813,10 +1813,6 @@ class ContainerManager(DockerBaseClass):
                 self.fail("Error stopping container %s: %s" % (container_id, str(exc)))
         return response
 
-    def connect_container_to_network(self, container_id, network    ):
-        # TODO - Implement network connecions
-        pass
-
 
 def main():
     argument_spec = dict(


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

docker_container.py
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 3aae0b8a6b) last updated 2016/06/03 02:08:00 (GMT -400)
  lib/ansible/modules/core: (detached HEAD ca4365b644) last updated 2016/06/03 02:08:08 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD b0aec50b9a) last updated 2016/06/01 10:11:03 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Remove _connect_container_to_network_ method in ContainerManager.
