### PR TITLE
Bugfix: IAM group modules need `module` passed

### DIFF
--- a/cloud/amazon/iam.py
+++ b/cloud/amazon/iam.py
@@ -439,7 +439,7 @@ def create_role(module, iam, name, path, role_list, prof_list):
                 name, path=path).create_role_response.create_role_result.role
 
             if name not in prof_list:
-                instance_profile_result = iam.create_instance_profile(name, 
+                instance_profile_result = iam.create_instance_profile(name,
                     path=path).create_instance_profile_response.create_instance_profile_result.instance_profile
                 iam.add_role_to_instance_profile(name, name)
     except boto.exception.BotoServerError, err:
@@ -673,11 +673,12 @@ def main():
         group_exists = name in orig_group_list
 
         if state == 'present' and not group_exists:
-            new_group, changed = create_group(iam=iam, name=name, path=path)
+            new_group, changed = create_group(module=module, iam=iam, name=name, path=path)
             module.exit_json(changed=changed, group_name=new_group)
         elif state in ['present', 'update'] and group_exists:
             changed, updated_name, updated_path, cur_path = update_group(
-                iam=iam, name=name, new_name=new_name, new_path=new_path)
+                module=module, iam=iam, name=name, new_name=new_name,
+                new_path=new_path)
 
             if new_path and new_name:
                 module.exit_json(changed=changed, old_group_name=name,
@@ -699,11 +700,11 @@ def main():
 
         elif state == 'update' and not group_exists:
             module.fail_json(
-                changed=changed, msg="Update Failed. Group %s doesn't seem to exit!" % name)
+                changed=changed, msg="Update Failed. Group %s doesn't seem to exist!" % name)
 
         elif state == 'absent':
             if name in orig_group_list:
-                removed_group, changed = delete_group(iam=iam, name=name)
+                removed_group, changed = delete_group(module=module, iam=iam, name=name)
                 module.exit_json(changed=changed, delete_group=removed_group)
             else:
                 module.exit_json(changed=changed, msg="Group already absent")


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

iam
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 85f4c95843) last updated 2016/06/03 10:44:00 (GMT -400)
  lib/ansible/modules/core: (iam-pass-module 1b9e28cc68) last updated 2016/06/03 13:16:39 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD b0aec50b9a) last updated 2016/06/03 10:44:10 (GMT -400)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

The IAM group modules were not receiving the `module` object, but they
use `module.fail_json()` in their exception handlers. This patch passes
through the module object so the real errors from boto are exposed,
rather than errors about "NoneType has no method `fail_json`".

```
BEFORE: 
An exception occurred during task execution. The full traceback is:                                                                    [6133/7646]
Traceback (most recent call last):
  File "/tmp/ryansb/ansible_KVlo55/ansible_module_iam.py", line 728, in <module>
    main()
  File "/tmp/ryansb/ansible_KVlo55/ansible_module_iam.py", line 676, in main
    new_group, changed = create_group(iam=iam, name=name, path=path)
  File "/tmp/ryansb/ansible_KVlo55/ansible_module_iam.py", line 379, in create_group
    module.fail_json(changed=changed, msg=str(err))
AttributeError: 'NoneType' object has no attribute 'fail_json'

failed: [localhost] (item=100) => {"failed": true, "invocation": {"module_name": "iam"}, "item": 100, "module_stderr": "Traceback (most recent cal
l last):\n  File \"/tmp/ryansb/ansible_KVlo55/ansible_module_iam.py\", line 728, in <module>\n    main()\n  File \"/tmp/ryansb/ansible_KVlo55/ansi
ble_module_iam.py\", line 676, in main\n    new_group, changed = create_group(iam=iam, name=name, path=path)\n  File \"/tmp/ryansb/ansible_KVlo55/
ansible_module_iam.py\", line 379, in create_group\n    module.fail_json(changed=changed, msg=str(err))\nAttributeError: 'NoneType' object has no 
attribute 'fail_json'\n", "module_stdout": "", "msg": "MODULE FAILURE", "parsed": false}


AFTER: 
failed: [localhost] (item=103) => {"changed": true, "failed": true, "invocation": {"module_args": {"access_key_ids": null, "access_key_state": nul
l, "aws_access_key": null, "aws_secret_key": null, "ec2_url": null, "groups": null, "iam_type": "role", "key_count": 1, "name": "ryan-test-103", "
new_name": null, "new_path": null, "password": null, "path": "/", "profile": null, "region": null, "security_token": null, "state": "present", "up
date_password": "always", "validate_certs": true}, "module_name": "iam"}, "item": 103, "msg": "BotoServerError: 409 Conflict\n<ErrorResponse xmlns
=\"https://iam.amazonaws.com/doc/2010-05-08/\">\n  <Error>\n    <Type>Sender</Type>\n    <Code>LimitExceeded</Code>\n    <Message>Cannot exceed qu
ota for InstanceProfilesPerAccount: 100</Message>\n  </Error>\n  <RequestId>a14376d4-29ae-11e6-b5d1-69ac7f45cffc</RequestId>\n</ErrorResponse>\n"}
```
