### PR TITLE
Fix 3857 name regex

### DIFF
--- a/cloud/azure/azure_rm_virtualnetwork.py
+++ b/cloud/azure/azure_rm_virtualnetwork.py
@@ -145,7 +145,7 @@ except ImportError:
     pass
 
 
-NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_]{1,61}[a-z0-9_]$")
+NAME_PATTERN = re.compile(r"^[a-zA-Z0-9]+[a-zA-Z0-9\._-]+[a-zA-Z0-9_]+$")
 
 
 def virtual_network_to_dict(vnet):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

azure_rm_virtualnetwork.py 
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 3aae0b8a6b) last updated 2016/06/03 02:08:00 (GMT -400)
  lib/ansible/modules/core: (devel 0a42ada42a) last updated 2016/06/03 03:00:00 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD b0aec50b9a) last updated 2016/06/01 10:11:03 (GMT -400)
  config file = /Users/chouseknecht/projects/azure/azurerm/test/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fix #3857 name validation bug. You can now create names containing `.` or `-`.
