### PR TITLE
Fix ios_config broken logic

### DIFF
--- a/network/ios/ios_config.py
+++ b/network/ios/ios_config.py
@@ -193,7 +193,7 @@ responses:
   sample: ['...', '...']
 """
 from ansible.module_utils.netcfg import NetworkConfig, dumps
-from ansible.module_utils.ios import NetworkModule
+from ansible.module_utils.network import NetworkModule
 from ansible.module_utils.ios import load_config, get_config, ios_argument_spec
 
 def invoke(name, *args, **kwargs):
@@ -271,9 +271,10 @@ def main():
     commands = list()
     if configobjs:
         commands = dumps(configobjs, 'commands')
+        commands = commands.split('\n')
 
         if module.params['before']:
-            commands[:0] = before
+            commands[:0] = module.params['before']
 
         if module.params['after']:
             commands.extend(module.params['after'])
@@ -283,9 +284,6 @@ def main():
             result.update(**response)
 
         result['changed'] = True
-
-    if commands:
-        commands = commands.split('\n')
 
     result['updates'] = commands
     result['connected'] = module.connected


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

ios/ios_config
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.2
```
##### SUMMARY

Hopefully addresses #4320.

`commands` appears to be a list universally except when it is returned from `dumps()`, so making the split call come right after that should allow the before and after segments to work properly. Removing the conditional seemed to make sense as the only output from `dumps()` other than a string is an exception.
