### PR TITLE
Allow cron to target remote user without sudo

### DIFF
--- a/system/cron.py
+++ b/system/cron.py
@@ -476,7 +476,7 @@ class CronTab(object):
                 return "%s -l %s" % (pipes.quote(CRONCMD), pipes.quote(self.user))
             elif platform.system() == 'HP-UX':
                 return "%s %s %s" % (CRONCMD , '-l', pipes.quote(self.user))
-            else:
+            elif os.getlogin() != self.user:
                 user = '-u %s' % pipes.quote(self.user)
         return "%s %s %s" % (CRONCMD , user, '-l')
 
@@ -488,7 +488,7 @@ class CronTab(object):
         if self.user:
             if platform.system() in ['SunOS', 'HP-UX', 'AIX']:
                 return "chown %s %s ; su '%s' -c '%s %s'" % (pipes.quote(self.user), pipes.quote(path), pipes.quote(self.user), CRONCMD, pipes.quote(path))
-            else:
+            elif os.getlogin() != self.user:
                 user = '-u %s' % pipes.quote(self.user)
         return "%s %s %s" % (CRONCMD , user, pipes.quote(path))
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

cron.py
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file = /Users/{redacted}/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

```
[user@server ~]$ crontab -u user
must be privileged to use -u
```

Using the `-u` flag with the logged in username throws the above error.  By omitting the `-u` flag if the user var matches the logged in username, then the user is implied and the error is avoided.

<!--- Paste verbatim command output below, e.g. before and after your change -->
##### BEFORE

```
$ ansible -i inventory -u user server -m cron \
    -a 'user=user state=present hour=12 name=testcron job="echo foo"'

server | FAILED! => {
    "changed": false,
    "failed": true,
    "msg": "must be privileged to use -u\n"
}
```
##### AFTER

```
$ ansible -i inventory -u user server -m cron \
    -a 'user=user state=present hour=12 name=testcron job="echo foo"'

server | SUCCESS => {
    "changed": true,
    "envs": [],
    "jobs": [
        "testcron"
    ]
}
```
