### PR TITLE
Fixes incorrect key name protocols -> protocol

### DIFF
--- a/cloud/amazon/ec2_elb_lb.py
+++ b/cloud/amazon/ec2_elb_lb.py
@@ -313,7 +313,7 @@ EXAMPLES = """
       - us-east-1a
       - us-east-1d
     listeners:
-      - protocols: http
+      - protocol: http
       - load_balancer_port: 80
       - instance_port: 80
 
@@ -327,7 +327,7 @@ EXAMPLES = """
       - us-east-1a
       - us-east-1d
     listeners:
-      - protocols: http
+      - protocol: http
       - load_balancer_port: 80
       - instance_port: 80
     stickiness:
@@ -345,7 +345,7 @@ EXAMPLES = """
       - us-east-1a
       - us-east-1d
     listeners:
-      - protocols: http
+      - protocol: http
       - load_balancer_port: 80
       - instance_port: 80
     stickiness:
@@ -363,7 +363,7 @@ EXAMPLES = """
       - us-east-1a
       - us-east-1d
     listeners:
-      - protocols: http
+      - protocol: http
       - load_balancer_port: 80
       - instance_port: 80
     tags:
@@ -381,7 +381,7 @@ EXAMPLES = """
       - us-east-1a
       - us-east-1d
     listeners:
-      - protocols: http
+      - protocol: http
       - load_balancer_port: 80
       - instance_port: 80
     tags: {}


### PR DESCRIPTION
##### ISSUE TYPE

Docs Pull Request
##### COMPONENT NAME

`cloud/amazon/ec2_elb_lb`
##### ANSIBLE VERSION

```
ansible 2.2.0
  config file = /Users/adambutler/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fixes a documentation in for the `ec2_elb_lb` module. Running the example as is raises the following exception -

```
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/var/folders/sc/x51lj8352b3g94kbwqx57sz00000gn/T/ansible_A3Y_8G/ansible_module_ec2_elb_lb.py", line 1342, in <module>
    main()
  File "/var/folders/sc/x51lj8352b3g94kbwqx57sz00000gn/T/ansible_A3Y_8G/ansible_module_ec2_elb_lb.py", line 1326, in main
    elb_man.ensure_ok()
  File "/var/folders/sc/x51lj8352b3g94kbwqx57sz00000gn/T/ansible_A3Y_8G/ansible_module_ec2_elb_lb.py", line 410, in _do_op
    return op(*args, **kwargs)
  File "/var/folders/sc/x51lj8352b3g94kbwqx57sz00000gn/T/ansible_A3Y_8G/ansible_module_ec2_elb_lb.py", line 474, in ensure_ok
    self._create_elb()
  File "/var/folders/sc/x51lj8352b3g94kbwqx57sz00000gn/T/ansible_A3Y_8G/ansible_module_ec2_elb_lb.py", line 695, in _create_elb
    listeners = [self._listener_as_tuple(l) for l in self.listeners]
  File "/var/folders/sc/x51lj8352b3g94kbwqx57sz00000gn/T/ansible_A3Y_8G/ansible_module_ec2_elb_lb.py", line 802, in _listener_as_tuple
    str(listener['protocol'].upper()),
KeyError: 'protocol'
```
