### PR TITLE
Fix change status on django_manage collectstatic.

### DIFF
--- a/web_infrastructure/django_manage.py
+++ b/web_infrastructure/django_manage.py
@@ -167,7 +167,7 @@ def migrate_filter_output(line):
     return ("Migrating forwards " in line) or ("Installed" in line and "Installed 0 object" not in line) or ("Applying" in line)
 
 def collectstatic_filter_output(line):
-    return "0 static files" not in line
+    return line and "0 static files" not in line
 
 def main():
     command_allowed_param_map = dict(


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

web_infrastructure/django_manage.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/usr/share/ansible']
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

django_manage collectstatic always reports as changed because blank lines in output are not ignored.

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
localhost | SUCCESS => {
    "app_path": "/tmp/django-env/proj", 
    "changed": [
        "", 
        ""
    ], 
    "cmd": "./manage.py collectstatic --noinput", 
    "out": "\n0 static files copied to '/tmp/django-env/proj/static', 57 unmodified.\n", 
    "pythonpath": null, 
    "settings": null, 
    "virtualenv": "/tmp/django-env"
}
```
