### PR TITLE
also match on tabs in ini_file

### DIFF
--- a/files/ini_file.py
+++ b/files/ini_file.py
@@ -110,16 +110,16 @@ import os
 
 def match_opt(option, line):
   option = re.escape(option)
-  return re.match('%s *=' % option, line) \
-    or re.match('# *%s *=' % option, line) \
-    or re.match('; *%s *=' % option, line)
+  return re.match('%s( |\t)*=' % option, line) \
+    or re.match('# *%s( |\t)*=' % option, line) \
+    or re.match('; *%s( |\t)*=' % option, line)
 
 # ==============================================================
 # match_active_opt
 
 def match_active_opt(option, line):
   option = re.escape(option)
-  return re.match('%s *=' % option, line)
+  return re.match('%s( |\t)*=' % option, line)
 
 # ==============================================================
 # do_ini


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

ini_file
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

When using the `ini_file` module to manage, e.g. `~/.gitconfig` which is indented using tabs when managed via `git config` an error is encountered, because `ini_file` doesn't recongnize the keys, because of the tab indentation. This pull requests also adds tabs to the key matching logic and fixes #106.

 (Fixes #106)
