### PR TITLE
Add jinja2 way of specifying the md5'd password

### DIFF
--- a/database/postgresql/postgresql_user.py
+++ b/database/postgresql/postgresql_user.py
@@ -45,6 +45,7 @@ options:
     description:
       - set the user's password, before 1.4 this was required.
       - "When passing an encrypted password, the encrypted parameter must also be true, and it must be generated with the format C('str[\\"md5\\"] + md5[ password + username ]'), resulting in a total of 35 characters.  An easy way to do this is: C(echo \\"md5`echo -n \\"verysecretpasswordJOE\\" | md5`\\"). Note that if encrypted is set, the stored password will be hashed whether or not it is pre-encrypted."
+      - this may also be done inside Ansible with Jinja2':' {{'md5' + (mypasswordvar|md5)}}
     required: false
     default: null
   db:


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

postgresql_user.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
1.9.5
```
##### SUMMARY

The md5 method given is not Ansibleonic. My way is nicer.
