### PR TITLE
Fix labels input is used in environment not supporting it

### DIFF
--- a/cloud/docker/_docker.py
+++ b/cloud/docker/_docker.py
@@ -1624,7 +1624,6 @@ class DockerManager(object):
                   'ports':        self.exposed_ports,
                   'volumes':      self.volumes,
                   'environment':  self.environment,
-                  'labels':       self.module.params.get('labels'),
                   'hostname':     self.module.params.get('hostname'),
                   'domainname':   self.module.params.get('domainname'),
                   'detach':       self.module.params.get('detach'),
@@ -1635,6 +1634,8 @@ class DockerManager(object):
                   'cpu_shares':   self.module.params.get('cpu_shares'),
                   'user':         self.module.params.get('docker_user'),
                   }
+        if self.ensure_capability('labels', fail=False):
+            params['labels'] = self.module.params.get('labels')
         if self.ensure_capability('host_config', fail=False):
             params['host_config'] = self.create_host_config()
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

`cloud/docker`
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
  config file = /users/pikachuexe/projects/spacious/spacious-rails/ansible.cfg
  configured module search path = ['./ansible/library']
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Labels is passed into `docker-py` without checking it's supported or not
Causing error when calling `create_container`

This PR make the module check the env before using it (with existing function)
The data is already there, but mistakenly not used

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

See #4047 
