### PR TITLE
Fix ec2_group 'rules' doc string.

### DIFF
--- a/cloud/amazon/ec2_group.py
+++ b/cloud/amazon/ec2_group.py
@@ -42,7 +42,7 @@ options:
     required: false
   rules:
     description:
-      - List of firewall inbound rules to enforce in this group (see example). If none are supplied, a default all-out rule is assumed. If an empty list is supplied, no inbound rules will be enabled.
+      - List of firewall inbound rules to enforce in this group (see example). If none are supplied, a default all-in rule is assumed. If an empty list is supplied, no inbound rules will be enabled.
     required: false
   rules_egress:
     description:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

cloud/amazon/ec2_group
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (vault_embedded_text_weird 1ad566052e) last updated 2016/08/05 15:34:12 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 24db4de245) last updated 2016/07/27 15:10:26 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD db979dde74) last updated 2016/07/27 15:10:26 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

Update to correct 'all-in' default if rules aren't
specified.

Fixes #17004
