### PR TITLE
Add support for password aging on Solaris

### DIFF
--- a/system/user.py
+++ b/system/user.py
@@ -1430,6 +1430,7 @@ class SunOS(User):
                     open(self.SHADOWFILE, 'w+').writelines(lines)
                     rc = 0
                 except Exception, err:
+                    err = get_exception()
                     self.module.fail_json(msg="failed to update users password: %s" % str(err))
 
         return (rc, out, err)

--- a/system/user.py
+++ b/system/user.py
@@ -1247,11 +1247,11 @@ class SunOS(User):
                     continue
                 key, value = line.split('=')
                 if key == "MINWEEKS":
-                    minweeks = value
+                    minweeks = value.rstrip('\n')
                 elif key == "MAXWEEKS":
-                    maxweeks = value
+                    maxweeks = value.rstrip('\n')
                 elif key == "WARNWEEKS":
-                    warnweeks = value
+                    warnweeks = value.rstrip('\n')
         except Exception:
             err = get_exception()
             self.module.fail_json(msg="failed to read /etc/default/passwd: %s" % str(err))
@@ -1325,11 +1325,11 @@ class SunOS(User):
                             continue
                         fields[1] = self.password
                         fields[2] = str(int(time.time() / 86400))
-                        if minweeks is not None:
+                        if minweeks:
                             fields[3] = str(int(minweeks) * 7)
-                        if maxweeks is not None:
+                        if maxweeks:
                             fields[4] = str(int(maxweeks) * 7)
-                        if warnweeks is not None:
+                        if warnweeks:
                             fields[5] = str(int(warnweeks) * 7)
                         line = ':'.join(fields)
                         lines.append('%s\n' % line)
@@ -1419,11 +1419,11 @@ class SunOS(User):
                             continue
                         fields[1] = self.password
                         fields[2] = str(int(time.time() / 86400))
-                        if minweeks is not None:
+                        if minweeks:
                             fields[3] = str(int(minweeks) * 7)
-                        if maxweeks is not None:
+                        if maxweeks:
                             fields[4] = str(int(maxweeks) * 7)
-                        if warnweeks is not None:
+                        if warnweeks:
                             fields[5] = str(int(warnweeks) * 7)
                         line = ':'.join(fields)
                         lines.append('%s\n' % line)

--- a/system/user.py
+++ b/system/user.py
@@ -1429,7 +1429,7 @@ class SunOS(User):
                         lines.append('%s\n' % line)
                     open(self.SHADOWFILE, 'w+').writelines(lines)
                     rc = 0
-                except Exception, err:
+                except Exception:
                     err = get_exception()
                     self.module.fail_json(msg="failed to update users password: %s" % str(err))
 


### PR DESCRIPTION
- Feature Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

system/user.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
  config file = /usr/local/etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

The user module was missing support for password aging (min days, max days and warn days). This patch adds the missing functionality.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

Fixes #1280 

<!--- Paste verbatim command output below, e.g. before and after your change -->

```

```
