### PR TITLE
Add a example with a non service unit

### DIFF
--- a/system/systemd.py
+++ b/system/systemd.py
@@ -77,6 +77,11 @@ EXAMPLES = '''
     name: httpd
     enabled: yes
     masked: no
+# Example action to enable a timer for dnf-automatic
+- systemd:
+    name: dnf-automatic.timer
+    state: started
+    enabled: True
 '''
 
 RETURN = '''


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

systemd
##### SUMMARY

Add a example with a non service unit

Since the documentation focus mostly on service
units, a explicit example may help people realizing
it can be used for socket and timer too.
