### PR TITLE
Quick fix to nxos_command and minify imports

### DIFF
--- a/network/nxos/nxos_command.py
+++ b/network/nxos/nxos_command.py
@@ -115,8 +115,13 @@ failed_conditions:
 """
 
 import time
-import shlex
 import re
+
+from ansible.module_utils.basic import get_exception
+from ansible.module_utils.netcmd import Conditional
+from ansible.module_utils.network import get_module
+from ansible.module_utils.nxos import *
+
 
 INDEX_RE = re.compile(r'(\[\d+\])')
 
@@ -158,7 +163,7 @@ def main():
         kwargs['command_type'] = 'cli_show'
 
     while retries > 0:
-        response = module.execute(commands, **kwargs)
+        response = module.cli(commands, **kwargs)
         result['stdout'] = response
 
         for index, cmd in enumerate(commands):
@@ -188,11 +193,5 @@ def main():
     return module.exit_json(**result)
 
 
-from ansible.module_utils.basic import *
-from ansible.module_utils.urls import *
-from ansible.module_utils.shell import *
-from ansible.module_utils.netcfg import *
-from ansible.module_utils.nxos import *
 if __name__ == '__main__':
-        main()
-
+    main()


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

nxos/nxos_command
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.2
```
##### SUMMARY

Quick fix for problems encountered in nxos_command, may not be the full fix, but should avoid `AttributeError: 'NetworkModule' object has no attribute 'execute'` errors
