### PR TITLE
Add default port for aurora

### DIFF
--- a/cloud/amazon/rds.py
+++ b/cloud/amazon/rds.py
@@ -320,6 +320,7 @@ except ImportError:
     has_rds2 = False
 
 DEFAULT_PORTS= {
+    'aurora': 3306,
     'mariadb': 3306,
     'mysql': 3306,
     'oracle': 1521,


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

`cloud/amazon/rds.py`
##### ANSIBLE VERSION

```
ansible 2.1.0.0
```
##### SUMMARY

If a port isn't specified, it's looked up. The lookup breaks without
this, as 'ansible' isn't in the dict.

Related: https://github.com/ansible/ansible-modules-core/pull/3414
