### PR TITLE
Fix purge_networks

### DIFF
--- a/cloud/docker/docker_container.py
+++ b/cloud/docker/docker_container.py
@@ -1688,7 +1688,7 @@ class ContainerManager(DockerBaseClass):
             if self.diff.get('differences'):
                 self.diff['differences'].append(dict(network_differences=network_differences))
             else:
-                self.diff['differences'] = dict(network_differences=network_differences)
+                self.diff['differences'] = [dict(network_differences=network_differences)]
             self.results['changed'] = True
             updated_container = self._add_networks(container, network_differences)
 
@@ -1698,7 +1698,7 @@ class ContainerManager(DockerBaseClass):
                 if self.diff.get('differences'):
                     self.diff['differences'].append(dict(purge_networks=extra_networks))
                 else:
-                    self.diff['differences'] = dict(purge_networks=extra_networks)
+                    self.diff['differences'] = [dict(purge_networks=extra_networks)]
                 self.results['changed'] = True
                 updated_container = self._purge_networks(container, extra_networks)
         return updated_container
@@ -1734,7 +1734,7 @@ class ContainerManager(DockerBaseClass):
     def _purge_networks(self, container, networks):
         for network in networks:
             self.results['actions'].append(dict(removed_from_network=network['name']))
-            if not self.check_mode:
+            if not self.check_mode and network.get('id'):
                 try:
                     self.client.disconnect_container_from_network(container.Id, network['id'])
                 except Exception as exc:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

docker_container.py 
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel be66ebca37) last updated 2016/07/09 01:55:50 (GMT -400)
  lib/ansible/modules/core: (fix_4139 78f6c7e51e) last updated 2016/07/11 00:24:46 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 618e740d52) last updated 2016/07/08 17:30:59 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fix issue #4139. Module fails when using _purge_networks_. The action taken was not being appended to differences correctly.
