### PR TITLE
Fixes #2316 - Ensure blank line at end of cron file

### DIFF
--- a/system/cron.py
+++ b/system/cron.py
@@ -456,7 +456,7 @@ class CronTab(object):
 
         self.lines = newlines
 
-    def render(self):
+    def render(self, diff=None):
         """
         Render this crontab as it would be in the crontab.
         """
@@ -465,7 +465,7 @@ class CronTab(object):
             crons.append(cron)
 
         result = '\n'.join(crons)
-        if result:
+        if result and not diff:
             result = result.rstrip('\r\n') + '\n'
         return result
 
@@ -582,7 +582,7 @@ def main():
 
     if module._diff:
         diff = dict()
-        diff['before'] = crontab.render()
+        diff['before'] = crontab.render(diff=True)
         if crontab.cron_file:
             diff['before_header'] = crontab.cron_file
         else:

--- a/system/cron.py
+++ b/system/cron.py
@@ -223,6 +223,7 @@ class CronTab(object):
         self.root      = (os.getuid() == 0)
         self.lines     = None
         self.ansible   = "#Ansible: "
+        self.terminated= True
 
         if cron_file:
             if os.path.isabs(cron_file):
@@ -241,7 +242,9 @@ class CronTab(object):
             # read the cronfile
             try:
                 f = open(self.cron_file, 'r')
-                self.lines = f.read().splitlines()
+                read_cron_file = f.read()
+                self.terminated = read_cron_file.endswith(('\r', '\n'))
+                self.lines = read_cron_file.splitlines()
                 f.close()
             except IOError:
                 # cron file does not exist
@@ -254,6 +257,8 @@ class CronTab(object):
 
             if rc != 0 and rc != 1: # 1 can mean that there are no jobs.
                 raise CronTabError("Unable to read crontab")
+
+            self.terminated = out.endswith(('\r', '\n'))
 
             lines = out.splitlines()
             count = 0
@@ -460,8 +465,8 @@ class CronTab(object):
             crons.append(cron)
 
         result = '\n'.join(crons)
-        if result and result[-1] not in ['\n', '\r']:
-            result += '\n'
+        if result:
+            result = result.rstrip('\r\n') + '\n'
         return result
 
     def _read_user_execute(self):
@@ -655,6 +660,10 @@ def main():
             if len(old_job) > 0:
                 crontab.remove_job(name)
                 changed = True
+
+    # no changes to env/job, but existing crontab needs a terminating newline
+    if not changed and not crontab.terminated:
+        changed = True
 
     res_args = dict(
         jobs = crontab.get_jobnames(),


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

cron module
##### ANSIBLE VERSION

```
ansible 2.1.1.0
```
##### SUMMARY
- Normalizes and ensures **a single newline** terminating the rendered cron file
- Detects when an existing cron file is missing a terminating newline, and **triggers a render & write** with proper termination
- ~~For diff mode, renders the `before` to reflect whether existing cron file is newline terminated~~
- For diff mode, retrieves existing cron file content as the `before`

Fixes #2316

Testing with these tasks against a server that has _existing managed jobs_, without a terminating newline:

``` yml
- name: cron test
  cron:
    name: "cron test"
    hour: 0
    minute: 0
    user: root
    job: "/bin/echo 'nightly cron job has run' | /usr/bin/logger -t cron_nightly"
    cron_file: nightly
- name: cron test 2
  cron:
    name: "cron test 2"
    hour: 0
    minute: 0
    user: root
    job: "/bin/echo 'nightly cron job has run' | /usr/bin/logger -t cron_nightly"
    cron_file: nightly
```

Running with `--check` and `--diff` flags, the diff properly reflects that the current cron file is **not newline terminated**:

```
TASK [cron test] ***************************************************************
changed: [local]
--- before: /etc/cron.d/nightly
+++ after: /etc/cron.d/nightly
@@ -1,4 +1,4 @@
 #Ansible: cron test
 0 0 * * * root /bin/echo 'nightly cron job has run' | /usr/bin/logger -t cron_nightly
 #Ansible: cron test 2
-0 0 * * * root /bin/echo 'nightly cron job has run' | /usr/bin/logger -t cron_nightly+0 0 * * * root /bin/echo 'nightly cron job has run' | /usr/bin/logger -t cron_nightly


TASK [cron test 2] *************************************************************
changed: [local]
--- before: /etc/cron.d/nightly
+++ after: /etc/cron.d/nightly
@@ -1,4 +1,4 @@
 #Ansible: cron test
 0 0 * * * root /bin/echo 'nightly cron job has run' | /usr/bin/logger -t cron_nightly
 #Ansible: cron test 2
-0 0 * * * root /bin/echo 'nightly cron job has run' | /usr/bin/logger -t cron_nightly+0 0 * * * root /bin/echo 'nightly cron job has run' | /usr/bin/logger -t cron_nightly
```

And running with only `--diff` flag, **the first task registers a `change` in order to write a newline**, while the second task only registers an `ok`:

```
TASK [cron test] ***************************************************************
changed: [local]
--- before: /etc/cron.d/nightly
+++ after: /etc/cron.d/nightly
@@ -1,4 +1,4 @@
 #Ansible: cron test
 0 0 * * * root /bin/echo 'nightly cron job has run' | /usr/bin/logger -t cron_nightly
 #Ansible: cron test 2
-0 0 * * * root /bin/echo 'nightly cron job has run' | /usr/bin/logger -t cron_nightly+0 0 * * * root /bin/echo 'nightly cron job has run' | /usr/bin/logger -t cron_nightly


TASK [cron test 2] *************************************************************
ok: [local]
```
