### PR TITLE
Fix azure_rm_virtualmachine to be able to remove vm.

### DIFF
--- a/cloud/azure/azure_rm_virtualmachine.py
+++ b/cloud/azure/azure_rm_virtualmachine.py
@@ -504,7 +504,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
         self.os_type = None
         self.os_disk_caching = None
         self.network_interface_names = None
-        self.remove_on_absent = set()
+        self.remove_on_absent = None
         self.tags = None
         self.force = None
         self.public_ip_allocation_method = None
@@ -526,13 +526,13 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
         super(AzureRMVirtualMachine, self).__init__(derived_arg_spec=self.module_arg_spec,
                                                     supports_check_mode=True)
 
-        # make sure options are lower case
-        self.remove_on_absent = set([resource.lower() for resource in  self.remove_on_absent])
-
     def exec_module(self, **kwargs):
 
         for key in self.module_arg_spec.keys() + ['tags']:
             setattr(self, key, kwargs[key])
+
+        # make sure options of remove_on_absent are lower case
+        self.remove_on_absent = set([resource.lower() for resource in  self.remove_on_absent])
 
         changed = False
         powerstate_change = None


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

azure_rm_virtualmachine
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

When I try to remove existing vm via azure_rm_virtualmachine, the module always raises exception.

Sample playbook:

``` yaml
- name: Remove Virtual Machine.
  resource_group: Testing
  name: vm01
  state: absent
```

Raised Exception:

```
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/var/folders/q4/84lmsm5n76j611z6fs2tdcgh0000gn/T/ansible_Zteyve/ansible_module_azure_rm_virtualmachine.py", line 1284, in <module>
    main()
  File "/var/folders/q4/84lmsm5n76j611z6fs2tdcgh0000gn/T/ansible_Zteyve/ansible_module_azure_rm_virtualmachine.py", line 1281, in main
    AzureRMVirtualMachine()
  File "/var/folders/q4/84lmsm5n76j611z6fs2tdcgh0000gn/T/ansible_Zteyve/ansible_module_azure_rm_virtualmachine.py", line 527, in __init__
    supports_check_mode=True)
  File "/var/folders/q4/84lmsm5n76j611z6fs2tdcgh0000gn/T/ansible_Zteyve/ansible_modlib.zip/ansible/module_utils/azure_rm_common.py", line 178, in __init__
  File "/var/folders/q4/84lmsm5n76j611z6fs2tdcgh0000gn/T/ansible_Zteyve/ansible_module_azure_rm_virtualmachine.py", line 854, in exec_module
    self.delete_vm(vm)
  File "/var/folders/q4/84lmsm5n76j611z6fs2tdcgh0000gn/T/ansible_Zteyve/ansible_module_azure_rm_virtualmachine.py", line 959, in delete_vm
    if self.remove_on_absent.intersection(set(['all','virtual_storage'])):
AttributeError: 'list' object has no attribute 'intersection'
```

In current azure_rm_virtualmachine, `remove_on_absent` list is converted to set after all execution are finished. And it doesn't make sense. I move this conversion to the top of the `exec_module` not to raise the exception.
