### PR TITLE
Fix container option to be parsed when comparing values from input option `stdin_open`

### DIFF
--- a/cloud/docker/_docker.py
+++ b/cloud/docker/_docker.py
@@ -1343,7 +1343,7 @@ class DockerManager(object):
             # STDIN_OPEN
 
             expected_stdin_open = self.module.params.get('stdin_open')
-            actual_stdin_open = container['Config']['AttachStdin']
+            actual_stdin_open = container['Config']['OpenStdin']
             if actual_stdin_open != expected_stdin_open:
                 self.reload_reasons.append('stdin_open ({0} => {1})'.format(actual_stdin_open, expected_stdin_open))
                 differing.append(container)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

cloud/docker
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.0.2.0
  config file = /users/pikachuexe/projects/spacious/spacious-rails/ansible.cfg
  configured module search path = ./ansible/library
```

This applied to all versions with docker module supporting "reloaded"
This is tested on the version above but should apply to all versions supporting `stdin_open`
I will submit another PR for 2.0 if this is merged.
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Read `OpenStdin` instead of `AttachStdin` when comparing with input in option `stdin_open`
The module `cloud/docker_container` is already using the [correct one](https://github.com/ansible/ansible-modules-core/blob/devel/cloud/docker/docker_container.py#L1163)

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
Before:
"changed": true, "item": "1", "msg": "removed 1 container, stopped 1 container, started 1 container, created 1 container.", "reload_reasons": "stdin_open (False => True)", "summary": {"created": 1, "killed": 0, "pulled": 0, "removed": 1, "restarted": 0, "started": 1, "stopped": 1}

After:
"changed": false, "item": "1", "msg": "No action taken.", "reload_reasons": null, "summary": {"created": 0, "killed": 0, "pulled": 0, "removed": 0, "restarted": 0, "started": 0, "stopped": 0}
```
