### PR TITLE
Apt repo fixes #16370 (see #4072 as well for devel fix)

### DIFF
--- a/packaging/os/apt_repository.py
+++ b/packaging/os/apt_repository.py
@@ -451,7 +451,7 @@ def main():
         argument_spec=dict(
             repo=dict(required=True),
             state=dict(choices=['present', 'absent'], default='present'),
-            mode=dict(required=False, default=0644),
+            mode=dict(required=False, default='0644'),
             update_cache = dict(aliases=['update-cache'], type='bool', default='yes'),
             filename=dict(required=False, default=None),
             # this should not be needed, but exists as a failsafe

--- a/packaging/os/apt_repository.py
+++ b/packaging/os/apt_repository.py
@@ -108,6 +108,7 @@ except ImportError:
     distro = None
     HAVE_PYTHON_APT = False
 
+DEFAULT_SOURCES_PERM = int('0644', 8)
 
 VALID_SOURCE_TYPES = ('deb', 'deb-src')
 
@@ -279,7 +280,7 @@ class SourcesList(object):
 
                 # allow the user to override the default mode
                 if filename in self.new_repos:
-                    this_mode = self.module.params['mode']
+                    this_mode = self.module.params.get('mode', DEFAULT_SOURCES_PERM)
                     self.module.set_mode_if_different(filename, this_mode, False)
             else:
                 del self.files[filename]
@@ -451,7 +452,7 @@ def main():
         argument_spec=dict(
             repo=dict(required=True),
             state=dict(choices=['present', 'absent'], default='present'),
-            mode=dict(required=False, default='0644'),
+            mode=dict(required=False, type='raw'),
             update_cache = dict(aliases=['update-cache'], type='bool', default='yes'),
             filename=dict(required=False, default=None),
             # this should not be needed, but exists as a failsafe
@@ -465,6 +466,8 @@ def main():
     repo = module.params['repo']
     state = module.params['state']
     update_cache = module.params['update_cache']
+    mode = module.params.get('mode', None)
+
     sourceslist = None
 
     if not HAVE_PYTHON_APT:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

packaging/os/apt_repository.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.1.0 (stable-2.1 4d4bbcbb33) last updated 2016/06/20 18:17:18 (GMT +000)
  lib/ansible/modules/core: (detached HEAD b746f047ed) last updated 2016/06/20 18:18:25 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD f7a99e9433) last updated 2016/06/20 18:17:54 (GMT +000)
  config file = 
  configured module search path = Default w/o overrides


```
##### SUMMARY

A different potential fix for https://github.com/ansible/ansible/issues/16370

This is changing apt_repository.py's handling of it's 'mode' argument to be more like the
mode in the common_file_args. 

ie, mode's type='raw', with no default value for the arg, but with a default value in the
python module, set via int(0644, 8) 
