### PR TITLE
Adding pull option

### DIFF
--- a/cloud/docker/docker_service.py
+++ b/cloud/docker/docker_service.py
@@ -123,6 +123,7 @@ options:
       type: bool
       required: false
       default: false
+      version_added: "2.2"
   remove_images:
       description:
         - Use with state I(absent) to remove the all images or only local images.


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

docker_service.py 
##### ANSIBLE VERSION

```
ansible 2.2.0 (docker_connection 17e4629d52) last updated 2016/08/02 04:23:18 (GMT -400)
  lib/ansible/modules/core: (devel 81b3022eb5) last updated 2016/08/02 22:23:09 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD db979dde74) last updated 2016/08/02 04:22:23 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Per issue #4257, this PR fixes the following:

Currently it is not easily possible to update images used by docker_service. When an image does not exist, docker_service will pull it, but it won't update it once it is already there. The only way around this is to use state:absent and remove_images:all to kill the container and delete all images. This is suboptimal because you have to re-download the whole image even if just a tiny part changed and you have to invoke two instances of the docker_service command to update an existing service.
