### PR TITLE
Do not hardcode default ssh key size for RSA

### DIFF
--- a/system/user.py
+++ b/system/user.py
@@ -150,7 +150,7 @@ options:
               This will B(not) overwrite an existing SSH key.
     ssh_key_bits:
         required: false
-        default: 2048
+        default: default set by ssh-keygen
         version_added: "0.9"
         description:
             - Optionally specify number of bits in SSH key to create.
@@ -603,8 +603,9 @@ class User(object):
         cmd = [self.module.get_bin_path('ssh-keygen', True)]
         cmd.append('-t')
         cmd.append(self.ssh_type)
-        cmd.append('-b')
-        cmd.append(self.ssh_bits)
+        if self.ssh_bits > 0:
+            cmd.append('-b')
+            cmd.append(self.ssh_bits)
         cmd.append('-C')
         cmd.append(self.ssh_comment)
         cmd.append('-f')
@@ -2026,7 +2027,7 @@ class HPUX(User):
 
 def main():
     ssh_defaults = {
-            'bits': '2048',
+            'bits': 0,
             'type': 'rsa',
             'passphrase': None,
             'comment': 'ansible-generated on %s' % socket.gethostname()
@@ -2058,7 +2059,7 @@ def main():
             append=dict(default='no', type='bool'),
             # following are specific to ssh key generation
             generate_ssh_key=dict(type='bool'),
-            ssh_key_bits=dict(default=ssh_defaults['bits'], type='str'),
+            ssh_key_bits=dict(default=ssh_defaults['bits'], type='int'),
             ssh_key_type=dict(default=ssh_defaults['type'], type='str'),
             ssh_key_file=dict(default=None, type='path'),
             ssh_key_comment=dict(default=ssh_defaults['comment'], type='str'),


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

user
##### SUMMARY

By default, ssh-keygen will pick a suitable default for ssh keys
for all type of keys. By hardocing the number of bits to the
RSA default, we make life harder for people picking Elliptic
Curve keys, so this commit make ssh-keygen use its own default
unless specificed otherwise by the playbook
