### PR TITLE
Add states for stopping and starting machines

### DIFF
--- a/cloud/google/gce.py
+++ b/cloud/google/gce.py
@@ -121,7 +121,7 @@ options:
       - desired state of the resource
     required: false
     default: "present"
-    choices: ["active", "present", "absent", "deleted"]
+    choices: ["active", "present", "absent", "deleted", "started", "stopped", "terminated"]
   tags:
     description:
       - a comma-separated list of tags to associate with the instance
@@ -502,6 +502,59 @@ def create_instances(module, gce, instance_names):
 
     return (changed, instance_json_data, instance_names)
 
+def start_instances(module, gce, instance_names, zone_name):
+    """Starts a list of stopped instances.
+
+    module: Ansible module object
+    gce: authenticated GCE connection object
+    instance_names: a list of instance names to start
+    zone_name: the zone where the instances reside prior to termination
+
+    Returns a dictionary of instance names that were started.
+    """
+    changed = False
+    started_instance_names = []
+    for name in instance_names:
+        inst = None
+        try:
+            inst = gce.ex_get_node(name, zone_name)
+        except ResourceNotFoundError:
+            pass
+        except Exception as e:
+            module.fail_json(msg=unexpected_error_msg(e), changed=False)
+        if inst and inst.state == libcloud.compute.types.NodeState.STOPPED:
+            gce.ex_start_node(inst)
+            started_instance_names.append(inst.name)
+            changed = True
+
+    return (changed, started_instance_names)
+
+def stop_instances(module, gce, instance_names, zone_name):
+    """Stops a list of instances.
+
+    module: Ansible module object
+    gce: authenticated GCE connection object
+    instance_names: a list of instance names to stop
+    zone_name: the zone where the instances reside prior to termination
+
+    Returns a dictionary of instance names that were stopped.
+    """
+    changed = False
+    stopped_instance_names = []
+    for name in instance_names:
+        inst = None
+        try:
+            inst = gce.ex_get_node(name, zone_name)
+        except ResourceNotFoundError:
+            pass
+        except Exception as e:
+            module.fail_json(msg=unexpected_error_msg(e), changed=False)
+        if inst and inst.state == libcloud.compute.types.NodeState.RUNNING:
+            gce.ex_stop_node(inst)
+            stopped_instance_names.append(inst.name)
+            changed = True
+
+    return (changed, stopped_instance_names)
 
 def terminate_instances(module, gce, instance_names, zone_name):
     """Terminates a list of instances.
@@ -544,7 +597,8 @@ def main():
             subnetwork = dict(),
             persistent_boot_disk = dict(type='bool', default=False),
             disks = dict(type='list'),
-            state = dict(choices=['active', 'present', 'absent', 'deleted'],
+            state = dict(choices=['active', 'present', 'absent', 'deleted',
+                                  'started', 'stopped', 'terminated'],
                          default='present'),
             tags = dict(type='list'),
             zone = dict(default='us-central1-a'),
@@ -623,6 +677,22 @@ def main():
         json_output['instance_data'] = instance_data
         if instance_names:
             json_output['instance_names'] = instance_name_list
+        elif name:
+            json_output['name'] = name
+
+    elif state in ['started']:
+        json_output['state'] = 'started'
+        (changed, started_instance_names) = start_instances(module, gce, inames, zone)
+        if instance_names:
+            json_output['instance_names'] = started_instance_names
+        elif name:
+            json_output['name'] = name
+
+    elif state in ['stopped', 'terminated']:
+        json_output['state'] = 'stopped'
+        (changed, stopped_instance_names) = stop_instances(module, gce, inames, zone)
+        if instance_names:
+            json_output['instance_names'] = stopped_instance_names
         elif name:
             json_output['name'] = name
 

--- a/cloud/google/gce.py
+++ b/cloud/google/gce.py
@@ -502,73 +502,21 @@ def create_instances(module, gce, instance_names):
 
     return (changed, instance_json_data, instance_names)
 
-def start_instances(module, gce, instance_names, zone_name):
-    """Starts a list of stopped instances.
-
-    module: Ansible module object
-    gce: authenticated GCE connection object
-    instance_names: a list of instance names to start
-    zone_name: the zone where the instances reside prior to termination
-
-    Returns a dictionary of instance names that were started.
-    """
-    changed = False
-    started_instance_names = []
-    for name in instance_names:
-        inst = None
-        try:
-            inst = gce.ex_get_node(name, zone_name)
-        except ResourceNotFoundError:
-            pass
-        except Exception as e:
-            module.fail_json(msg=unexpected_error_msg(e), changed=False)
-        if inst and inst.state == libcloud.compute.types.NodeState.STOPPED:
-            gce.ex_start_node(inst)
-            started_instance_names.append(inst.name)
-            changed = True
-
-    return (changed, started_instance_names)
-
-def stop_instances(module, gce, instance_names, zone_name):
-    """Stops a list of instances.
-
-    module: Ansible module object
-    gce: authenticated GCE connection object
-    instance_names: a list of instance names to stop
-    zone_name: the zone where the instances reside prior to termination
-
-    Returns a dictionary of instance names that were stopped.
-    """
-    changed = False
-    stopped_instance_names = []
-    for name in instance_names:
-        inst = None
-        try:
-            inst = gce.ex_get_node(name, zone_name)
-        except ResourceNotFoundError:
-            pass
-        except Exception as e:
-            module.fail_json(msg=unexpected_error_msg(e), changed=False)
-        if inst and inst.state == libcloud.compute.types.NodeState.RUNNING:
-            gce.ex_stop_node(inst)
-            stopped_instance_names.append(inst.name)
-            changed = True
-
-    return (changed, stopped_instance_names)
-
-def terminate_instances(module, gce, instance_names, zone_name):
-    """Terminates a list of instances.
+def change_instance_state(module, gce, instance_names, zone_name, state):
+    """Changes the state of a list of instances. For example,
+    change from started to stopped, or started to absent.
 
     module: Ansible module object
     gce: authenticated GCE connection object
     instance_names: a list of instance names to terminate
     zone_name: the zone where the instances reside prior to termination
+    state: 'state' parameter passed into module as argument
 
-    Returns a dictionary of instance names that were terminated.
+    Returns a dictionary of instance names that were changed.
 
     """
     changed = False
