### PR TITLE
[stable-2.1] Fix default perm for apt_repo files.

### DIFF
--- a/packaging/os/apt_repository.py
+++ b/packaging/os/apt_repository.py
@@ -451,7 +451,7 @@ def main():
         argument_spec=dict(
             repo=dict(required=True),
             state=dict(choices=['present', 'absent'], default='present'),
-            mode=dict(required=False, default=0644),
+            mode=dict(required=False, default='0644'),
             update_cache = dict(aliases=['update-cache'], type='bool', default='yes'),
             filename=dict(required=False, default=None),
             # this should not be needed, but exists as a failsafe


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

packaging/os/apt_repository.py
##### ANSIBLE VERSION

2.1
##### SUMMARY

The apt_repository module mode arg defaults to 0644. For 2.1, a value of
0644 for an untyped arg results in the string '0644' and converted to decimal
along the way.  Octal 644 == Dec 420, so apt repos would then get created
with the octal perm of 0420, which is weird.

Fixes #16370
