### PR TITLE
Adding ability to create linode from stack script

### DIFF
--- a/cloud/linode/linode.py
+++ b/cloud/linode/linode.py
@@ -78,7 +78,7 @@ options:
     description:
      - JSON encoded name/value pairs, answering the StackScript's User Defined Fields
     default: null
-    type: string
+    type: json
   distribution:
     description:
      - distribution to use for the instance (Linode Distribution)
@@ -464,7 +464,7 @@ def main():
             name = dict(type='str'),
             plan = dict(type='int'),
             stack_script_id = dict(type='int'),
-            stack_script_udf_responses = dict(type='str'),
+            stack_script_udf_responses = dict(type='json'),
             distribution = dict(type='int'),
             datacenter = dict(type='int'),
             linode_id = dict(type='int', aliases=['lid']),

--- a/cloud/linode/linode.py
+++ b/cloud/linode/linode.py
@@ -74,11 +74,13 @@ options:
      - The ID of the StackScript to use
     default: null
     type: integer
+    version_added: "2.2"
   stack_script_udf_responses:
     description:
      - JSON encoded name/value pairs, answering the StackScript's User Defined Fields
     default: null
     type: json
+    version_added: "2.2"
   distribution:
     description:
      - distribution to use for the instance (Linode Distribution)


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

ansible-modules-core/cloud/linode/linode.py
##### ANSIBLE VERSION

```
ansible 2.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Linode has the capability of accepting a [StackScript](https://www.linode.com/stackscripts) when creating an instance. This script can then be run as part of the initialization process. The functionality is already part of the [linode library](https://github.com/tjfontaine/linode-python) that Ansible depends upon. This pull request implements that functionality into the Ansible linode module.

Example playbook:

```

---
- hosts: 127.0.0.1
  connection: local
  gather_facts: yes

  tasks:
    - name: Create a linode machine 
      linode:
        api_key: 'yourapikey'
        name: hostname
        plan: 1
        datacenter: 2
        distribution: 124
        stack_script_id: 12345
        stack_script_udf_responses: '{"hello": "world"}'
        password: 'rootpassword'
        ssh_pub_key: 'ssh-rsa AAAABBBBCCCC'
        swap: 768
        wait: yes
        wait_timeout: 600
        state: started
...
```

Save the example as `linode-test.yml` and run from the command line:

```
# ansible-playbook linode-test.yml -vvvvv
```

Side note, not sure why we were duplicating the call to createfromdistribution if there was a root SSH key specified. So I removed that duplication and we now gracefully continue with or without a key.
