### PR TITLE
bug fix in ios_config module for handling config contents

### DIFF
--- a/network/ios/ios_config.py
+++ b/network/ios/ios_config.py
@@ -202,7 +202,7 @@ def check_args(module, warnings):
 def get_candidate(module):
     candidate = NetworkConfig(indent=1)
     if module.params['src']:
-        candidate = module.params['src']
+        candidate.load(module.params['src'])
     elif module.params['lines']:
         parents = module.params['parents'] or list()
         candidate.add(module.params['lines'], parents=parents)


### PR DESCRIPTION
Config contents when passed via argument were returning a string but
the module expects an instance of NetworkConfig.  This fixes that
problem.
