### PR TITLE
docker_container: always removes volumes associated with container

### DIFF
--- a/cloud/docker/docker_container.py
+++ b/cloud/docker/docker_container.py
@@ -1776,10 +1776,10 @@ class ContainerManager(DockerBaseClass):
                 self.fail("Error starting container %s: %s" % (container_id, str(exc)))
         return self._get_container(container_id)
 
-    def container_remove(self, container_id, v=False, link=False, force=False):
-        volume_state = (True if self.parameters.keep_volumes else False)
-        self.log("remove container container:%s v:%s link:%s force%s" % (container_id, v, link, force))
-        self.results['actions'].append(dict(removed=container_id, volume_state=volume_state))
+    def container_remove(self, container_id, link=False, force=False):
+        volume_state = (not self.parameters.keep_volumes)  
+        self.log("remove container container:%s v:%s link:%s force%s" % (container_id, volume_state, link, force))
+        self.results['actions'].append(dict(removed=container_id, volume_state=volume_state, link=link, force=force))
         self.results['changed'] = True
         response = None
         if not self.check_mode:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

docker_container.py 
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 0e98ce11c4) last updated 2016/06/13 13:46:47 (GMT -400)
  lib/ansible/modules/core: (detached HEAD d6f01d0b4f) last updated 2016/06/13 13:48:02 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 43760b2c4a) last updated 2016/06/13 13:48:02 (GMT -400)
  config file = /Users/chouseknecht/projects/docker-testing/test/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Pass the correct value for _'remove the volumes associated with the container'_ to docker-py client.remove_volume(). Fixes issue #3941.
