### PR TITLE
handle processors always as arrays, sum cores and logical processors

### DIFF
--- a/windows/setup.ps1
+++ b/windows/setup.ps1
@@ -107,7 +107,7 @@ Set-Attr $result.ansible_facts "ansible_fqdn" ($ip_props.Hostname + "." + $ip_pr
 Set-Attr $result.ansible_facts "ansible_processor" $cpu_list
 Set-Attr $result.ansible_facts "ansible_processor_cores" $cores
 Set-Attr $result.ansible_facts "ansible_processor_count" $win32_cs.NumberOfProcessors
-Set-Attr $result.ansible_facts "ansible_processor_threads_per_core" ($logicalProcessors / $win32_cs.NumberOfProcessors / $cores)
+Set-Attr $result.ansible_facts "ansible_processor_threads_per_core" ($logicalProcessors / $cores)
 Set-Attr $result.ansible_facts "ansible_processor_vcpus" ($logicalProcessors)
 Set-Attr $result.ansible_facts "ansible_product_name" $win32_cs.Model.Trim()
 Set-Attr $result.ansible_facts "ansible_product_serial" $win32_bios.SerialNumber

--- a/windows/setup.ps1
+++ b/windows/setup.ps1
@@ -56,10 +56,8 @@ $win32_os = Get-CimInstance Win32_OperatingSystem
 $win32_cs = Get-CimInstance Win32_ComputerSystem
 $win32_bios = Get-CimInstance Win32_Bios
 $win32_cpu = Get-CimInstance Win32_Processor
-$temp = @()
 If ($win32_cpu -isnot [array]) {
-    $temp = $win32_cpu
-    $win32_cpu = $temp
+    $win32_cpu = @($win32_cpu)
 }
 
 $ip_props = [System.Net.NetworkInformation.IPGlobalProperties]::GetIPGlobalProperties()


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

setup.ps1
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0
  config file = /Users/richardlevenberg/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

setup.ps1 need to handle multiple slots for CPU. The code was only tested with one slot and the return from Get-CimInstance was a CimObject rather than array of CimObjects in the case of multiple cores. This change coerces win32_cpu variable to an array and calculates all derivative facts off the aggregates of the array of processors (may be 1)

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
before:
        "ansible_processor": [], 
        "ansible_processor_cores": 1, 
        "ansible_processor_count": 2, 
        "ansible_processor_threads_per_core": 0.5, 
        "ansible_processor_vcpus": 0.5,
after:
       "ansible_processor": [
            "AuthenticAMD", 
            "AMD Opteron(tm) Processor 6282 SE", 
            "AuthenticAMD", 
            "AMD Opteron(tm) Processor 6282 SE"
        ], 
        "ansible_processor_cores": 2, 
        "ansible_processor_count": 2, 
        "ansible_processor_threads_per_core": 0.5, 
        "ansible_processor_vcpus": 2, 

```
