### PR TITLE
Improve documentation on security_groups-option

### DIFF
--- a/cloud/amazon/ec2_lc.py
+++ b/cloud/amazon/ec2_lc.py
@@ -53,7 +53,7 @@ options:
     required: false
   security_groups:
     description:
-      - A list of security groups into which instances should be found
+      - A list of security groups to apply to the instances. For VPC instances, specify security group IDs. For EC2-Classic, specify either security group names or IDs.
     required: false
   volumes:
     description:


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Docs Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

ec2_lc.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Edited the documentation on `security_groups`-option from:

> A list of security groups into which instances should be found

to this:

> A list of security groups to apply to the instances. For VPC instances, specify security group IDs. For EC2-Classic, specify either security group names or IDs.

The original didn't describe well enough how to use the option which lead myself to spend way too much time with trial and error and then in the end reading the AWS CLI documentation to find out that VPCs only accept the security group IDs in this case. The new text is more clear about the usage.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```

```
