### PR TITLE
iam_policy module policy document passing

### DIFF
--- a/cloud/amazon/iam_policy.py
+++ b/cloud/amazon/iam_policy.py
@@ -38,7 +38,7 @@ options:
   policy_document:
     description:
       - The path to the properly json formatted policy file
-      - A properly json formatted policy as string (mutually exclusive with C(policy_document), see https://github.com/ansible/ansible/issues/7005#issuecomment-42894813 on how to use it properly)
+      - A properly json formatted policy as string
     required: false
   state:
     description:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

iam_policy_module
##### ANSIBLE VERSION

```
ansible --version
ansible 2.1.0
```
##### SUMMARY

Cleaner way to pass policy document parameter.

I believe that it is more safer to pass the policy document this way.

Instead of having `policy_document` and `policy_json` as parameters which take different input format, why not have one which takes both format?

```
- name: Apply READ-ONLY policy to new groups that have been recently created
  iam_policy:
    iam_type: group
    iam_name: myiamname
    policy_name: "READ-ONLY"
    policy_document: readonlypolicy.json
    state: present
  with_items: new_groups.results

tasks:
- name: Create S3 policy from template
  iam_policy:
    iam_type: user
    iam_name: myiamname
    policy_name: "s3_limited_access_prefix"
    state: present
    policy_document: " {{ lookup( 'template', 's3_policy.json.j2') }} "
```

This also fixes the bug on #3404 #2801 .
