### PR TITLE
Return reboot pending as true/false

### DIFF
--- a/windows/setup.ps1
+++ b/windows/setup.ps1
@@ -153,6 +153,9 @@ if ($winrm_cert_expiry)
     Set-Attr $result.ansible_facts "ansible_winrm_certificate_expires" $winrm_cert_expiry.NotAfter.ToString("yyyy-MM-dd HH:mm:ss")
 }
 
+$PendingReboot = Get-PendingRebootStatus
+Set-Attr $result.ansible_facts "ansible_reboot_pending" $PendingReboot
+
 # See if Facter is on the System Path
 Try {
     $facter_exe = Get-Command facter -ErrorAction Stop


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

setup.ps1 now returns ansible_reboot_pending (true/false). Using new module function from #16161 (https://github.com/ansible/ansible/pull/16161)
This PR should be merged after #16161 because of its dependency
##### ANSIBLE VERSION

2.2.0
##### SUMMARY

Discussed in https://github.com/ansible/ansible-modules-core/pull/3795
Sample gather_facts output:
`"ansible_reboot_pending":  false`
