### PR TITLE
Fixed delete statement for juniper_config.py #4007 #3984

### DIFF
--- a/network/junos/junos_config.py
+++ b/network/junos/junos_config.py
@@ -132,8 +132,8 @@ def diff_config(candidate, config):
 
         elif action == 'delete':
             for cfg in config:
-                if cfg.startswith(cfgline):
-                    updates.add(cfgline)
+                if cfg[4:].startswith(cfgline):
+                    updates.add(line)
 
     return list(updates)
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

network/junos/junos_config.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Changed if-loop so it checks towards current configuration correctly.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Before:

```
PLAY [Create vlan] *************************************************************

TASK [Delete vlan on Juniper Junos] ********************************************
ok: [netlab-sw01-a.osl.basefarm.net]

PLAY RECAP *********************************************************************
netlab-sw01-a.osl.basefarm.net : ok=1    changed=0    unreachable=0    failed=0   
```

After:

```
PLAY [Create vlan] *************************************************************

TASK [Delete vlan on Juniper Junos] ********************************************
changed: [netlab-sw01-a.osl.basefarm.net]

PLAY RECAP *********************************************************************
netlab-sw01-a.osl.basefarm.net : ok=1    changed=1    unreachable=0    failed=0  
```
