### PR TITLE
Added implementation of ignore_image

### DIFF
--- a/cloud/docker/docker_container.py
+++ b/cloud/docker/docker_container.py
@@ -45,7 +45,7 @@ options:
       - Use with I(detach) to remove the container after successful execution.
     default: false
     required: false
-    version_added: 2.2
+    version_added: "2.2"
   command:
     description:
       - Command to execute when the container starts.
@@ -150,10 +150,11 @@ options:
     description:
       - When C(state) is I(present) or I(started) the module compares the configuration of an existing
         container to requested configuration. The evaluation includes the image version. If
-        the image vesion in the registry does not match the container, the container will be
+        the image version in the registry does not match the container, the container will be
         recreated. Stop this behavior by setting C(ignore_image) to I(True).
     default: false
     required: false
+    version_added: "2.2"      
   image:
     description:
       - Repository path and tag used to create the container. If an image is not found or pull is true, the image
@@ -691,6 +692,7 @@ class TaskParameters(DockerBaseClass):
         self.force_kill = None
         self.groups = None
         self.hostname = None
+        self.ignore_image = None
         self.image = None
         self.interactive = None
         self.ipc_mode = None
@@ -1629,7 +1631,9 @@ class ContainerManager(DockerBaseClass):
         else:
             # Existing container
             different, differences = container.has_different_configuration(image)
-            image_different = self._image_is_different(image, container)
+            image_different = False
+            if not self.parameters.ignore_image:
+                image_different = self._image_is_different(image, container)
             if image_different or different or self.parameters.recreate:
                 self.diff['differences'] = differences
                 if image_different:
@@ -1892,6 +1896,7 @@ def main():
         force_kill=dict(type='bool', default=False, aliases=['forcekill']),
         groups=dict(type='list'),
         hostname=dict(type='str'),
+        ignore_image=dict(type='bool', default=False),
         image=dict(type='str'),
         interactive=dict(type='bool', default=False),
         ipc_mode=dict(type='str'),


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

docker_container.py
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 5f12731797) last updated 2016/08/03 16:02:50 (GMT -400)
  lib/ansible/modules/core: (devel af177834af) last updated 2016/08/03 16:36:56 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD db979dde74) last updated 2016/08/02 04:22:23 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fixes issue #3949 

The _ignore_image_ parameter was documented but never implemented. This change implements it. When ignore_image is true, the module will not check the image version. Normally if the container is running on a different version of an image, the container will be recreated. Passing _ignore_image_ stops this behavior, leaving the running container untouched.
