### PR TITLE
Make the RDS endpoint available if AWS returns it

### DIFF
--- a/cloud/amazon/rds.py
+++ b/cloud/amazon/rds.py
@@ -538,8 +538,8 @@ class RDSDBInstance:
             'iops'               : self.instance.iops
             }
 
-        # Endpoint exists only if the instance is available
-        if self.status == 'available':
+        # Only assign an Endpoint if one is available
+        if hasattr(self.instance, 'endpoint'):
             d["endpoint"] = self.instance.endpoint[0]
             d["port"] = self.instance.endpoint[1]
             if self.instance.vpc_security_groups is not None:
@@ -586,9 +586,9 @@ class RDS2DBInstance:
         }
         if self.instance["VpcSecurityGroups"] is not None:
             d['vpc_security_groups'] = ','.join(x['VpcSecurityGroupId'] for x in self.instance['VpcSecurityGroups'])
-        if self.status == 'available':
-            d['endpoint'] = self.instance["Endpoint"]["Address"]
-            d['port'] = self.instance["Endpoint"]["Port"]
+        if "Endpoint" in self.instance and self.instance["Endpoint"] is not None:
+            d['endpoint'] = self.instance["Endpoint"].get('Address', None)
+            d['port'] = self.instance["Endpoint"].get('Port', None)
         else:
             d['endpoint'] = None
             d['port'] = None


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

cloud/amazon/rds.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel e04d552bc6) last updated 2016/06/28 21:42:08 (GMT +100)
  lib/ansible/modules/core: (detached HEAD 3c6f2c2db1) last updated 2016/06/28 22:21:44 (GMT +100)
  lib/ansible/modules/extras: (detached HEAD 1c36665545) last updated 2016/06/28 22:22:01 (GMT +100)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

When creating and RDS instance the endpoint is available after the `creating` phase, this PR returns the endpoint as soon as it's available from AWS rather than waiting for the instance to be `available` before returning it.

By doing this it can make ansible runs 5-8 minutes shorter when creating a new RDS instance.
