### PR TITLE
Fix/network module typos

### DIFF
--- a/network/ios/ios_command.py
+++ b/network/ios/ios_command.py
@@ -37,12 +37,12 @@ options:
         configured provider. The resulting output from the command
         is returned. If the I(waitfor) argument is provided, the
         module is not returned until the condition is satisfied or
-        the number of retires as expired.
+        the number of retries has expired.
     required: true
   wait_for:
     description:
       - List of conditions to evaluate against the output of the
-        command. The task will wait for a each condition to be true
+        command. The task will wait for each condition to be true
         before moving forward. If the conditional is not true
         within the configured number of retries, the task fails.
         See examples.
@@ -55,7 +55,7 @@ options:
       - Specifies the number of retries a command should by tried
         before it is considered failed. The command is run on the
         target device every retry and evaluated against the
-        waitfor conditions.
+        I(waitfor) conditions.
     required: false
     default: 10
   interval:
@@ -78,7 +78,7 @@ vars:
     password: cisco
     transport: cli
 
-- name: run show verion on remote devices
+- name: run show version on remote devices
   ios_command:
     commands: show version
     provider "{{ cli }}"
@@ -96,7 +96,7 @@ vars:
       - show interfaces
     provider "{{ cli }}"
 
-- name: run multiple commands and evalute the output
+- name: run multiple commands and evaluate the output
   ios_command:
     commands:
       - show version
@@ -122,7 +122,7 @@ stdout_lines:
 
 failed_conditions:
   description: The list of conditionals that have failed
-  retured: failed
+  returned: failed
   type: list
   sample: ['...', '...']
 

--- a/network/ios/ios_config.py
+++ b/network/ios/ios_config.py
@@ -23,8 +23,8 @@ version_added: "2.1"
 author: "Peter Sprygada (@privateip)"
 short_description: Manage Cisco IOS configuration sections
 description:
-  - Cisco IOS configurations use a simple block indent file sytanx
-    for segementing configuration into sections.  This module provides
+  - Cisco IOS configurations use a simple block indent file syntax
+    for segmenting configuration into sections.  This module provides
     an implementation for working with IOS configuration sections in
     a deterministic way.
 extends_documentation_fragment: ios
@@ -59,7 +59,7 @@ options:
     version_added: "2.2"
   dest:
     description:
-      - Configures a destination file write the source template or config
+      - Configures a destination file to write the source template or config
         updates to.  The path to the destination file can either be a full
         path on the Ansible control host or a relative path from the
         playbook or role root dir.  This will, by default, overwrite any
@@ -74,7 +74,7 @@ options:
   append:
     description:
       - Changes the default behavior when writing the configuration out
-        to a remote file on disk.  By defaul if O(dest) is specified, the
+        to a remote file on disk.  By default if O(dest) is specified, the
         file is overridden.  By setting this argument to true, the remote
         file (if it exists) is appended to.
     required: false
@@ -93,7 +93,7 @@ options:
   after:
     description:
       - The ordered set of commands to append to the end of the command
-        stack if a changed needs to be made.  Just like with I(before) this
+        stack if a change needs to be made.  Just like with I(before) this
         allows the playbook designer to append a set of commands to be
         executed after the command set.
     required: false
@@ -188,7 +188,7 @@ updates:
 
 responses:
   description: The set of responses from issuing the commands on the device
-  retured: when not check_mode
+  returned: when not check_mode
   type: list
   sample: ['...', '...']
 """

--- a/network/ios/ios_facts.py
+++ b/network/ios/ios_facts.py
@@ -32,7 +32,7 @@ options:
   gather_subset:
     description:
       - When supplied, this argument will restrict the facts collected
-        to a given subset.  Possible values for this argument inlcude
+        to a given subset.  Possible values for this argument include
         all, hardware, config, and interfaces.  Can specify a list of
         values to include a larger subset.  Values can also be used
         with an initial M(!) to specify that a specific subset should
@@ -54,7 +54,7 @@ EXAMPLES = """
 # Do not collect hardware facts
 - ios_facts:
     gather_subset:
-      - "!interfaces"
+      - "!hardware"
 """
 
 RETURN = """
@@ -75,7 +75,7 @@ ansible_net_hostname:
   returned: always
   type: str
 ansible_net_image:
-  desription: The image the system booted from
+  description: The image the system booted from
   returned: always
   type: str
 ansible_net_module:

--- a/network/ios/ios_template.py
+++ b/network/ios/ios_template.py
@@ -23,9 +23,9 @@ author: "Peter Sprygada (@privateip)"
 short_description: Manage Cisco IOS device configurations over SSH
 description:
   - Manages Cisco IOS network device configurations over SSH.  This module
-    allows implementors to work with the device running-config.  It
+    allows implementers to work with the device running-config.  It
     provides a way to push a set of commands onto a network device
-    by evaluting the current running-config and only pushing configuration
+    by evaluating the current running-config and only pushing configuration
     commands that are not already configured.  The config source can
     be a set of commands or a template.
 extends_documentation_fragment: ios
@@ -50,7 +50,7 @@ options:
   include_defaults:
     description:
       - The module, by default, will collect the current device
-        running-config to use as a base for comparision to the commands
+        running-config to use as a base for comparison to the commands
         in I(src).  Setting this value to true will cause the command
         issued to add any necessary flags to collect all defaults as
         well as the device configuration.  If the destination device
@@ -74,8 +74,8 @@ options:
         against the contents of source.  There are times when it is not
         desirable to have the task get the current running-config for
         every task.  The I(config) argument allows the implementer to
-        pass in the configuruation to use as the base config for
-        comparision.
+        pass in the configuration to use as the base config for
+        comparison.
     required: false
     default: null
 """
@@ -111,7 +111,7 @@ updates:
 
 responses:
   description: The set of responses from issuing the commands on the device
-  retured: when not check_mode
+  returned: when not check_mode
   type: list
   sample: ['...', '...']
 """


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

network/ios_*
##### ANSIBLE VERSION

```
ansible 2.1.0.0
```
##### SUMMARY

Fixes typos in network/ios_\* modules
