### PR TITLE
Fail on duplicate ami names

### DIFF
--- a/cloud/amazon/ec2_ami.py
+++ b/cloud/amazon/ec2_ami.py
@@ -369,7 +369,7 @@ def create_image(module, ec2):
         images = ec2.get_all_images(filters={'name': name})
 
         if images and images[0]:
-            module.exit_json(msg="AMI name already present", image_id=images[0].id, state=images[0].state, changed=False)
+            module.fail_json(msg="AMI name already present", image_id=images[0].id, state=images[0].state, changed=False)
 
         if device_mapping:
             bdm = BlockDeviceMapping()


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

ec2_ami
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.1.0.0
```
##### SUMMARY

I introduced a bug speeding up the duplicate ami name detection code. It should FAIL when duplicate names are found. This should be released ASAP to help people debug why their AMI's aren't being updated.
