### PR TITLE
Fix module failing when no ports are exposed

### DIFF
--- a/cloud/docker/docker_container.py
+++ b/cloud/docker/docker_container.py
@@ -126,7 +126,7 @@ options:
     description:
       - List of additional container ports to expose for port mappings or links.
         If the port is already exposed using EXPOSE in a Dockerfile, it does not
-        need to be xposed again.
+        need to be exposed again.
     default: null
     required: false
     aliases:
@@ -738,15 +738,13 @@ class TaskParameters(DockerBaseClass):
                 except ValueError as exc:
                     self.fail("Failed to convert %s to bytes: %s" % (param_name, exc))
 
-        if 'all' in (port.lower() if isinstance(port, basestring) else port for port in self.published_ports):
+        self.publish_all_ports = False
+        self.published_ports = self._parse_publish_ports()
+        if self.published_ports == 'all':
             self.publish_all_ports = True
             self.published_ports = None
-            self.ports = None
-        else:
-            self.publish_all_ports = False
-            self.published_ports = self._parse_publish_ports()
-            self.ports = self._parse_exposed_ports(self.published_ports)
 
+        self.ports = self._parse_exposed_ports(self.published_ports)
         self.log("expose ports:")
         self.log(self.ports, pretty_print=True)
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

docker_container.py
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 7a078317a3) last updated 2016/07/12 12:06:58 (GMT -400)
  lib/ansible/modules/core: (devel 89e7255c87) last updated 2016/07/12 12:38:39 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 482b1a640e) last updated 2016/07/11 17:13:47 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

The right fix for publishing all ports without breaking exposed ports.  Fixes issue #4161, replaces PR #4162 .
