### PR TITLE
Fixing nxos_vrrp status bug

### DIFF
--- a/network/nxos/nxos_vrrp.py
+++ b/network/nxos/nxos_vrrp.py
@@ -124,7 +124,8 @@ changed:
 def execute_config_command(commands, module):
     try:
         module.configure(commands)
-    except ShellError, clie:
+    except ShellError:
+        clie = get_exception()
         module.fail_json(msg='Error sending CLI commands',
                          error=str(clie), commands=commands)
 
@@ -157,7 +158,8 @@ def execute_show(cmds, module, command_type=None):
             response = module.execute(cmds, command_type=command_type)
         else:
             response = module.execute(cmds)
-    except ShellError, clie:
+    except ShellError:
+        clie = get_exception()
         module.fail_json(msg='Error sending {0}'.format(command),
                          error=str(clie))
     return response

--- a/network/nxos/nxos_vrrp.py
+++ b/network/nxos/nxos_vrrp.py
@@ -21,7 +21,7 @@ DOCUMENTATION = '''
 ---
 
 module: nxos_vrrp
-version_added: "2.1"
+version_added: "2.2"
 short_description: Manages VRRP configuration on NX-OS switches
 description:
     - Manages VRRP configuration on NX-OS switches
@@ -123,7 +123,7 @@ changed:
 
 def execute_config_command(commands, module):
     try:
-        module.configure(commands)
+        module.config(commands)
     except ShellError:
         clie = get_exception()
         module.fail_json(msg='Error sending CLI commands',
@@ -152,12 +152,12 @@ def get_cli_body_ssh_vrrp(command, response, module):
     return body
 
 
-def execute_show(cmds, module, command_type=None):
+def execute_show(cmds, module, output=None):
     try:
         if command_type:
-            response = module.execute(cmds, command_type=command_type)
+            response = module.cli(cmds, output=output)
         else:
-            response = module.execute(cmds)
+            response = module.cli(cmds)
     except ShellError:
         clie = get_exception()
         module.fail_json(msg='Error sending {0}'.format(command),
@@ -165,7 +165,7 @@ def execute_show(cmds, module, command_type=None):
     return response
 
 
-def execute_show_command(command, module, command_type='cli_show'):
+def execute_show_command(command, module, output='json'):
     if module.params['transport'] == 'cli':
         command += ' | json'
         cmds = [command]
@@ -173,7 +173,7 @@ def execute_show_command(command, module, command_type='cli_show'):
         body = get_cli_body_ssh_vrrp(command, response, module)
     elif module.params['transport'] == 'nxapi':
         cmds = [command]
-        body = execute_show(cmds, module, command_type=command_type)
+        body = execute_show(cmds, module, output=output)
 
     return body
 
@@ -246,7 +246,7 @@ def get_interface_mode(interface, intf_type, module):
 
 def get_vrr_status(group, module, interface):
     command = 'show run all | section interface.{0}$'.format(interface)
-    body = execute_show_command(command, module, command_type='cli_show_ascii')[0]
+    body = execute_show_command(command, module, output='text')[0]
     vrf_index = None
     admin_state = 'shutdown'
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

nxos_vrrp
##### ANSIBLE VERSION

```
ansible 2.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = xxx
```
##### SUMMARY

Added a param to specify the VRRP process status, which would always be 'shutdown' by default. 
