### PR TITLE
Unarchive: stop passing file mode to tar command

### DIFF
--- a/files/unarchive.py
+++ b/files/unarchive.py
@@ -614,8 +614,6 @@ class TgzArchive(object):
             cmd.append('--owner=' + quote(self.file_args['owner']))
         if self.file_args['group']:
             cmd.append('--group=' + quote(self.file_args['group']))
-        if self.file_args['mode']:
-            cmd.append('--mode=' + quote(self.file_args['mode']))
         if self.module.params['keep_newer']:
             cmd.append('--keep-newer-files')
         if self.excludes:
@@ -663,8 +661,6 @@ class TgzArchive(object):
             cmd.append('--owner=' + quote(self.file_args['owner']))
         if self.file_args['group']:
             cmd.append('--group=' + quote(self.file_args['group']))
-        if self.file_args['mode']:
-            cmd.append('--mode=' + quote(self.file_args['mode']))
         if self.module.params['keep_newer']:
             cmd.append('--keep-newer-files')
         if self.excludes:


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

unarchive
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel 786ee97c38) last updated 2016/07/13 17:22:29 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 8e241a87cc) last updated 2016/07/13 17:22:33 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 2078c4b4da) last updated 2016/07/13 17:22:36 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Fixes #4063 .

Removes the `--mode` argument passed to `tar` on extraction (`-x`) and diff (`-d`).

Tar does not use this parameter on extraction (`-x`) or diff (`-d`) (the only two cases where it is passed in unarchive). It only [uses it on creation](https://www.gnu.org/software/tar/manual/html_section/tar_33.html).

This would cause issues in the following case: providing `unarchive` with a file mode of `0755` (octal) would end up calling `tar` with the argument `--mode 493` (`493` = `0755` in decimal). Tar then fails while verifying it (because it contains an invalid octal char `9`).
We _could_ change it so that the mode is passed with an octal representation _when_ it is an integer (and not a symbolic mode), but `tar` is not using that parameter anyway in `unarchive`'s use case, so why bother?

Not passing the parameter to `tar` solves the issue (and shouldn't change the current behaviour).
My understanding is that the following line is the one that actually uses the `mode` to apply it:

```
res_args['changed'] = module.set_fs_attributes_if_different(file_args, res_args['changed'])
```
