### PR TITLE
Fix default perm for apt_repo files.

### DIFF
--- a/packaging/os/apt_repository.py
+++ b/packaging/os/apt_repository.py
@@ -108,6 +108,7 @@ except ImportError:
     distro = None
     HAVE_PYTHON_APT = False
 
+DEFAULT_SOURCES_PERM = int('0644', 8)
 
 VALID_SOURCE_TYPES = ('deb', 'deb-src')
 
@@ -280,7 +281,7 @@ class SourcesList(object):
 
                 # allow the user to override the default mode
                 if filename in self.new_repos:
-                    this_mode = self.module.params['mode']
+                    this_mode = self.module.params.get('mode', DEFAULT_SOURCES_PERM)
                     self.module.set_mode_if_different(filename, this_mode, False)
             else:
                 del self.files[filename]
@@ -452,7 +453,7 @@ def main():
         argument_spec=dict(
             repo=dict(required=True),
             state=dict(choices=['present', 'absent'], default='present'),
-            mode=dict(required=False, default=int('0644',8)),
+            mode=dict(required=False, type='raw'),
             update_cache = dict(aliases=['update-cache'], type='bool', default='yes'),
             filename=dict(required=False, default=None),
             # this should not be needed, but exists as a failsafe
@@ -466,6 +467,8 @@ def main():
     repo = module.params['repo']
     state = module.params['state']
     update_cache = module.params['update_cache']
+    # Note: mode is referenced in SourcesList class via the passed in module (self here)
+
     sourceslist = None
 
     if not HAVE_PYTHON_APT:


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

packaging/os/apt_repository.py
##### ANSIBLE VERSION

ansible 2.2.0 (devel 7c690f04e2) last updated 2016/06/29 11:45:49 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 2f0f04437b) last updated 2016/06/29 10:48:47 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD d25c487ac8) last updated 2016/06/29 10:48:48 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides
##### SUMMARY

This a patch to apt_repository, originally made against the stable 2.1 branch where the issue https://github.com/ansible/ansible/issues/16370 shows up. 
The stable-2.1 pr is at https://github.com/ansible/ansible-modules-core/pull/3991

That particular bug only showed up against 2.1, because devel/2.2 has commit 
https://github.com/ansible/ansible-modules-core/commit/75715a1b7343d5537839ee05ac62f2e40751f915  

In addition to some py2/py3 changes, that commit also changed apt_repository's module arg spec:

``` diff
-            mode=dict(required=False, default=0644),
+            mode=dict(required=False, default=int('0644',8)),
```

But discussed with @abadger and decided that making the 'mode' arg here work like the mode arg in the common file arg spec makes more sense. 

So while https://github.com/ansible/ansible/issues/16370 doesn't manifest with the devel/2.2 branch, the module still needs to be updated. Then we can backport/cherrypick from devel to stable-2.1

(original commit message)

Change the file mode arg to 'raw' ala file args

Following the file_common_args model, change the
type of the 'mode' arg here to type='raw' with no
default arg value.

The default mode for file creation is the module
constant DEFAULT_SOURCES_PER, and is used if no
mode os specified.

A default mode of 0644 (and not specified as int or str)
would get converted to an octal 420, resulting in the
sources file being created with mode '0420' instead of '0644'

Fixes #16370
