### PR TITLE
Fix #3906 - Enforce required minimum compose version.

### DIFF
--- a/cloud/docker/docker_service.py
+++ b/cloud/docker/docker_service.py
@@ -478,8 +478,8 @@ class ContainerManager(DockerBaseClass):
             self.options[u'--file'] = self.files
 
         if LooseVersion(compose_version) < LooseVersion(MINIMUM_COMPOSE_VERSION):
-            self.client.fail("Found docker-composer version %s installed. Minimum required version is %s. "
-                             "Upgrade docker-compose to a minimum version of %s" %
+            self.client.fail("Found docker-compose version %s. Minimum required version is %s. "
+                             "Upgrade docker-compose to a min version of %s." %
                              (compose_version, MINIMUM_COMPOSE_VERSION, MINIMUM_COMPOSE_VERSION))
 
         if not HAS_COMPOSE:

--- a/cloud/docker/docker_service.py
+++ b/cloud/docker/docker_service.py
@@ -404,12 +404,15 @@ actions:
 
 HAS_COMPOSE = True
 HAS_COMPOSE_EXC = None
+MINIMUM_COMPOSE_VERSION = '1.7.0'
 
 import yaml
+from distutils.version import LooseVersion
 
 from ansible.module_utils.basic import *
 
 try:
+    from compose import __version__ as compose_version
     from compose.cli.command import project_from_options
     from compose.service import ConvergenceStrategy
     from compose.cli.main import convergence_strategy_from_opts, build_action_from_opts, image_type_from_opt
@@ -473,6 +476,11 @@ class ContainerManager(DockerBaseClass):
 
         if self.files:
             self.options[u'--file'] = self.files
+
+        if LooseVersion(compose_version) < LooseVersion(MINIMUM_COMPOSE_VERSION):
+            self.client.fail("Found docker-composer version %s installed. Minimum required version is %s. "
+                             "Upgrade docker-compose to a minimum version of %s" %
+                             (compose_version, MINIMUM_COMPOSE_VERSION, MINIMUM_COMPOSE_VERSION))
 
         if not HAS_COMPOSE:
             self.client.fail("Unable to load docker-compose. Try `pip install docker-compose`. Error: %s" % HAS_COMPOSE_EXC)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

docker_service.py
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 734bbcb1d3) last updated 2016/06/10 19:52:14 (GMT +000)
  lib/ansible/modules/core: (detached HEAD 138430f116) last updated 2016/06/10 20:04:17 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD 883ccbefe5) last updated 2016/06/10 20:04:22 (GMT +000)
  config file = /home/vagrant/docker-testing/test/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

A min version of 1.7.0 is required. Otherwise, things like imports fail, as reported in issue #3906. This change tests the version installed and reports an error, if less than 1.7.0. Tested on Fedora 23 with the docker-compose rpm package installed, which provides Python compose module version 1.6.2. The updated docker_service module now reports a meaningful message telling the user to upgrade docker-compose:

```
$ ansible-playbook test.yml

PLAY [run docker_service tests] ************************************************

TASK [docker_service : Launch compose services] ********************************
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "Found docker-compose version 1.6.2. Minimum required version is 1.7.0. Upgrade docker-compose to a min version of 1.7.0."}

NO MORE HOSTS LEFT *************************************************************
 [WARNING]: Could not create retry file 'test.retry'.         Unable to create local directories(): [Errno 2] No such file or directory: ''


PLAY RECAP *********************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1
```

Uninstall docker-compose and installed 1.7.0 via pip

```
$ sudo dnf remove docker-compose
....
$ sudo pip install docker-compose==1.7.0
...
Successfully installed backports.ssl-match-hostname-3.5.0.1 cached-property-1.3.0 docker-compose-1.7.0 docker-py-1.8.1 dockerpty-0.4.1 docopt-0.6.2 enum34-1.1.6 functools32-3.2.3.post2 ipaddress-1.0.16 jsonschema-2.5.1 requests-2.7.0 texttable-0.8.4 websocket-client-0.37.0
```

And run the test...

```
$ ansible-playbook test.yml

PLAY [run docker_service tests] ************************************************

TASK [docker_service : Launch compose services] ********************************
changed: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0
```

The test playbook, listed below, executes the docker_service role (which will be added to ansible/docker-testing shortly):

```
- name: run docker_service tests
  hosts: localhost
  connection: local
  gather_facts: no
  become: yes
  roles:
    - role: docker_service
```
