### PR TITLE
Clarify behaviour when state=present and no name is given

### DIFF
--- a/system/cron.py
+++ b/system/cron.py
@@ -52,7 +52,8 @@ options:
   name:
     description:
       - Description of a crontab entry or, if env is set, the name of environment variable.
-        Required if state=absent
+        Required if state=absent. Note that if name is not set and state=present, then a
+        new crontab entry will always be created, regardless of existing ones.
     default: null
     required: false
   user:


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Docs Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task  -->

system/cron
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 4625bd2de5) last updated 2016/06/09 22:15:38 (GMT +200)
  lib/ansible/modules/core: (topic/cron_noname_doc 679f4cba6d) last updated 2016/06/09 22:48:19 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 883ccbefe5) last updated 2016/06/09 22:34:58 (GMT +200)
  config file = 
  configured module search path = Default w/o overrides

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Clarify behaviour when state=present and name is unset, as discussed during Public Core Meeting.
