### PR TITLE
Fix azure_rm_virtualmachine to create a storage account with name contains lower-case only  (#4174).

### DIFF
--- a/cloud/azure/azure_rm_virtualmachine.py
+++ b/cloud/azure/azure_rm_virtualmachine.py
@@ -1142,9 +1142,10 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
         valid_name = False
 
         # Attempt to find a valid storage account name
+        storage_account_name_base = self.name[:20].lower()
         for i in range(0, 5):
             rand = random.randrange(1000, 9999)
-            storage_account_name = self.name[:20] + str(rand)
+            storage_account_name = storage_account_name_base + str(rand)
             if self.check_storage_account_name(storage_account_name):
                 valid_name = True
                 break


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

azure_rm_virtualmachine
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 221520cbad) last updated 2016/07/13 15:32:29 (GMT +900)
  lib/ansible/modules/core: (fix4174 977a6a8b28) last updated 2016/07/13 16:13:27 (GMT +900)
  lib/ansible/modules/extras: (detached HEAD 482b1a640e) last updated 2016/07/13 15:32:38 (GMT +900)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

This fix the issue #4174 by converting the given virtualmachine name to lower-case and generating the storage account name with random suffix based this lower-cased name.