-    terminated_instance_names = []
+    changed_instance_names = []
     for name in instance_names:
         inst = None
         try:
@@ -577,13 +525,22 @@ def terminate_instances(module, gce, instance_names, zone_name):
             pass
         except Exception as e:
             module.fail_json(msg=unexpected_error_msg(e), changed=False)
-        if inst:
+        if inst and state in ['absent', 'deleted']:
             gce.destroy_node(inst)
-            terminated_instance_names.append(inst.name)
+            changed_instance_names.append(inst.name)
+            changed = True
+        elif inst and state == 'started' and \
+                  inst.state == libcloud.compute.types.NodeState.STOPPED:
+            gce.ex_start_node(inst)
+            changed_instance_names.append(inst.name)
+            changed = True
+        elif inst and state in ['stopped', 'terminated'] and \
+                  inst.state == libcloud.compute.types.NodeState.RUNNING:
+            gce.ex_stop_node(inst)
+            changed_instance_names.append(inst.name)
             changed = True
 
-    return (changed, terminated_instance_names)
-
+    return (changed, changed_instance_names)
 
 def main():
     module = AnsibleModule(
@@ -658,15 +615,15 @@ def main():
                          changed=False)
 
     json_output = {'zone': zone}
-    if state in ['absent', 'deleted']:
-        json_output['state'] = 'absent'
-        (changed, terminated_instance_names) = terminate_instances(
-            module, gce, inames, zone)
+    if state in ['absent', 'deleted', 'started', 'stopped', 'terminated']:
+        json_output['state'] = state
+        (changed, changed_instance_names) = change_instance_state(
+            module, gce, inames, zone, state)
 
         # based on what user specified, return the same variable, although
         # value could be different if an instance could not be destroyed
         if instance_names:
-            json_output['instance_names'] = terminated_instance_names
+            json_output['instance_names'] = changed_instance_names
         elif name:
             json_output['name'] = name
 
@@ -677,22 +634,6 @@ def main():
         json_output['instance_data'] = instance_data
         if instance_names:
             json_output['instance_names'] = instance_name_list
-        elif name:
-            json_output['name'] = name
-
-    elif state in ['started']:
-        json_output['state'] = 'started'
-        (changed, started_instance_names) = start_instances(module, gce, inames, zone)
-        if instance_names:
-            json_output['instance_names'] = started_instance_names
-        elif name:
-            json_output['name'] = name
-
-    elif state in ['stopped', 'terminated']:
-        json_output['state'] = 'stopped'
-        (changed, stopped_instance_names) = stop_instances(module, gce, inames, zone)
-        if instance_names:
-            json_output['instance_names'] = stopped_instance_names
         elif name:
             json_output['name'] = name
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

gce
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

This will allow nodes to be started and stopped iteratively and synchronously. I have added two helper functions modeled after the deletion helper function using libcloud functionality to start and stop one or more machines in a loop. I hope to eventually work towards asynchronous iterative starting, stopping, creation, and destruction in a later pull request as this will potentially require libcloud contributions as well.

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
    "changed": true, 
    "instance_names": [
        "gce-test0", 
        "gce-test1"
    ], 
    "invocation": {
        "module_args": {
            "credentials_file": null, 
            "disk_auto_delete": true, 
            "disks": null, 
            "external_ip": "ephemeral", 
            "image": "debian-7", 
            "instance_names": "gce-test0,gce-test1", 
            "ip_forward": false, 
            "machine_type": "n1-standard-1", 
            "metadata": null, 
            "name": null, 
            "network": "default", 
            "pem_file": null, 
            "persistent_boot_disk": false, 
            "preemptible": null, 
            "project_id": null, 
            "service_account_email": null, 
            "service_account_permissions": null, 
            "state": "absent", 
            "subnetwork": null, 
            "tags": null, 
            "zone": "us-central1-a"
        }
    }, 
    "state": "absent", 
    "zone": "us-central1-a"
```

/cc @ryansb @erjohnso
