### PR TITLE
Refactor of eos modules to use the NetworkModule subclass directly instead of a factory function.

### DIFF
--- a/network/eos/eos_command.py
+++ b/network/eos/eos_command.py
@@ -111,8 +111,11 @@ failed_conditions:
 """
 
 import time
-import shlex
 import re
+
+from ansible.module_utils.pycompat24 import get_exception
+from ansible.module_utils.netcmd import Conditional
+from ansible.module_utils.eos import NetworkModule
 
 INDEX_RE = re.compile(r'(\[\d+\])')
 
@@ -130,7 +133,7 @@ def main():
         interval=dict(default=1, type='int')
     )
 
-    module = get_module(argument_spec=spec,
+    module = NetworkModule(argument_spec=spec,
                         supports_check_mode=True)
 
     commands = module.params['commands']
@@ -173,11 +176,6 @@ def main():
     return module.exit_json(**result)
 
 
-from ansible.module_utils.basic import *
-from ansible.module_utils.urls import *
-from ansible.module_utils.shell import *
-from ansible.module_utils.netcfg import *
-from ansible.module_utils.eos import *
 if __name__ == '__main__':
-        main()
+    main()
 

--- a/network/eos/eos_config.py
+++ b/network/eos/eos_config.py
@@ -147,6 +147,8 @@ responses:
   sample: ['...', '...']
 """
 
+from ansible.module_utils.eos import NetworkConfig, NetworkModule
+
 def get_config(module):
     config = module.params['config'] or dict()
     if not config and not module.params['force']:
@@ -168,7 +170,7 @@ def main():
         config=dict()
     )
 
-    module = get_module(argument_spec=argument_spec,
+    module = NetworkModule(argument_spec=argument_spec,
                         supports_check_mode=True)
 
     lines = module.params['lines']
@@ -210,11 +212,6 @@ def main():
     result['updates'] = commands
     module.exit_json(**result)
 
-from ansible.module_utils.basic import *
-from ansible.module_utils.urls import *
-from ansible.module_utils.shell import *
-from ansible.module_utils.netcfg import *
-from ansible.module_utils.eos import *
 if __name__ == '__main__':
     main()
 

--- a/network/eos/eos_eapi.py
+++ b/network/eos/eos_eapi.py
@@ -136,6 +136,8 @@ _config:
     sample: {...}
 """
 
+from ansible.module_utils.eos import NetworkModule
+
 
 def http_commands(protocol, port, enable, config):
 
@@ -261,7 +263,7 @@ def main():
         transport=dict(required=True, choices=['cli'])
     )
 
-    module = get_module(argument_spec=argument_spec,
+    module = NetworkModule(argument_spec=argument_spec,
                         supports_check_mode=True)
 
     check_version(module)
@@ -270,10 +272,6 @@ def main():
 
     return module.exit_json(**result)
 
-
-from ansible.module_utils.basic import *
-from ansible.module_utils.shell import *
-from ansible.module_utils.eos import *
 
 if __name__ == '__main__':
     main()

--- a/network/eos/eos_template.py
+++ b/network/eos/eos_template.py
@@ -119,6 +119,8 @@ responses:
 
 import re
 
+from ansible.module_utils.eos import NetworkConfig, NetworkModule
+
 def get_config(module):
     config = module.params.get('config')
     if not config and not module.params['force']:
@@ -164,7 +166,7 @@ def main():
 
     mutually_exclusive = [('config', 'backup'), ('config', 'force')]
 
-    module = get_module(argument_spec=argument_spec,
+    module = NetworkModule(argument_spec=argument_spec,
                         mutually_exclusive=mutually_exclusive,
                         supports_check_mode=True)
 
@@ -203,10 +205,5 @@ def main():
     result['updates'] = commands
     module.exit_json(**result)
 
-from ansible.module_utils.basic import *
-from ansible.module_utils.urls import *
-from ansible.module_utils.shell import *
-from ansible.module_utils.netcfg import *
-from ansible.module_utils.eos import *
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

eos networking modules
##### ANSIBLE VERSION

```
devel
```
##### SUMMARY

Porting of eos modules to take advantage of code in module_utils refactor: https://github.com/ansible/ansible/pull/16618
