### PR TITLE
Adding support for published_ports: ALL, since that is what the docs …

### DIFF
--- a/cloud/docker/docker_container.py
+++ b/cloud/docker/docker_container.py
@@ -911,7 +911,7 @@ class TaskParameters(DockerBaseClass):
         if self.published_ports is None:
             return None
 
-        if 'all' in self.published_ports:
+        if 'all' in self.published_ports or 'ALL' in self.published_ports:
             return 'all'
 
         binds = {}


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

ansible_container
##### ANSIBLE VERSION

```
ansible 2.1.0.0
```
##### SUMMARY

Including support for published_ports to be set to ALL instead of just all. Documentation specifies ALL, but code only supports all.
