### PR TITLE
Add retries to apt_key with keyserver, fixes #3986

### DIFF
--- a/packaging/os/apt_key.py
+++ b/packaging/os/apt_key.py
@@ -171,7 +171,14 @@ def import_key(module, keyring, keyserver, key_id):
         cmd = "apt-key --keyring %s adv --keyserver %s --recv %s" % (keyring, keyserver, key_id)
     else:
         cmd = "apt-key adv --keyserver %s --recv %s" % (keyserver, key_id)
-    (rc, out, err) = module.run_command(cmd, check_rc=True)
+    for retry in xrange(5):
+        (rc, out, err) = module.run_command(cmd)
+        if rc == 0:
+            break
+    else:
+        # Out of retries
+        module.fail_json(cmd=cmd, msg="error fetching key from keyserver: %s" % keyserver,
+                         rc=rc, stdout=out, stderr=err)
     return True
 
 def add_key(module, keyfile, keyring, data=None):


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

packaging/os/apt_key
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Adds 5 retries to apt_key --recv --keyserver $KEYSERVER because public servers are frequently unavailable.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

Fixes #3986 

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
Command:
ansible node1  -u vagrant -b --become-user=root -i inventory.cfg -m apt_key -a "keyserver=hkp://p80.pool.sks-keyservers.net:80 id=58118E89F3A912897C070ADBF76221572C52609D"

Before:
id=58118E89F3A912897C070ADBF76221572C52609D"
failed: [node1] (item=58118E89F3A912897C070ADBF76221572C52609D) => {"cmd": "apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv 2C52609D", "failed": true, "item": "58118E89F3A912897C070ADBF76221572C52609D", "msg": "gpg: requesting key 2C52609D from hkp server p80.pool.sks-keyservers.net\ngpg: no valid OpenPGP data found.\ngpg: Total number processed: 0\ngpg: keyserver communications error: keyserver helper general error\ngpg: keyserver communications error: unknown pubkey algorithm\ngpg: keyserver receive failed: unknown pubkey algorithm", "rc": 2, "stderr": "gpg: requesting key 2C52609D from hkp server p80.pool.sks-keyservers.net\ngpg: no valid OpenPGP data found.\ngpg: Total number processed: 0\ngpg: keyserver communications error: keyserver helper general error\ngpg: keyserver communications error: unknown pubkey algorithm\ngpg: keyserver receive failed: unknown pubkey algorithm\n", "stdout": "Executing: /tmp/tmp.s0hxEnoMlf/gpg.1.sh --keyserver\nhkp://p80.pool.sks-keyservers.net:80\n--recv\n2C52609D\ngpgkeys: key 2C52609D can't be retrieved\n", "stdout_lines": ["Executing: /tmp/tmp.s0hxEnoMlf/gpg.1.sh --keyserver", "hkp://p80.pool.sks-keyservers.net:80", "--recv", "2C52609D", "gpgkeys: key 2C52609D can't be retrieved"]}

After:
node1 | SUCCESS => {
    "changed": true
}

```

Public SKS gpg servers frequently are unavailable, but a retry
can mitigate frequent failures.
