### PR TITLE
Fixes #3791 cron always returning changed state for multiline jobs

### DIFF
--- a/system/cron.py
+++ b/system/cron.py
@@ -383,6 +383,9 @@ class CronTab(object):
         return []
 
     def get_cron_job(self,minute,hour,day,month,weekday,job,special,disabled):
+        # normalize any leading/trailing newlines (ansible/ansible-modules-core#3791)
+        job = job.strip()
+
         if disabled:
             disable_prefix = '#'
         else:

--- a/system/cron.py
+++ b/system/cron.py
@@ -384,7 +384,7 @@ class CronTab(object):
 
     def get_cron_job(self,minute,hour,day,month,weekday,job,special,disabled):
         # normalize any leading/trailing newlines (ansible/ansible-modules-core#3791)
-        job = job.strip()
+        job = job.strip('\r\n')
 
         if disabled:
             disable_prefix = '#'


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

cron
##### ANSIBLE VERSION

Confirmed fixed with the following versions:

```
ansible 2.0.1.0
  config file = 
  configured module search path = Default w/o overrides
ansible 2.1.1.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Stripping any leading/trailing whitespace (namely trailing newlines as a result of [folded style yaml](http://www.yaml.org/spec/1.2/spec.html#id2796251)) in `CronTab.get_cron_job`.

Fixes #3791

Given the following tasks:

``` yml
- name: cron test
  cron:
    name: cron test
    job: >
      bash -l -c
      "echo foo &&
      echo \"bar\" &&
      echo baz"
    special_time: "monthly"

- name: cron control
  cron:
    name: cron control
    job: bash -l -c "echo foo && echo \"bar\" && echo baz"
    special_time: "monthly"
```

Output before this change:

```
TASK [common : cron test] ******************************************************
changed: [local.example.com]

TASK [common : cron control] ***************************************************
ok: [local.example.com]
```

Output after this change:

```
TASK [common : cron test] ******************************************************
ok: [local.example.com]

TASK [common : cron control] ***************************************************
ok: [local.example.com]
```
