### PR TITLE
Fix inconsistent default value for network mode when `net` unspecified

### DIFF
--- a/cloud/docker/_docker.py
+++ b/cloud/docker/_docker.py
@@ -949,7 +949,7 @@ class DockerManager(object):
             'publish_all_ports': self.module.params.get('publish_all_ports'),
             'privileged': self.module.params.get('privileged'),
             'links': self.links,
-            'network_mode': self.module.params.get('net'),
+            'network_mode': self.module.params.get('net') or 'bridge',
         }
 
         optionals = {}


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

cloud/docker
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.0.2.0
  config file = /users/pikachuexe/projects/spacious/spacious-rails/ansible.cfg
  configured module search path = ./ansible/library
```

This applied to all versions with docker module supporting `net` and `bridge`, which should be 2.0+
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

The default value of network mode being used is inconsistent when `net` is unspecified
For actual container it uses `None` (in python), which translates to `default` in docker.
But in comparison it uses `bridge`.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
Before:
"reload_reasons": "net (default => bridge)"

After:
"reload_reasons": null
```
