### PR TITLE
Fix issue #3866

### DIFF
--- a/cloud/docker/docker_container.py
+++ b/cloud/docker/docker_container.py
@@ -1506,7 +1506,7 @@ class Container(DockerBaseClass):
         expected_env = dict()
         if image and image['ContainerConfig'].get('Env'):
             for env_var in image['ContainerConfig']['Env']:
-                parts = env_var.split('=')
+                parts = env_var.split('=', 1)
                 expected_env[parts[0]] = parts[1]
         if self.parameters.env:
             expected_env.update(self.parameters.env)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

docker_container
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 3bac945147) last updated 2016/06/04 00:59:10 (GMT -400)
  lib/ansible/modules/core: (devel 2bd8d78a8b) last updated 2016/06/04 01:00:29 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD b0aec50b9a) last updated 2016/06/01 10:11:03 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

When constructing the expected list of env variables, split strings on the first _=_ only.
