### PR TITLE
file module: add clarification on state=absent re files that do not e…

### DIFF
--- a/files/file.py
+++ b/files/file.py
@@ -55,6 +55,7 @@ options:
         or M(template) module if you want that behavior.  If C(link), the symbolic
         link will be created or changed. Use C(hard) for hardlinks. If C(absent),
         directories will be recursively deleted, and files or symlinks will be unlinked.
+        Note that M(file) will not fail if the C(path) does not exist as the state did not change.
         If C(touch) (new in 1.4), an empty file will be created if the C(path) does not
         exist, while an existing file or directory will receive updated file access and
         modification times (similar to the way `touch` works from the command line).


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

module file
##### ANSIBLE VERSION

Running

```
ansible 2.0.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

but using current devel branch of doc.
##### SUMMARY

When working on a playbook, I was not sure if the state management would prevent failing the deployment if the file did not exist. I had to review the module code to verify this was so, AFAICT, and putting that in the doc seems valuable to a new Ansible dev.
