### PR TITLE
Add rule revocation capabilities to ec2_group

### DIFF
--- a/cloud/amazon/ec2_group.py
+++ b/cloud/amazon/ec2_group.py
@@ -67,6 +67,18 @@ options:
     required: false
     default: 'true'
     aliases: []
+  revoke_rules:
+    version_added: "2.2"
+    description:
+      - List of firewall inbound rules to revoke in this group (see example). If none are supplied, nothing will change.
+    required: false
+    default: []
+  revoke_rules_egress:
+    version_added: "2.2"
+    description:
+      - List of firewall outbound rules to revoke in this group (see example). If none are supplied, nothing will change.
+    required: false
+    default: []
 
 extends_documentation_fragment:
     - aws
@@ -127,6 +139,21 @@ EXAMPLES = '''
         group_name: example-other
         # description to use if example-other needs to be created
         group_desc: other example EC2 group
+
+# the example group will no longer accept connections on port 80
+- name: example ec2 group revocation
+  ec2_group:
+    name: example
+    description: an example EC2 group
+    vpc_id: 12345
+    region: eu-west-1a
+    aws_secret_key: SECRET
+    aws_access_key: ACCESS
+    revoke_rules:
+      - proto: tcp
+        from_port: 80
+        to_port: 80
+        cidr_ip: 0.0.0.0/0
 '''
 
 try:
@@ -241,6 +268,8 @@ def main():
             state = dict(default='present', type='str', choices=['present', 'absent']),
             purge_rules=dict(default=True, required=False, type='bool'),
             purge_rules_egress=dict(default=True, required=False, type='bool'),
+            revoke_rules=dict(default=[], required=False, type='list'),
+            revoke_rules_egress=dict(default=[], required=False, type='list'),
 
         )
     )
@@ -260,6 +289,8 @@ def main():
     state = module.params.get('state')
     purge_rules = module.params['purge_rules']
     purge_rules_egress = module.params['purge_rules_egress']
+    revoke_rules = module.params['revoke_rules']
+    revoke_rules_egress = module.params['revoke_rules_egress']
 
     changed = False
 
@@ -369,6 +400,38 @@ def main():
                             group.authorize(rule['proto'], rule['from_port'], rule['to_port'], thisip, grantGroup)
                         changed = True
 
+        # Revoke ingress rules
+        if revoke_rules is not None:
+            for rule in revoke_rules:
+                validate_rule(module, rule)
+
+                group_id, ip, target_group_created = get_target_from_rule(module, ec2, rule, name, group, groups, vpc_id)
+                if target_group_created:
+                    changed = True
+
+                if rule['proto'] in ('all', '-1', -1):
+                    rule['proto'] = -1
+                    rule['from_port'] = None
+                    rule['to_port'] = None
+
+                # Convert ip to list we can iterate over
+                if not isinstance(ip, list):
+                    ip = [ip]
+
+                # Only try to revoke rule if it exists
+                for thisip in ip:
+                    ruleId = make_rule_key('in', rule, group_id, thisip)
+                    if ruleId in groupRules:
+                        del groupRules[ruleId]
+
+                        grantGroup = None
+                        if group_id:
+                            grantGroup = groups[group_id]
+
+                        if not module.check_mode:
+                            group.revoke(rule['proto'], rule['from_port'], rule['to_port'], thisip, grantGroup)
+                        changed = True
+
         # Finally, remove anything left in the groupRules -- these will be defunct rules
         if purge_rules:
             for (rule, grant) in groupRules.itervalues() :
@@ -444,6 +507,44 @@ def main():
             else:
                 # make sure the default egress rule is not removed
                 del groupRules[default_egress_rule]
+
+       # Revoke egress rules
+        if revoke_rules_egress is not None:
+            for rule in revoke_rules_egress:
+                validate_rule(module, rule)
+
+                group_id, ip, target_group_created = get_target_from_rule(module, ec2, rule, name, group, groups, vpc_id)
+                if target_group_created:
+                    changed = True
+
+                if rule['proto'] in ('all', '-1', -1):
+                    rule['proto'] = -1
+                    rule['from_port'] = None
+                    rule['to_port'] = None
+
+                # Convert ip to list we can iterate over
+                if not isinstance(ip, list):
+                    ip = [ip]
+
+                # Only try to revoke rule if it exists
+                for thisip in ip:
+                    ruleId = make_rule_key('in', rule, group_id, thisip)
+                    if ruleId in groupRules:
+                        del groupRules[ruleId]
+
+                        grantGroup = None
+                        if group_id:
+                            grantGroup = groups[group_id].id
+
+                        if not module.check_mode:
+                            ec2.revoke_security_group_egress(
+                                    group_id=group.id,
+                                    ip_protocol=rule['proto'],
+                                    from_port=rule['from_port'],
+                                    to_port=rule['to_port'],
+                                    src_group_id=grantGroup,
+                                    cidr_ip=thisip)
+                        changed = True
 
         # Finally, remove anything left in the groupRules -- these will be defunct rules
         if purge_rules_egress:


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

ec2_group
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

ec2_group allows us to create security groups, to remove security groups and to add new rules to security groups. What it doesn't allow us to do is to remove rules, so we can't easily revoke rules that have been set. With this change we can.

Fixes #4251
