### PR TITLE
add project to os_router

### DIFF
--- a/cloud/openstack/os_router.py
+++ b/cloud/openstack/os_router.py
@@ -306,14 +306,14 @@ def main():
         module.fail_json(msg='shade is required for this module')
 
     if (module.params['project'] and
-            StrictVersion(shade.__version__) < StrictVersion('1.9.1')):
+            StrictVersion(shade.__version__) <= StrictVersion('1.9.0')):
         module.fail_json(msg="To utilize project, the installed version of"
-                             "the shade library MUST be >=1.9.1")
+                             "the shade library MUST be > 1.9.0")
 
     state = module.params['state']
     name = module.params['name']
     network = module.params['network']
-    project = module.params.pop('project')
+    project = module.params('project')
 
     if module.params['external_fixed_ips'] and not network:
         module.fail_json(msg='network is required when supplying external_fixed_ips')

--- a/cloud/openstack/os_router.py
+++ b/cloud/openstack/os_router.py
@@ -313,7 +313,7 @@ def main():
     state = module.params['state']
     name = module.params['name']
     network = module.params['network']
-    project = module.params('project')
+    project = module.params['project']
 
     if module.params['external_fixed_ips'] and not network:
         module.fail_json(msg='network is required when supplying external_fixed_ips')
@@ -384,9 +384,10 @@ def main():
                 # We need to detach all internal interfaces on a router before
                 # we will be allowed to delete it.
                 ports = cloud.list_router_interfaces(router, 'internal')
+                router_id = router['id']
                 for port in ports:
                     cloud.remove_router_interface(router, port_id=port['id'])
-                cloud.delete_router(name)
+                cloud.delete_router(router_id)
                 module.exit_json(changed=True)
 
     except shade.OpenStackCloudException as e:

--- a/cloud/openstack/os_router.py
+++ b/cloud/openstack/os_router.py
@@ -25,7 +25,7 @@ DOCUMENTATION = '''
 module: os_router
 short_description: Create or delete routers from OpenStack
 extends_documentation_fragment: openstack
-version_added: "2.0"
+version_added: "2.2"
 author: "David Shrewsbury (@Shrews)"
 description:
    - Create or Delete routers from OpenStack. Although Neutron allows

--- a/cloud/openstack/os_router.py
+++ b/cloud/openstack/os_router.py
@@ -25,7 +25,7 @@ DOCUMENTATION = '''
 module: os_router
 short_description: Create or delete routers from OpenStack
 extends_documentation_fragment: openstack
-version_added: "2.2"
+version_added: "2.0"
 author: "David Shrewsbury (@Shrews)"
 description:
    - Create or Delete routers from OpenStack. Although Neutron allows
@@ -64,6 +64,7 @@ options:
      type: string
      required: false
      default: None
+     version_added: "2.2"
    external_fixed_ips:
      description:
         - The IP address parameters for the external gateway network. Each

--- a/cloud/openstack/os_router.py
+++ b/cloud/openstack/os_router.py
@@ -253,8 +253,6 @@ def _build_kwargs(cloud, module, router, network, project_id):
 
     if project_id:
         kwargs['project_id'] = project_id
-    else:
-        kwargs['project_id'] = module.params['project']
 
     if module.params['external_fixed_ips']:
         kwargs['ext_fixed_ips'] = []


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

/ansible-modules-core/cloud/openstack/os_router.py
##### ANSIBLE VERSION

```
"ansible 2.1.0.0"
```
##### SUMMARY

add project to os_router module

For reference: https://groups.google.com/forum/#!topic/ansible-devel/3CplIn2WIfM

use case:
I am an admin of openstack infra managed mostly by ansible
in particular the admin manages the creation of new "project" that include the initial setup of the network
it includes creation of router for the project

depend on having openstack-infra/shade/ with commit
https://github.com/openstack-infra/shade/commit/c56d8e0f3858304f09469ebf8c728966ed0e810c

It has been merged to master
