### PR TITLE
pip: Fix uninitialized variable during check_mode

### DIFF
--- a/packaging/language/pip.py
+++ b/packaging/language/pip.py
@@ -410,6 +410,7 @@ def main():
             out += out_pip
             err += err_pip
 
+            changed = False
             if name:
                 for pkg in name:
                     is_present = _is_present(pkg, version, out.split())


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

packaging/language/pip
##### ANSIBLE VERSION

```
ansible 2.2.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

During check_mode (`--check`), the variable `changed` could be
used uninitialized, yielding this error:

`UnboundLocalError: local variable 'changed' referenced before assignment`

This commit simply initializes it to False.  The fragment below it will assign it True if there is a change.

I believe this bug was introduced in commit a3c5d072e01dc8a1d997b77119e5c4a515e6f4b5.

```
fatal: [pg1]: FAILED! => {"changed": false, "failed": true, "module_stderr": "", "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_AbKLPb/ansible_module_pip.py
\", line 458, in <module>\r\n    main()\r\n  File \"/tmp/ansible_AbKLPb/ansible_module_pip.py\", line 419, in main\r\n    module.exit_json(changed=changed, cmd=freeze_cmd, stdout=out, std
err=err)\r\nUnboundLocalError: local variable 'changed' referenced before assignment\r\n", "msg": "MODULE FAILURE", "parsed": false}
```
