### PR TITLE
Fix typo in "ssantaize" typo

### DIFF
--- a/network/junos/junos_config.py
+++ b/network/junos/junos_config.py
@@ -51,7 +51,7 @@ options:
     default: null
   zeroize:
     description:
-      - The C(zeroize) argument is used to completely ssantaize the
+      - The C(zeroize) argument is used to completely santaize the
         remote device configuration back to initial defaults.  This
         argument will effectively remove all current configuration
         statements on the remote device

--- a/network/junos/junos_config.py
+++ b/network/junos/junos_config.py
@@ -51,7 +51,7 @@ options:
     default: null
   zeroize:
     description:
-      - The C(zeroize) argument is used to completely santaize the
+      - The C(zeroize) argument is used to completely sanitize the
         remote device configuration back to initial defaults.  This
         argument will effectively remove all current configuration
         statements on the remote device


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

network/junos/junos_config.py
##### SUMMARY

Fix a typo. Typos make things look bad and make people question accuracy of other information

ssantaize to santaize
