### PR TITLE
Fix multi-interface port binding.

### DIFF
--- a/cloud/docker/docker_container.py
+++ b/cloud/docker/docker_container.py
@@ -1410,7 +1410,7 @@ class Container(DockerBaseClass):
         return entrypoint
 
     def _get_expected_ports(self):
-        if self.parameters.published_ports is None:
+        if not self.parameters.published_ports:
             return None
         expected_bound_ports = {}
         for container_port, config in self.parameters.published_ports.iteritems():
@@ -1420,7 +1420,7 @@ class Container(DockerBaseClass):
                 expected_bound_ports[container_port] = [{'HostIp': "0.0.0.0", 'HostPort': ""}]
             elif isinstance(config[0], tuple):
                 expected_bound_ports[container_port] = []
-                for host_ip, host_port in config.iteritems():
+                for host_ip, host_port in config:
                     expected_bound_ports[container_port].append({ 'HostIp': host_ip, 'HostPort': str(host_port)})
             else:
                 expected_bound_ports[container_port] = [{'HostIp': config[0], 'HostPort': str(config[1])}]


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

docker_container.py 
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel be66ebca37) last updated 2016/07/09 01:55:50 (GMT -400)
  lib/ansible/modules/core: (devel 4aee56553f) last updated 2016/07/11 13:14:51 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 618e740d52) last updated 2016/07/08 17:30:59 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fixes issue #3989 - binding multiple host ports to a single container port fails. 
