### PR TITLE
Fix unit parsing

### DIFF
--- a/cloud/docker/docker_container.py
+++ b/cloud/docker/docker_container.py
@@ -185,7 +185,8 @@ options:
   kernel_memory:
     description:
       - "Kernel memory limit (format: <number>[<unit>]). Number is a positive integer.
-        Unit can be one of b, k, m, or g. Minimum is 4M."
+        Unit is optional and can be `B` (bytes), `KB` (kilobytes), `MB` (megabytes), `GB` (gigabytes),
+        `TB` (terabytes), or `PB` (petabytes). Minimum is 4MB."
     default: 0
     required: false
   labels:
@@ -666,6 +667,7 @@ except:
 
 
 REQUIRES_CONVERSION_TO_BYTES = [
+    'kernel_memory',
     'memory',
     'memory_reservation',
     'memory_swap',

--- a/cloud/docker/docker_container.py
+++ b/cloud/docker/docker_container.py
@@ -225,19 +225,25 @@ options:
   memory:
     description:
       - "Memory limit (format: <number>[<unit>]). Number is a positive integer.
-        Unit can be one of b, k, m, or g"
+        Unit is optional and can be `B` (bytes), `KB` (kilobytes), `MB` (megabytes), `GB` (gigabytes),
+        `TB` (terabytes), or `PB` (petabytes)."
+      - Omitting the unit defaults to bytes.
     default: 0
     required: false
   memory_reservation:
     description:
       - "Memory soft limit (format: <number>[<unit>]). Number is a positive integer.
-        Unit can be one of b, k, m, or g"
+        Unit is optional and can be `B` (bytes), `KB` (kilobytes), `MB` (megabytes), `GB` (gigabytes),
+        `TB` (terabytes), or `PB` (petabytes)."
+      - Omitting the unit defaults to bytes.
     default: 0
     required: false
   memory_swap:
     description:
-      - Total memory limit (memory + swap, format:<number>[<unit>]).
-        Number is a positive integer. Unit can be one of b, k, m, or g.
+      - "Total memory limit (memory + swap, format:<number>[<unit>]). Number is a positive integer.
+        Unit is optional and can be `B` (bytes), `KB` (kilobytes), `MB` (megabytes), `GB` (gigabytes),
+        `TB` (terabytes), or `PB` (petabytes)."
+      - Omitting the unit defaults to bytes.
     default: 0
     required: false
   memory_swappiness:
@@ -360,8 +366,9 @@ options:
   shm_size:
     description:
       - Size of `/dev/shm`. The format is `<number><unit>`. `number` must be greater than `0`.
-        Unit is optional and can be `b` (bytes), `k` (kilobytes), `m` (megabytes), or `g` (gigabytes).
-      - Omitting the unit defaults to bytes. If you omit the size entirely, the system uses `64m`.
+        Unit is optional and can be `B` (bytes), `KB` (kilobytes), `MB` (megabytes), `GB` (gigabytes),
+        `TB` (terabytes), or `PB` (petabytes).
+      - Omitting the unit defaults to bytes. If you omit the size entirely, the system uses `64MB`.
     default: null
     required: false
   security_opts:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

docker
##### SUMMARY

Fixes ansible/ansible#16526.

The second commit adds unit parsing to the "kernel_memory" option.  This depends on pull request ansible/ansible#16748,.  Without ansible/ansible#16748, this would be a breaking change.
