### PR TITLE
Move call to filter_exit out of command execution block

### DIFF
--- a/network/eos/eos_template.py
+++ b/network/eos/eos_template.py
@@ -192,8 +192,8 @@ def main():
         else:
             commands = str(candidate).split('\n')
 
+    commands = filter_exit(commands)
     if commands:
-        commands = filter_exit(commands)
         if not module.check_mode:
             commands = [str(c).strip() for c in commands]
             response = module.configure(commands, replace=replace)


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

network/eos/eos_template.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel 27d065924f) last updated 2016/06/14 09:39:10 (GMT -600)
  lib/ansible/modules/core: (detached HEAD 1d0f408897) last updated 2016/06/14 09:39:17 (GMT -600)
  lib/ansible/modules/extras: (detached HEAD 146c969c07) last updated 2016/06/14 09:39:23 (GMT -600)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

The filter_exit function removes unnecessary code blocks from a template to avoid sending empty commands, so that if a template contains a single command followed by a single indented exit, this is considered a no-op and should be removed from the list of commands.

If the initial list of commands only contains exit blocks that will be filtered, the command list will ultimately become empty. When the filter_exit call is made from within the command execution block, the command list becomes empty, but the status is marked 'changed', returning an invalid result.

This PR moves the filter_exit call outside the command execution block. Thus, if the command list is completely emptied due to filtering, the command block does not execute, and the status remains unchanged.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```

```
