### PR TITLE
GCE: Add support for 'number' parameter for manually provisioned Google Compute clusters

### DIFF
--- a/cloud/google/gce.py
+++ b/cloud/google/gce.py
@@ -614,8 +614,7 @@ def main():
             disk_auto_delete = dict(type='bool', default=True),
             preemptible = dict(type='bool', default=None),
         ),
-        mutually_exclusive=[('instance_names', 'base_name')],
-        required_together=[('base_name', 'num_instances')]
+        mutually_exclusive=[('instance_names', 'name')]
     )
 
     if not HAS_PYTHON26:
@@ -646,7 +645,7 @@ def main():
         inames = instance_names
     elif isinstance(instance_names, str):
         inames = instance_names.split(',')
-    if name and number:
+    if name:
         inames = name
     if not inames:
         module.fail_json(msg='Must specify a "base_name" or "instance_names"',

--- a/cloud/google/gce.py
+++ b/cloud/google/gce.py
@@ -465,6 +465,9 @@ def create_instances(module, gce, instance_names, number):
     if subnetwork is not None:
         gce_args['ex_subnetwork'] = subnetwork
 
+    if isinstance(instance_names, str) and not number:
+        instance_names = [instance_names]
+
     if isinstance(instance_names, str) and number:
         instance_responses = gce.ex_create_multiple_nodes(instance_names, lc_machine_type,
                                                           lc_image(), number, **gce_args)
@@ -550,8 +553,11 @@ def change_instance_state(module, gce, instance_names, number, zone_name, state)
     changed = False
     nodes = []
     state_instance_names = []
+
     if isinstance(instance_names, str) and number:
         node_names = ['%s-%03d' % (instance_names, i) for i in range(number)]
+    elif isinstance(instance_names, str) and not number:
+        node_names = [instance_names]
     else:
         node_names = instance_names
 
@@ -640,7 +646,7 @@ def main():
     preemptible = module.params.get('preemptible')
     changed = False
 
-    inames = []
+    inames = None
     if isinstance(instance_names, list):
         inames = instance_names
     elif isinstance(instance_names, str):
@@ -648,7 +654,7 @@ def main():
     if name:
         inames = name
     if not inames:
-        module.fail_json(msg='Must specify a "base_name" or "instance_names"',
+        module.fail_json(msg='Must specify a "name" or "instance_names"',
                          changed=False)
     if not zone:
         module.fail_json(msg='Must specify a "zone"', changed=False)

--- a/cloud/google/gce.py
+++ b/cloud/google/gce.py
@@ -89,16 +89,17 @@ options:
     default: null
   name:
     description:
-      - required with 'num_instances', base of generated name of node group
+      - either a name of a single instance or when used with 'num_instances',
+        the base name of a cluster of nodes
     required: false
     aliases: ['base_name']
   num_instances:
     description:
-      - required with 'base_name', specifies
-        the number of nodes to provision using 'base_name'
+      - can be used with 'name', specifies
+        the number of nodes to provision using 'name'
         as a base name
     required: false
-    version_added: "2.2"
+    version_added: "2.3"
   network:
     description:
       - name of the network, 'default' will be used if not specified

--- a/cloud/google/gce.py
+++ b/cloud/google/gce.py
@@ -98,6 +98,7 @@ options:
         the number of nodes to provision using name
         as a base name
     required: false
+    version_added: "2.2"
   network:
     description:
       - name of the network, 'default' will be used if not specified

--- a/cloud/google/gce.py
+++ b/cloud/google/gce.py
@@ -87,11 +87,11 @@ options:
       - your GCE project ID
     required: false
     default: null
-  base_name:
+  name:
     description:
       - required with 'num_instances', base of generated name of node group
     required: false
-    version_added: "2.2"
+    aliases: ['base_name']
   num_instances:
     description:
       - required with 'base_name', specifies
@@ -483,9 +483,9 @@ def create_instances(module, gce, instance_names, number):
                 pd = lc_disks[0]
             elif persistent_boot_disk:
                 try:
-                    pd = gce.ex_get_volume("%s" % name, lc_zone)
+                    pd = gce.ex_get_volume("%s" % instance, lc_zone)
                 except ResourceNotFoundError:
-                    pd = gce.create_volume(None, "%s" % name, image=lc_image())
+                    pd = gce.create_volume(None, "%s" % instance, image=lc_image())
             gce_args['ex_boot_disk'] = pd
 
             inst = None
@@ -498,7 +498,7 @@ def create_instances(module, gce, instance_names, number):
                 changed = True
             except GoogleBaseError as e:
                 module.fail_json(msg='Unexpected error attempting to create ' +
-                                 'instance %s, error: %s' % (name, e.value))
+                                 'instance %s, error: %s' % (instance, e.value))
             if inst:
                 new_instances.append(inst)
 
@@ -593,7 +593,7 @@ def main():
             instance_names = dict(),
             machine_type = dict(default='n1-standard-1'),
             metadata = dict(),
-            base_name = dict(),
+            name = dict(aliases=['base_name']),
             num_instances = dict(type='int'),
             network = dict(default='default'),
             subnetwork = dict(),
@@ -629,7 +629,7 @@ def main():
     instance_names = module.params.get('instance_names')
     machine_type = module.params.get('machine_type')
     metadata = module.params.get('metadata')
-    name = module.params.get('base_name')
+    name = module.params.get('name')
     number = module.params.get('num_instances')
     network = module.params.get('network')
     subnetwork = module.params.get('subnetwork')

--- a/cloud/google/gce.py
+++ b/cloud/google/gce.py
@@ -479,6 +479,9 @@ def create_instances(module, gce, instance_names, number):
                     n = gce.ex_get_node(n.name, lc_zone)
                 except ResourceNotFoundError:
                     pass
+            else:
+                # Assure that at least one node has been created to set changed=True
+                changed = True
             new_instances.append(n)
     else:
         for instance in instance_names:

--- a/cloud/google/gce.py
+++ b/cloud/google/gce.py
@@ -92,6 +92,12 @@ options:
       - identifier when working with a single instance.  Will be deprecated in a future release.
         Please 'instance_names' instead.
     required: false
+  number:
+    description:
+      - when used in combination with 'name', specifies
+        the number of nodes to provision using name
+        as a base name
+    required: false
   network:
     description:
       - name of the network, 'default' will be used if not specified

--- a/cloud/google/gce.py
+++ b/cloud/google/gce.py
@@ -91,6 +91,7 @@ options:
     description:
       - required with 'num_instances', base of generated name of node group
     required: false
+    version_added: "2.2"
   num_instances:
     description:
       - required with 'base_name', specifies


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

gce
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

This change will take advantage of the libcloud `ex_create_multiple_nodes` and `ex_destroy_multiple_nodes` functions for faster provisioning and destruction of manually provisioned clusters on Google Cloud. Because libcloud does not have comparable functions for starting and stopping clusters, `number` is designed to be compatible with (but does not provide asynchronous behavior in the context of) `started` and `stopped` states or their aliases. Another problem is that because of the nature of the arguments taken by `ex_create_multiple_nodes`, providing `instance_names` to the `gce` module will result in synchronous behavior as `ex_create_multiple_nodes` always must generate a list of node names off of a base name and will not accept an arbitrarily named list of nodes or node names. There are some `try` blocks in the context of `number` that are meant to be consistent with other modules by showing all nodes in the output that were either provisioned or found to be compliant in terms of state as opposed to only showing nodes that were not compliant in terms of state. This will allow state to be consistently displayed in the output for all node names generated from the base name. 

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
{
    "changed": false, 
    "instance_data": [
        {
            "disks": [
                "test-000"
            ], 
            "image": "debian-7-wheezy-v20160531", 
            "machine_type": "n1-standard-1", 
            "metadata": {}, 
            "name": "test-000", 
            "network": "default", 
            "private_ip": "10.240.0.11", 
            "public_ip": "104.198.239.33", 
            "status": "RUNNING", 
            "subnetwork": null, 
            "tags": [], 
            "zone": "us-central1-a"
        }, 
        {
            "disks": [
                "test-001"
            ], 
            "image": "debian-7-wheezy-v20160531", 
            "machine_type": "n1-standard-1", 
            "metadata": {}, 
            "name": "test-001", 
            "network": "default", 
            "private_ip": "10.240.0.13", 
            "public_ip": "104.198.254.203", 
            "status": "RUNNING", 
            "subnetwork": null, 
            "tags": [], 
            "zone": "us-central1-a"
        }, 
        {
            "disks": [
                "test-002"
            ], 
            "image": "debian-7-wheezy-v20160531", 
            "machine_type": "n1-standard-1", 
            "metadata": {}, 
            "name": "test-002", 
            "network": "default", 
            "private_ip": "10.240.0.14", 
            "public_ip": "146.148.69.230", 
            "status": "RUNNING", 
            "subnetwork": null, 
            "tags": [], 
            "zone": "us-central1-a"
        }, 
        {
            "disks": [
                "test-003"
            ], 
            "image": "debian-7-wheezy-v20160531", 
            "machine_type": "n1-standard-1", 
            "metadata": {}, 
            "name": "test-003", 
            "network": "default", 
            "private_ip": "10.240.0.15", 
            "public_ip": "104.154.64.83", 
            "status": "RUNNING", 
            "subnetwork": null, 
            "tags": [], 
            "zone": "us-central1-a"
        }, 
        {
            "disks": [
                "test-004"
            ], 
            "image": "debian-7-wheezy-v20160531", 
            "machine_type": "n1-standard-1", 
            "metadata": {}, 
            "name": "test-004", 
            "network": "default", 
            "private_ip": "10.240.0.16", 
            "public_ip": "104.197.28.163", 
            "status": "RUNNING", 
            "subnetwork": null, 
            "tags": [], 
            "zone": "us-central1-a"
        }
    ], 
    "invocation": {
        "module_args": {
            "credentials_file": null, 
            "disk_auto_delete": true, 
            "disks": null, 
            "external_ip": "ephemeral", 
            "image": "debian-7", 
            "instance_names": null, 
            "ip_forward": false, 
            "machine_type": "n1-standard-1", 
            "metadata": null, 
            "name": "test", 
            "network": "default", 
            "number": 5, 
            "pem_file": null, 
            "persistent_boot_disk": false, 
            "preemptible": null, 
            "project_id": null, 
            "service_account_email": null, 
            "service_account_permissions": null, 
            "state": "present", 
            "subnetwork": null, 
            "tags": null, 
            "zone": "us-central1-a"
        }
    }, 
    "name": "test", 
    "state": "present", 
    "zone": "us-central1-a"
}
```

/cc @supertom @ryansb
