### PR TITLE
Allow value to be bool where 'yes'/'no' are in choices

### DIFF
--- a/packaging/os/apt.py
+++ b/packaging/os/apt.py
@@ -684,7 +684,7 @@ def main():
             default_release = dict(default=None, aliases=['default-release']),
             install_recommends = dict(default=None, aliases=['install-recommends'], type='bool'),
             force = dict(default='no', type='bool'),
-            upgrade = dict(choices=['no', 'yes', 'safe', 'full', 'dist']),
+            upgrade = dict(choices=['no', 'False', 'yes', 'True', 'safe', 'full', 'dist']),
             dpkg_options = dict(default=DPKG_OPTIONS),
             autoremove = dict(type='bool', default=False, aliases=['autoclean']),
             only_upgrade = dict(type='bool', default=False),
@@ -717,8 +717,10 @@ def main():
 
     p = module.params
 
-    if p['upgrade'] == 'no':
+    if p['upgrade'] in ('no', 'False'):
         p['upgrade'] = None
+    elif p['upgrade'] == 'True':
+        p['upgrade'] = 'yes'
 
     if not APTITUDE_CMD and p.get('upgrade', None) in [ 'full', 'safe', 'yes' ]:
         module.fail_json(msg="Could not find aptitude. Please ensure it is installed.")


### PR DESCRIPTION
NOTE This pull request work on same issue as [#2593 on ansible-modules-extras](https://github.com/ansible/ansible-modules-extras/pull/2593). Therefore, below comment is almost copy-and-paste.
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAMES
- `_docker`
- `docker_container`
- `docker_image`
- `_nova_compute`
- `cl_img_install`
- `apt`

I did not modify `uri` module, since `'yes'`/`'no'` choices of `follow_redirects` argument is deprecated.
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Many arguments from many modules has limited choices including `'yes'` and/or `'no'` as a option. However, in some case, these are treated as string type; boolean values cause error.

This pull request fix this problem, in the following two way:
##### 1. Change type to bool

If choices are only `'yes'` and `'no'`, this argument can be easily modified to bool type. Even parameter is passed as string, it will be [converted to boolean](https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/basic.py#L1439-L1446), so it is 100% backward compatible.

**Modules:**
- `_nova_compute`

**Example:** `_nova_compute` module's case

``` yaml

---
# This still works,
- name: launch an instance
  nova_compute: wait=yes # snip...

---
# and this still works too,
- name: launch an instance
  nova_compute:
    wait: "yes"
    # snip...

---
# AND! this will work now.
- name: launch an instance
  nova_compute:
    wait: yes
    # snip...
```
##### 2. Add options to catch boolean

If choices contains other values than `'yes'` or `'no'`, this argument should be kept to be treated as string. In this case, if you pass boolean argument here, it will be [converted to `'True'` or `'False'` respectively](https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/basic.py#L1376-L1381). Therefore, adding them to the choices will solve the problem.

**Modules:**
- `_docker`
- `docker_container`
- `docker_image`
- `apt`

**Example**: `apt` module's case

The choices of `upgrade` argument of `apt` modules contain `"safe"`, `"full"` and `"dist"`, so it cannot be treated as boolean.

``` yaml

---
# This still works,
- name: upgrade packages
  apt: upgrade=yes update_cache=yes force=yes

---
# and this still works too,
- name: upgrade packages
  apt:
    upgrade: "yes"
    update_cache: yes
    force: yes

---
# AND! this will work now.
- name: upgrade packages
  apt:
    upgrade: yes
    update_cache: yes
    force: yes

---
# Of course, this
- name: upgrade packages
  apt: upgrade=dist

---
# or this still works.
- name: upgrade packages
  apt:
    upgrade: dist
```
