### PR TITLE
Fix compose_version error. Check has compose before checking version.

### DIFF
--- a/cloud/docker/docker_service.py
+++ b/cloud/docker/docker_service.py
@@ -484,13 +484,13 @@ class ContainerManager(DockerBaseClass):
         if self.files:
             self.options[u'--file'] = self.files
 
+        if not HAS_COMPOSE:
+            self.client.fail("Unable to load docker-compose. Try `pip install docker-compose`. Error: %s" % HAS_COMPOSE_EXC)
+
         if LooseVersion(compose_version) < LooseVersion(MINIMUM_COMPOSE_VERSION):
             self.client.fail("Found docker-compose version %s. Minimum required version is %s. "
                              "Upgrade docker-compose to a min version of %s." %
                              (compose_version, MINIMUM_COMPOSE_VERSION, MINIMUM_COMPOSE_VERSION))
-
-        if not HAS_COMPOSE:
-            self.client.fail("Unable to load docker-compose. Try `pip install docker-compose`. Error: %s" % HAS_COMPOSE_EXC)
 
         self.log("options: ")
         self.log(self.options, pretty_print=True)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel b7f9037b5b) last updated 2016/06/21 00:56:06 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 343c3ecfb9) last updated 2016/06/21 00:56:17 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 9392943915) last updated 2016/06/21 00:56:17 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Check that compose module imported before attempting to check the version. Fixes #3978.
