### PR TITLE
Fixes issue #2971 #1381 #3056

### DIFF
--- a/cloud/vmware/vsphere_guest.py
+++ b/cloud/vmware/vsphere_guest.py
@@ -736,7 +736,7 @@ def deploy_template(vsphere_client, guest, resource_pool, template_src, esxi, mo
 
     try:
         if not vmTarget:
-            cloneArgs = dict(resourcepool=rpmor, power_on=power_on_after_clone)
+            cloneArgs = dict(resourcepool=rpmor, power_on=False)
 
             if snapshot_to_clone is not None:
                 #check if snapshot_to_clone is specified, Create a Linked Clone instead of a full clone.
@@ -748,6 +748,18 @@ def deploy_template(vsphere_client, guest, resource_pool, template_src, esxi, mo
                 cloneArgs["folder"] = vm_extra_config.get("folder")
 
             vmTemplate.clone(guest, **cloneArgs)
+
+            vm = vsphere_client.get_vm_by_name(guest)
+
+            # VM was created. If there is any extra config options specified, set
+            if vm_extra_config:
+                vm.set_extra_config(vm_extra_config)
+
+            # Power on if asked
+            if power_on_after_clone == True:
+                state = 'powered_on'
+                power_state(vm, state, True)
+
             changed = True
         else:
             changed = False


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

vsphere_guest
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible-playbook 2.1.0.0

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

-Submitted an upstream PR for pySphere to include notes section in set_extra_config module
-After the clone section utilized an existing set_extra_config call to set all options
-The updated pySphere properly sets the note and the VM is properly tagged and put in the appropriate folder

<!---
If you are fixing an existing issue, please include "Fixes #2971 1381" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

No verbatim changes. The input was silently ignored and folder and notes were not being correctly assigned. Now they are. 

```

```
