### PR TITLE
Fixes #2322 fix for missing append check on Darwin systems

### DIFF
--- a/system/user.py
+++ b/system/user.py
@@ -1546,12 +1546,13 @@ class DarwinUser(User):
         else:
             target = set([])
 
-        for remove in current - target:
-            (_rc, _err, _out) = self.__modify_group(remove, 'delete')
-            rc += rc
-            out += _out
-            err += _err
-            changed = True
+        if self.append is False:
+            for remove in current - target:
+                (_rc, _err, _out) = self.__modify_group(remove, 'delete')
+                rc += rc
+                out += _out
+                err += _err
+                changed = True
 
         for add in target - current:
             (_rc, _err, _out) = self.__modify_group(add, 'add')


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

user module
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel aece03312f) last updated 2016/07/26 14:11:01 (GMT -500)
  lib/ansible/modules/core: (detached HEAD 24db4de245) last updated 2016/07/26 14:11:04 (GMT -500)
  lib/ansible/modules/extras: (detached HEAD db979dde74) last updated 2016/07/26 14:11:08 (GMT -500)
```
##### SUMMARY

This fixes an issue where on OS X systems setting the groups property would ignore the append property, so attempting to add a group to a user would delete all other groups the user currently belonged to.
