### PR TITLE
Update docs to indicate ec2_asg state defaults to present

### DIFF
--- a/cloud/amazon/ec2_asg.py
+++ b/cloud/amazon/ec2_asg.py
@@ -26,7 +26,7 @@ options:
   state:
     description:
       - register or deregister the instance
-    required: true
+    required: false
     choices: ['present', 'absent']
     default: present
   name:

--- a/cloud/amazon/ec2_asg.py
+++ b/cloud/amazon/ec2_asg.py
@@ -28,6 +28,7 @@ options:
       - register or deregister the instance
     required: true
     choices: ['present', 'absent']
+    default: present
   name:
     description:
       - Unique name for group to be created or deleted


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

ec2_asg_module
##### ANSIBLE VERSION

N/A
##### SUMMARY

The `Options` table indicates that `state` is a required parameter with no default values.

The given examples do not use a `state` parameter and [the code indicates it defaults to 'present'](https://github.com/ansible/ansible-modules-core/blob/devel/cloud/amazon/ec2_asg.py#L790).

This MR hopefully fixes Issue #4016.
