### PR TITLE
Add explicit image build

### DIFF
--- a/cloud/docker/docker_service.py
+++ b/cloud/docker/docker_service.py
@@ -400,9 +400,35 @@ actions:
           returned: always
           type: complex
           contains:
+              pulled_image:
+                  description: Provides image details when a new image is pulled for the service.
+                  returned: on image pull
+                  type: complex
+                  contains:
+                      name:
+                          description: name of the image
+                          returned: always
+                          type: string
+                      id:
+                          description: image hash
+                          returned: always
+                          type: string
+              built_image:
+                  description: Provides image details when a new image is built for the service.
+                  returned: on image build
+                  type: complex
+                  contains:
+                      name:
+                          description: name of the image
+                          returned: always
+                          type: string
+                      id:
+                          desription: image hash
+                          returned: always
+                          type: string
+
               action:
-                  description: A descriptive name of the action to be performed on the set of containers
-                               within the service.
+                  description: A descriptive name of the action to be performed on the service's containers.
                   returned: always
                   type: list
                   contains:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

docker_service.py 
##### ANSIBLE VERSION

```
ansible 2.2.0 (docker_connection 17e4629d52) last updated 2016/08/02 04:23:18 (GMT -400)
  lib/ansible/modules/core: (devel 18343c4e5a) last updated 2016/08/03 00:40:00 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD db979dde74) last updated 2016/08/02 04:22:23 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fixes issue #4158 by explicitly calling `docker-compose build` when _build_ is true. The build will be performed prior to calling `docker-compose up` so that replaced images will cause existing containers to be recreated. Also includes new _nocache_ option to allow ignoring cache during the image build process.
