### PR TITLE
Fix S3 fallback to connect_s3 with 'us-east-1' region

### DIFF
--- a/cloud/amazon/s3.py
+++ b/cloud/amazon/s3.py
@@ -435,6 +435,7 @@ def main():
     if region in ('us-east-1', '', None):
         # S3ism for the US Standard region
         location = Location.DEFAULT
+        region = 'us-east-1'
     else:
         # Boto uses symbolic names for locations but region strings will
         # actually work fine for everything except us-east-1 (US Standard)
@@ -484,7 +485,7 @@ def main():
         else:
             aws_connect_kwargs['is_secure'] = True
             try:
-                s3 = connect_to_aws(boto.s3, location, **aws_connect_kwargs)
+                s3 = connect_to_aws(boto.s3, region, **aws_connect_kwargs)
             except AnsibleAWSError:
                 # use this as fallback because connect_to_region seems to fail in boto + non 'classic' aws accounts in some cases
                 s3 = boto.connect_s3(**aws_connect_kwargs)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

`cloud/amazon/s3`
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel 54db1df244) last updated 2016/07/04 17:34:02 (GMT -400)
  lib/ansible/modules/core: (s3-us-east-1-region 01a7c0ed47) last updated 2016/07/04 18:25:03 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 00b8b96906) last updated 2016/07/04 17:34:10 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/usr/share/ansible']
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

When using the `s3` module, the default region is `us-east-1`. The connection to `s3` is done through a call to `connect_to_aws`, which calls `boto.s3.connect_to_region`. This function expects a full region name (e.g. `us-east-1`), except that the current code passes an empty string (`Location.DEFAULT`) and the call fails.

The fallback of the connection attempt calls `boto.connect_s3`, which succeeds, so we are still seeing expected behaviour (connection to the default `us-east-1`). This PR would prevent the connection from having to fallback in the first place.

Using a version where [the fallback would actually crash](https://github.com/ansible/ansible-modules-core/pull/3347) made it seem odd to reach the fallback code with a default region.

This PR proposes the approach of passing `region` rather than `location` to `connect_to_aws`, since `boto.s3.connect_to_region` [expects a region name](http://boto.cloudhackers.com/en/latest/ref/s3.html#boto.s3.connect_to_region), while `boto.s3.create_bucket` (the other place where `location` is used) [really expects a `boto.s3.connection.Location`](http://boto.cloudhackers.com/en/latest/ref/s3.html#boto.s3.connection.S3Connection.create_bucket).

`"us-east-1"` vs `""`:

```
$ python
>>> import boto
>>> print boto.s3.connect_to_region('')
None
>>> print boto.s3.connect_to_region('us-east-1')
S3Connection:s3.amazonaws.com
```
