### PR TITLE
Enforce boolean type for dup_ok

### DIFF
--- a/cloud/amazon/iam_cert.py
+++ b/cloud/amazon/iam_cert.py
@@ -232,7 +232,7 @@ def main():
         new_name=dict(default=None, required=False),
         path=dict(default='/', required=False),
         new_path=dict(default=None, required=False),
-        dup_ok=dict(default=False, required=False, choices=[False, True])
+        dup_ok=dict(default=False, required=False, choices=[False, True], type='bool')
     )
     )
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

core/cloud/amazon/iam_cert.py
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel branch)
Python 2.7.5
RHEL 7.2
```
##### SUMMARY

Every time I run this module, I get:

```
value of dup_ok must be one of: False,True, got: False
```

This occurs when dup_ok is not set (where "False" is the default).  It also occurs when dup_ok has a value set explicitly to "False".

When dup_ok is explicitly set to "True":

```
value of dup_ok must be one of: False,True, got: True
```

Investigation determined the choices are being interpreted as strings.  This PR adds type enforcing which stops "choices" from being interpreted as strings.
