### PR TITLE
strip output before filtering to fix #4309

### DIFF
--- a/web_infrastructure/django_manage.py
+++ b/web_infrastructure/django_manage.py
@@ -271,7 +271,7 @@ def main():
 
     changed = False
 
-    lines = out.split('\n')
+    lines = out.strip().split('\n')
     filt = globals().get(command + "_filter_output", None)
     if filt:
         filtered_output = filter(filt, out.split('\n'))


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

django_manage
##### ANSIBLE VERSION

```
ansible 2.0.0.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fixes #4309
this is not tested as I don't know how to run the tests for ansible
