### PR TITLE
Manage existing guests by UUID

### DIFF
--- a/cloud/vmware/vsphere_guest.py
+++ b/cloud/vmware/vsphere_guest.py
@@ -63,7 +63,7 @@ options:
     version_added: 2.1
   guest:
     description:
-      - The virtual server name you wish to manage.
+      - The virtual server name or UUID you wish to manage.
     required: true
   username:
     description:
@@ -1779,7 +1779,13 @@ def main():
 
     # Check if the VM exists before continuing
     try:
-        vm = viserver.get_vm_by_name(guest)
+        vm_paths = viserver.get_registered_vms(
+            advanced_filters={'config.uuid': guest}
+        )
+        if vm_paths:
+            vm = viserver.get_vm_by_path(vm_paths[0])
+        else:
+            vm = viserver.get_vm_by_name(guest)
     except Exception:
         pass
 


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### SUMMARY

This fix allows existing guests that are not uniquely named within a vCenter to be managed by specifying their UUID (e.g. 10241973-c79f-99cd-fbc5-e43d42002879).
