### PR TITLE
Add new volume types to ec2_vol.

### DIFF
--- a/cloud/amazon/ec2_vol.py
+++ b/cloud/amazon/ec2_vol.py
@@ -46,7 +46,7 @@ options:
     default: null
   volume_type:
     description:
-      - Type of EBS volume; standard (magnetic), gp2 (SSD), io1 (Provisioned IOPS). "Standard" is the old EBS default
+      - Type of EBS volume; standard (magnetic), gp2 (SSD), io1 (Provisioned IOPS), sc1 (Cold HDD), st1 (Throughput Optimized HDD). "Standard" is the old EBS default
         and continues to remain the Ansible default for backwards compatibility.
     required: false
     default: standard
@@ -480,7 +480,7 @@ def main():
             id = dict(),
             name = dict(),
             volume_size = dict(),
-            volume_type = dict(choices=['standard', 'gp2', 'io1'], default='standard'),
+            volume_type = dict(choices=['standard', 'gp2', 'io1', 'sc1', 'st1'], default='standard'),
             iops = dict(),
             encrypted = dict(type='bool', default=False),
             device_name = dict(),


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

ec2_vol
##### ANSIBLE VERSION

```
ansible 2.0.1.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Adds two new volume types 'st1' and 'sc1'. https://aws.amazon.com/about-aws/whats-new/2016/04/ebs-introduces-two-new-low-cost-high-throughput-hdd-volume-types/
