### PR TITLE
Fix getting actual_stdin_open backport for 2.0.x

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -117,7 +117,7 @@ options:
     version_added: "2.0"
   log_opt:
     description:
-      - Additional options to pass to the logging driver selected above. See Docker `log-driver 
+      - Additional options to pass to the logging driver selected above. See Docker `log-driver
         <https://docs.docker.com/reference/logging/overview/>` documentation for more information.
         Requires docker >=1.7.0.
     required: false
@@ -1173,7 +1173,7 @@ class DockerManager(object):
             # STDIN_OPEN
 
             expected_stdin_open = self.module.params.get('stdin_open')
-            actual_stdin_open = container['Config']['AttachStdin']
+            actual_stdin_open = container['Config']['OpenStdin']
             if actual_stdin_open != expected_stdin_open:
                 self.reload_reasons.append('stdin_open ({0} => {1})'.format(actual_stdin_open, expected_stdin_open))
                 differing.append(container)


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

docker
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.0.x and later
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Get the correct OpenStdin from docker-py
Backport of #4040 

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->
