### PR TITLE
enable the use of configure mode for junos

### DIFF
--- a/network/junos/junos_config.py
+++ b/network/junos/junos_config.py
@@ -39,6 +39,8 @@ options:
         exclusive.
     required: false
     default: None
+    choices: ['private', 'dynamic', 'batch', 'exclusive']
+    version_added: "2.2"
   lines:
     description:
       - The path to the config source.  The source can be either a

--- a/network/junos/junos_config.py
+++ b/network/junos/junos_config.py
@@ -32,6 +32,13 @@ description:
     configuration and only changes are pushed to the device.
 extends_documentation_fragment: junos
 options:
+  mode:
+    description:
+      - By default you'll work in a shared candidate configuration. The 
+        C(mode) argument can be set to either private, dynamic, batch or
+        exclusive.
+    required: false
+    default: None
   lines:
     description:
       - The path to the config source.  The source can be either a
@@ -140,6 +147,7 @@ def diff_config(candidate, config):
 def main():
 
     argument_spec = dict(
+        mode=dict(default=None, choices=['private', 'dynamic', 'batch', 'exclusive']),
         lines=dict(type='list'),
         rollback=dict(type='int'),
         zeroize=dict(default=False, type='bool'),
@@ -167,6 +175,7 @@ def main():
     else:
         action = 'merge'
 
+    mode = module.params['mode']
     lines = module.params['lines']
     commit = not module.check_mode
 
@@ -179,7 +188,7 @@ def main():
         if updates:
             updates = '\n'.join(updates)
             diff = module.load_config(updates, action=action, comment=comment,
-                    format='set', commit=commit, confirm=confirm)
+                    format='set', commit=commit, confirm=confirm, mode=mode)
 
             if diff:
                 results['changed'] = True


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

network/junos/junos_config.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Requires ansible pull-request #16434
This will enable use of mode in playbooks for junos_config.py load_config module.
mode is None by default. This is the same as previous behaviour.
Can be set to private, dynamic, batch or exclusive.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

netconf debug on junos switch will show up following on incoming request:

```
<open-configuration><private/></open-configuration>
```
