### PR TITLE
docker_container detach not waiting on container to execute.

### DIFF
--- a/cloud/docker/docker_container.py
+++ b/cloud/docker/docker_container.py
@@ -802,7 +802,6 @@ class TaskParameters(DockerBaseClass):
             tty='tty',
             ports='ports',
             environment='env',
-            dns='dns_servers',
             name='name',
             entrypoint='entrypoint',
             cpu_shares='cpu_shares',


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

docker_container.py
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 0e98ce11c4) last updated 2016/06/13 13:46:47 (GMT -400)
  lib/ansible/modules/core: (detached HEAD d6f01d0b4f) last updated 2016/06/13 13:48:02 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 43760b2c4a) last updated 2016/06/13 13:48:02 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fix #3945. After starting a container the module fails to check the detach parameter. If detach is not true, it should wait on the container to finish executing, check the output and throw an error, if appropriate.
