### PR TITLE
Add CAPABILITY_NAMED_IAM to cloudformation capabilities

### DIFF
--- a/cloud/amazon/cloudformation.py
+++ b/cloud/amazon/cloudformation.py
@@ -319,7 +319,7 @@ def main():
                              stack_policy_body=stack_policy_body,
                              template_url=template_url,
                              disable_rollback=disable_rollback,
-                             capabilities=['CAPABILITY_IAM'],
+                             capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
                              **kwargs)
             operation = 'CREATE'
         except Exception as err:
@@ -342,7 +342,7 @@ def main():
                              stack_policy_body=stack_policy_body,
                              disable_rollback=disable_rollback,
                              template_url=template_url,
-                             capabilities=['CAPABILITY_IAM'])
+                             capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'])
             operation = 'UPDATE'
         except Exception as err:
             error_msg = boto_exception(err)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

cloudformation
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 372018dfce) last updated 2016/07/21 00:15:45 (GMT -500)
  lib/ansible/modules/core: (devel 04d62ed966) last updated 2016/07/21 11:05:42 (GMT -500)
  lib/ansible/modules/extras: (detached HEAD 68ca157f3b) last updated 2016/07/21 00:16:01 (GMT -500)
  config file = /Users/phy1729/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

`CAPABILITY_NAMED_IAM` is required to support CloudFormation stacks that contain named IAM resources. While from the [documentation](http://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CreateStack.html) one would assume that replacing `CAPABILITY_IAM` with `CAPABILITY_NAMED_IAM` would be sufficient, this as empirically been shown to not be the case.
