### PR TITLE
Fix #3927 - only stop/kill running containers

### DIFF
--- a/cloud/docker/docker_container.py
+++ b/cloud/docker/docker_container.py
@@ -1616,7 +1616,8 @@ class ContainerManager(DockerBaseClass):
                     self.diff['image_different'] = True
                 self.log("differences")
                 self.log(differences, pretty_print=True)
-                self.container_stop(container.Id)
+                if container.running:
+                    self.container_stop(container.Id)
                 self.container_remove(container.Id)
                 new_container = self.container_create(self.parameters.image, self.parameters.create_parameters)
                 if new_container:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

docker_container.py
##### ANSIBLE VERSION

```
ansible 2.1.0.0 (stable-2.1 b950f75489) last updated 2016/06/05 20:09:05 (GMT -400)
  lib/ansible/modules/core: (devel 7d64264bcb) last updated 2016/06/04 02:54:14 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD b0aec50b9a) last updated 2016/06/01 10:11:03 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Check if a container is running before attempting to stop or kill it. Fixes issue #3927.
