### PR TITLE
Fix the certificates bodies compare into iam_cert module

### DIFF
--- a/cloud/amazon/iam_cert.py
+++ b/cloud/amazon/iam_cert.py
@@ -158,10 +158,13 @@ def dup_check(module, iam, name, new_name, cert, orig_cert_names, orig_cert_bodi
                 except NameError:
                     continue
                 else:
-                    if orig_cert_bodies[c_index] == cert:
+                    # NOTE: remove the carriage return to strictly compare the cert bodies.
+                    slug_cert = cert.replace('\r', '')
+                    slug_orig_cert_bodies = orig_cert_bodies[c_index].replace('\r', '')
+                    if slug_orig_cert_bodies == slug_cert:
                         update=True
                         break
-                    elif orig_cert_bodies[c_index] != cert:
+                    elif slug_orig_cert_bodies != slug_cert:
                         module.fail_json(changed=False, msg='A cert with the name %s already exists and'
                                                            ' has a different certificate body associated'
                                                            ' with it. Certificates cannot have the same name' % i_name)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

cloud/amazon/iam_cert
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
```

When the certificate origin contains special caracter (e.g. carriage return) an error is raise.
However, the certificate body is the same.

I added a simply replace before the body comparaison.
###### tests
- lanch a task to upload a certificate with a carriage return
- re-launch the same task

Thanks
