### PR TITLE
docker_container - security_opts - unknown type <type 'list'> error

### DIFF
--- a/cloud/docker/docker_container.py
+++ b/cloud/docker/docker_container.py
@@ -1894,7 +1894,7 @@ def main():
         restart_policy=dict(type='str', choices=['no', 'on-failure', 'always', 'unless-stopped']),
         restart_retries=dict(type='int', default=0),
         shm_size=dict(type='str'),
-        security_opts=dict(type=list),
+        security_opts=dict(type='list'),
         state=dict(type='str', choices=['absent', 'present', 'started', 'stopped'], default='started'),
         stop_signal=dict(type='str'),
         stop_timeout=dict(type='int'),


### PR DESCRIPTION
Discard pull request #3955 and use this one instead.
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

docker_container.py
##### FEATURE NAME

security_opts
##### ANSIBLE VERSION

```
ansible 2.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/usr/share/ansible/modules/']
```
##### SUMMARY

I have been trying to use the "security_opts" option as outlined below.

```
security_opts:
  - "apparmor:unconfined"
  - "seccomp:unconfined"
```

When running Ansible I got the error:

**FAILED! => {"changed": false, "failed": true, "msg": "implementation error: unknown type <type 'list'> requested for security_opts"}**

Before fix: => Error

```
FAILED! => {"changed": false, "failed": true, "msg": "implementation error: unknown type <type 'list'> requested for security_opts"}
```

After fix: => No Error
Verified with Docker inspect where it correctly shows:

```
"SecurityOpt": [
  "apparmor:unconfined",
  "seccomp:unconfined"
],
```

Bug was caused by missing single quotations.
