### PR TITLE
Fix Typo in docker_image_facts module

### DIFF
--- a/cloud/docker/docker_image_facts.py
+++ b/cloud/docker/docker_image_facts.py
@@ -57,7 +57,7 @@ EXAMPLES = '''
     name: pacur/centos-7
 
 - name: Inspect multiple images
-  docker_iamge_facts:
+  docker_image_facts:
     name:
       - pacur/centos-7
       - sinatra


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

docker_image_facts module
##### ANSIBLE VERSION

```
devel
```
##### SUMMARY

```
Fix typo in the example of docker_image_facts module, replaced docker_iamge_facts by docker_image_facts
```
