### PR TITLE
fixes issues where iam_policy incorrected reported changed

### DIFF
--- a/cloud/amazon/iam_policy.py
+++ b/cloud/amazon/iam_policy.py
@@ -139,6 +139,7 @@ def user_action(module, iam, name, policy_name, skip, pdoc, state):
     current_policies = [cp for cp in iam.get_all_user_policies(name).
                                         list_user_policies_result.
                                         policy_names]
+    pol = ""
     for pol in current_policies:
       '''
       urllib is needed here because boto returns url encoded strings instead
@@ -146,12 +147,13 @@ def user_action(module, iam, name, policy_name, skip, pdoc, state):
       if urllib.unquote(iam.get_user_policy(name, pol).
                         get_user_policy_result.policy_document) == pdoc:
         policy_match = True
+        break
 
     if state == 'present':
       # If policy document does not already exist (either it's changed
       # or the policy is not present) or if we're not skipping dupes then
       # make the put call.  Note that the put call does a create or update.
-      if not policy_match or not skip:
+      if (not policy_match or not skip) and pol != name:
         changed = True
         iam.put_user_policy(name, policy_name, pdoc)
     elif state == 'absent':
@@ -189,16 +191,18 @@ def role_action(module, iam, name, policy_name, skip, pdoc, state):
       module.fail_json(msg=e.message)
 
   try:
+    pol = ""
     for pol in current_policies:
       if urllib.unquote(iam.get_role_policy(name, pol).
                         get_role_policy_result.policy_document) == pdoc:
         policy_match = True
+        break
 
     if state == 'present':
       # If policy document does not already exist (either it's changed
       # or the policy is not present) or if we're not skipping dupes then
       # make the put call.  Note that the put call does a create or update.
-      if not policy_match or not skip:
+      if (not policy_match or not skip) and pol != name:
         changed = True
         iam.put_role_policy(name, policy_name, pdoc)
     elif state == 'absent':
@@ -232,6 +236,7 @@ def group_action(module, iam, name, policy_name, skip, pdoc, state):
     current_policies = [cp for cp in iam.get_all_group_policies(name).
                                         list_group_policies_result.
                                         policy_names]
+    pol = ""
     for pol in current_policies:
       if urllib.unquote(iam.get_group_policy(name, pol).
                         get_group_policy_result.policy_document) == pdoc:
@@ -239,11 +244,12 @@ def group_action(module, iam, name, policy_name, skip, pdoc, state):
         if policy_match:
           msg=("The policy document you specified already exists "
                "under the name %s." % pol)
+        break
     if state == 'present':
       # If policy document does not already exist (either it's changed
       # or the policy is not present) or if we're not skipping dupes then
       # make the put call.  Note that the put call does a create or update.
-      if not policy_match or not skip:
+      if (not policy_match or not skip) and pol != name:
         changed = True
         iam.put_group_policy(name, policy_name, pdoc)
     elif state == 'absent':


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

iam_policy.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel e560bfeaca) last updated 2016/07/15 20:12:37 (GMT +000)
  lib/ansible/modules/core: (iam_policy_fix 1447ac963d) last updated 2016/07/18 13:12:22 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD 68ca157f3b) last updated 2016/07/15 20:12:44 (GMT +000)
  config file = /home/vagrant/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
Fixes #4189 by eliminating the incorrect changed indication when skip_duplicates is false and a policy by that name already exists with the desired policy document contents
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
before: changed: [localhost]
after: ok: [localhost]
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible-modules-core/4203)

<!-- Reviewable:end -->
