### PR TITLE
Use type=bool instead of choices for dup_ok

### DIFF
--- a/cloud/amazon/iam_cert.py
+++ b/cloud/amazon/iam_cert.py
@@ -232,7 +232,7 @@ def main():
         new_name=dict(default=None, required=False),
         path=dict(default='/', required=False),
         new_path=dict(default=None, required=False),
-        dup_ok=dict(default=False, required=False, choices=[False, True])
+        dup_ok=dict(default=False, required=False, type='bool'),
     )
     )
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME
- iam_cert
##### ANSIBLE VERSION

```
2.1.0.0
```
##### SUMMARY

IAM certificate creation failed with `value of dup_ok must be one of: False,True, got: False`
