### PR TITLE
Fix for docker container labels

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -1301,9 +1301,12 @@ class DockerManager(object):
                 expected_labels[name] = str(value)
 
             actual_labels = {}
-            for container_label in container['Config']['Labels'] or []:
-                name, value = container_label.split('=', 1)
-                actual_labels[name] = value
+            if type(container['Config']['Labels']) is dict:
+                actual_labels = container['Config']['Labels']
+            else:
+                for container_label in container['Config']['Labels'] or []:
+                    name, value = container_label.split('=', 1)
+                    actual_labels[name] = value
 
             if actual_labels != expected_labels:
                 self.reload_reasons.append('labels {0} => {1}'.format(actual_labels, expected_labels))

--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -1301,7 +1301,7 @@ class DockerManager(object):
                 expected_labels[name] = str(value)
 
             actual_labels = {}
-            if type(container['Config']['Labels']) is dict:
+            if isinstance(container['Config']['Labels'], dict):
                 actual_labels = container['Config']['Labels']
             else:
                 for container_label in container['Config']['Labels'] or []:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

cloud/docker/docker.py
##### ANSIBLE VERSION

```
$ ansible --version                                                                                                                                                                       [15:02:35]
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

If a container have labels, when reloaded, the docker module can't parse the new format.
From PR https://github.com/ansible/ansible-modules-core/pull/3005

"This is because the labels data structure changed from docker api version 1.17 to 1.18. It was a list but it became a dictionary."

This commit allows both list and dictionary versions of the api to beparsed correctly.
Fix #3006, updated PR https://github.com/ansible/ansible-modules-core/pull/3005

Before:

```
fatal: [XXXX]: FAILED! => {"changed": false, "failed": true, "invocation": {"module_name": "docker"}, "module_stderr": "OpenSSH_7.2p2, OpenSSL 1.0.2h  3 May 2016\r\ndebug1: Reading configuration data /home/XXX/.ssh/config\r\ndebug1: Reading configuration data /etc/ssh/ssh_config\r\ndebug1: auto-mux: Trying existing master\r\ndebug2: fd 3 setting O_NONBLOCK\r\ndebug2: mux_client_hello_exchange: master version 4\r\ndebug3: mux_client_forwards: request forwardings: 0 local, 0 remote\r\ndebug3: mux_client_request_session: entering\r\ndebug3: mux_client_request_alive: entering\r\ndebug3: mux_client_request_alive: done pid = 32380\r\ndebug3: mux_client_request_session: session request sent\r\ndebug1: mux_client_request_session: master session id: 2\r\ndebug3: mux_client_read_packet: read header failed: Broken pipe\r\ndebug2: Received exit status from master 0\r\nShared connection to 127.0.0.1 closed.\r\n", "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_ANEfbd/ansible_module_docker.py\", line 1978, in <module>\r\n    main()\r\n  File \"/tmp/ansible_ANEfbd/ansible_module_docker.py\", line 1948, in main\r\n    reloaded(manager, containers, count, name)\r\n  File \"/tmp/ansible_ANEfbd/ansible_module_docker.py\", line 1798, in reloaded\r\n    for container in manager.get_differing_containers():\r\n  File \"/tmp/ansible_ANEfbd/ansible_module_docker.py\", line 1311, in get_differing_containers\r\n    name, value = container_label.split('=', 1)\r\nValueError: need more than 1 value to unpack\r\n", "msg": "MODULE FAILURE", "parsed": false}
```

After:

```
"reload_reasons": "labels {u'build-date': u'2016-03-31', u'vendor': u'CentOS', u'name': u'CentOS Base Image', u'license': u'GPLv2'} => {}", "summary": {"created": 1, "killed": 0, "pulled": 0, "removed": 1, "restarted": 0, "started": 1, "stopped": 1}}
```
