### PR TITLE
fix health instances count when we have more than one lb in asg

### DIFF
--- a/cloud/amazon/ec2_asg.py
+++ b/cloud/amazon/ec2_asg.py
@@ -318,7 +318,7 @@ def elb_dreg(asg_connection, module, group_name, instance_id):
 
 
 def elb_healthy(asg_connection, elb_connection, module, group_name):
-    healthy_instances = []
+    healthy_instances = set()
     as_group = asg_connection.get_all_groups(names=[group_name])[0]
     props = get_properties(as_group)
     # get healthy, inservice instances from ASG
@@ -337,7 +337,7 @@ def elb_healthy(asg_connection, elb_connection, module, group_name):
             pass
         for i in lb_instances:
             if i.state == "InService":
-                healthy_instances.append(i.instance_id)
+                healthy_instances.add(i.instance_id)
             log.debug("{0}: {1}".format(i.instance_id, i.state))
     return len(healthy_instances)
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

cloud/amazon/ec2_asg.py
##### ANSIBLE VERSION

```
devel, stable-2.1
```
##### SUMMARY

```
elb_health function returns the number of all healthy (in service)
instances associated to asg load balancers

When we have an asg with more than one lb associated, 
elb_health returns the sum of instances in all lb (not the set of unique instances). 
In this case the wait_for_elb function don't wait for the new instances 
become in service and the old instances are terminated, 
leaving the load balancers with no instances.

This bug was causing a downtime in our deployment when 
we attached a public and private lb to the same auto scale group.

```
