### PR TITLE
Don't forcibly push loaded images to registry.

### DIFF
--- a/cloud/docker/docker_image.py
+++ b/cloud/docker/docker_image.py
@@ -268,7 +268,6 @@ class ImageManager(DockerBaseClass):
                 self.log("Building image %s" % image_name)
                 self.results['actions'].append("Built image %s from %s" % (image_name, self.path))
                 self.results['changed'] = True
-                self.push = True
                 if not self.check_mode:
                     self.results['image'] = self.build_image()
             elif self.load_path:

--- a/cloud/docker/docker_image.py
+++ b/cloud/docker/docker_image.py
@@ -191,11 +191,12 @@ EXAMPLES = '''
     name: registry.ansible.com/chouseknecht/sinatra
     tag: v1
     load_path: my_sinatra.tar
+    push: True
 '''
 
 RETURN = '''
 image:
-    description: Image inspection results for the affected image. 
+    description: Image inspection results for the affected image.
     returned: success
     type: complex
     sample: {}
@@ -236,7 +237,7 @@ class ImageManager(DockerBaseClass):
         self.state = parameters.get('state')
         self.tag = parameters.get('tag')
         self.http_timeout = parameters.get('http_timeout')
-        self.debug = parameters.get('debug') 
+        self.debug = parameters.get('debug')
         self.push = False
 
         if self.state in ['present', 'build']:
@@ -275,7 +276,6 @@ class ImageManager(DockerBaseClass):
                 if not os.path.isfile(self.load_path):
                     self.fail("Error loading image %s. Specified path %s does not exist." % (self.name,
                                                                                              self.load_path))
-                self.push = True
                 image_name = self.name
                 if self.tag:
                     image_name = "%s:%s" % (self.name, self.tag)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

docker_image
##### ANSIBLE VERSION

```
ansible 2.2.0
```
##### SUMMARY

There are use cases where the `docker_image` module is used to load packaged images on the target machine but there is no need to push that image to a registry, let alone forcibly and opaquely upload it to docker hub, which could happen if the target machine has docker.io configured credentials.

This PR removes the forcible push and requires an explicit request on the playbook task to do that by specifying `push: True`

Fixes #3763
