### PR TITLE
Enable IRC and Slack notifications on Shippable.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -30,3 +30,19 @@ integrations:
       on_failure: never
       on_start: never
       on_pull_request: never
+    - integrationName: irc
+      type: irc
+      recipients:
+      - "chat.freenode.net#ansible-notices"
+      on_success: change
+      on_failure: always
+      on_start: never
+      on_pull_request: always
+    - integrationName: slack
+      type: slack
+      recipients:
+      - "#shippable"
+      on_success: change
+      on_failure: always
+      on_start: never
+      on_pull_request: never


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### COMPONENT NAME

Tests
##### ANSIBLE VERSION

N/A
##### SUMMARY

Enable IRC and Slack notifications on Shippable. These settings match the main ansible repo.
