### PR TITLE
Make group_name resolution VPC aware

### DIFF
--- a/cloud/amazon/ec2_group.py
+++ b/cloud/amazon/ec2_group.py
@@ -213,7 +213,7 @@ def get_target_from_rule(module, ec2, rule, name, group, groups, vpc_id):
             group_id = group.id
             groups[group_id] = group
             groups[group_name] = group
-        elif group_name in groups:
+        elif group_name in groups and (vpc_id is None or groups[group_name].vpc_id == vpc_id):
             group_id = groups[group_name].id
         else:
             if not rule.get('group_desc', '').strip():


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

cloud/amazon/ec2_group.py
##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.2.0 (devel aece03312f) last updated 2016/07/27 11:32:03 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 24db4de245) last updated 2016/07/27 12:07:55 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD db979dde74) last updated 2016/07/27 12:07:59 (GMT -400)
  config file = /home/sbrady/.ansible.cfg
  configured module search path = Default w/o overrides
$
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_x6CKl8/ansible_module_ec2_group.py", line 472, in <module>
    main()
  File "/tmp/ansible_x6CKl8/ansible_module_ec2_group.py", line 368, in main
    group.authorize(rule['proto'], rule['from_port'], rule['to_port'], thisip, grantGroup)
  File "/home/sbrady/.virtualenvs/infrastructure2/local/lib/python2.7/site-packages/boto/ec2/securitygroup.py", line 203, in authorize
    dry_run=dry_run)
  File "/home/sbrady/.virtualenvs/infrastructure2/local/lib/python2.7/site-packages/boto/ec2/connection.py", line 3207, in authorize_security_group
    params, verb='POST')
  File "/home/sbrady/.virtualenvs/infrastructure2/local/lib/python2.7/site-packages/boto/connection.py", line 1227, in get_status
    raise self.ResponseError(response.status, response.reason, body)
boto.exception.EC2ResponseError: EC2ResponseError: 400 Bad Request
<?xml version="1.0" encoding="UTF-8"?>
<Response><Errors><Error><Code>InvalidGroup.NotFound</Code><Message>You have specified two resources that belong to different networks.</Message></Error></Errors><RequestID>3bff3c06-2f83-47ba-a482-1d6bb5c5b559</RequestID></Response>
```

EC2 Security Group names are unique given a VPC.  When a group_name
value is specified in a rule, if the group_name does not exist in the
provided vpc_id it should create the group as per the documentation.

The groups dictionary uses group_names as keys, so it is possible to
find a group in another VPC with the name that is desired.  This causes
an error as the security group being acted on, and the security group
referenced in the rule are in two different VPCs.

To prevent this issue, we check to see if vpc_id is defined and if so
check that VPCs match, else we treat the group as new.
