### PR TITLE
update ec2_ami_find to allow product-code filter

### DIFF
--- a/cloud/amazon/ec2_ami_find.py
+++ b/cloud/amazon/ec2_ami_find.py
@@ -79,6 +79,12 @@ options:
       - Platform type to match.
     default: null
     required: false
+  product_code:
+    description:
+      - Marketplace product code to match.
+    default: null
+    required: false
+    version_added: "2.2"
   sort:
     description:
       - Optional attribute which with to sort the results.
@@ -303,6 +309,7 @@ def main():
             is_public = dict(required=False, type='bool'),
             name = dict(required=False),
             platform = dict(required=False),
+            product_code = dict(required=False),
             sort = dict(required=False, default=None,
                 choices=['name', 'description', 'tag', 'architecture', 'block_device_mapping', 'creationDate', 'hypervisor', 'is_public', 'location', 'owner_id', 'platform', 'root_device_name', 'root_device_type', 'state', 'virtualization_type']),
             sort_tag = dict(required=False),
@@ -332,6 +339,7 @@ def main():
     name = module.params.get('name')
     owner = module.params.get('owner')
     platform = module.params.get('platform')
+    product_code = module.params.get('product_code')
     sort = module.params.get('sort')
     sort_tag = module.params.get('sort_tag')
     sort_order = module.params.get('sort_order')
@@ -358,6 +366,8 @@ def main():
         filter['name'] = name
     if platform:
         filter['platform'] = platform
+    if product_code:
+        filter['product-code'] = product_code
     if virtualization_type:
         filter['virtualization_type'] = virtualization_type
 


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

ec2_ami_find
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

CentOS's [cloud image wiki page](https://wiki.centos.org/Cloud/AWS) gives an example of using their product code to search for AMIs. This commit adds an optional parameter `product_code` to ec2_ami_find to allow this filtering.

Implemented with the `product-code` filter described in the [CLI documentation](https://docs.aws.amazon.com/AWSEC2/latest/CommandLineReference/ApiReference-cmd-DescribeInstances.html#ApiReference-cmd-DescribeInstances-Syntax) (see "Supported Filters")
