### PR TITLE
Make ec2_elb_lb respect VPCs when resolving groups

### DIFF
--- a/cloud/amazon/ec2_elb_lb.py
+++ b/cloud/amazon/ec2_elb_lb.py
@@ -456,7 +456,7 @@ class ElbManager(object):
         self.wait = wait
         self.wait_timeout = wait_timeout
         self.tags = tags
-        
+
         self.aws_connect_params = aws_connect_params
         self.region = region
 
@@ -498,7 +498,7 @@ class ElbManager(object):
         self._set_instance_ids()
 
         self._set_tags()
-        
+
     def ensure_gone(self):
         """Destroy the ELB"""
         if self.elb:
@@ -610,7 +610,7 @@ class ElbManager(object):
                     info['cross_az_load_balancing'] = 'no'
 
             # return stickiness info?
-            
+
             info['tags'] = self.tags
 
         return info
@@ -1172,7 +1172,7 @@ class ElbManager(object):
         """Add/Delete tags"""
         if self.tags is None:
             return
-        
+
         params = {'LoadBalancerNames.member.1': self.name}
 
         tagdict = dict()
@@ -1183,8 +1183,8 @@ class ElbManager(object):
                                                   [('member', Tag)])
             tagdict = dict((tag.Key, tag.Value) for tag in current_tags
                            if hasattr(tag, 'Key'))
-            
-        # Add missing tags 
+
+        # Add missing tags
         dictact = dict(set(self.tags.items()) - set(tagdict.items()))
         if dictact:
             for i, key in enumerate(dictact):
@@ -1194,7 +1194,7 @@ class ElbManager(object):
             self.elb_conn.make_request('AddTags', params)
             self.changed=True
 
-        # Remove extra tags 
+        # Remove extra tags
         dictact = dict(set(tagdict.items()) - set(self.tags.items()))
         if dictact:
             for i, key in enumerate(dictact):
@@ -1202,7 +1202,7 @@ class ElbManager(object):
 
             self.elb_conn.make_request('RemoveTags', params)
             self.changed=True
-    
+
     def _get_health_check_target(self):
         """Compose target string from healthcheck parameters"""
         protocol = self.health_check['ping_protocol'].upper()
@@ -1276,7 +1276,7 @@ def main():
     wait = module.params['wait']
     wait_timeout = module.params['wait_timeout']
     tags = module.params['tags']
-    
+
     if state == 'present' and not listeners:
         module.fail_json(msg="At least one port is required for ELB creation")
 

--- a/cloud/amazon/ec2_elb_lb.py
+++ b/cloud/amazon/ec2_elb_lb.py
@@ -391,6 +391,7 @@ try:
     import boto
     import boto.ec2.elb
     import boto.ec2.elb.attributes
+    import boto.vpc
     from boto.ec2.elb.healthcheck import HealthCheck
     from boto.ec2.tag import Tag
     from boto.regioninfo import RegionInfo
@@ -418,6 +419,12 @@ def _throttleable_operation(max_retries):
                         raise
         return _do_op
     return _operation_wrapper
+
+def _get_vpc_connection(module, region, aws_connect_params):
+    try:
+        return connect_to_aws(boto.vpc, region, **aws_connect_params)
+    except (boto.exception.NoAuthHandlerFound, AnsibleAWSError) as e:
+        module.fail_json(msg=str(e))
 
 
 _THROTTLING_RETRIES = 5
@@ -1290,7 +1297,13 @@ def main():
         security_group_ids = []
         try:
             ec2 = ec2_connect(module)
-            grp_details = ec2.get_all_security_groups()
+            if subnets: # We have at least one subnet, ergo this is a VPC
+                vpc_conn = _get_vpc_connection(module=module, region=region, aws_connect_params=aws_connect_params)
+                vpc_id = vpc_conn.get_all_subnets([subnets[0]])[0].vpc_id
+                filters = {'vpc_id': vpc_id}
+            else:
+                filters = None
+            grp_details = ec2.get_all_security_groups(filters=filters)
 
             for group_name in security_group_names:
                 if isinstance(group_name, basestring):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

cloud/amazon/ec2_elb_lb.py
##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.1.0.0
  config file = /home/sbrady/.ansible.cfg
  configured module search path = Default w/o overrides
$
```
##### SUMMARY

When resolving group names to group_ids, ec2_elb_lb can find the same name(s) in other VPCs.  Since an ELB is tied to a VPC (by the subnets provided) we should only consider group names in our VPC.  This avoids the below error.

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
boto.exception.BotoServerError: BotoServerError: 409 Conflict
<ErrorResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/">
  <Error>
    <Type>Sender</Type>
    <Code>InvalidConfigurationRequest</Code>
    <Message>Security group &quot;sg-12db4676&quot; does not belong to VPC &quot;vpc-724a7a17&quot;</Message>
  </Error>
  <RequestId>dbcd7950-54ec-11e6-b41c-4d30340fdc1f</RequestId>
</ErrorResponse>
```
