### PR TITLE
Improve hostname module to support systemd in more generic way

### DIFF
--- a/system/hostname.py
+++ b/system/hostname.py
@@ -48,6 +48,7 @@ from distutils.version import LooseVersion
 
 # import module snippets
 from ansible.module_utils.basic import *
+from ansible.module_utils.facts import *
 
 
 class UnimplementedStrategy(object):
@@ -94,9 +95,12 @@ class Hostname(object):
         return load_platform_subclass(Hostname, args, kwargs)
 
     def __init__(self, module):
-        self.module   = module
-        self.name     = module.params['name']
-        self.strategy = self.strategy_class(module)
+        self.module       = module
+        self.name         = module.params['name']
+        if self.platform == 'Linux' and Facts(module).is_systemd_managed():
+            self.strategy = SystemdStrategy(module)
+        else:
+            self.strategy = self.strategy_class(module)
 
     def get_current_hostname(self):
         return self.strategy.get_current_hostname()
@@ -512,9 +516,7 @@ class SLESHostname(Hostname):
     platform = 'Linux'
     distribution = 'Suse linux enterprise server '
     distribution_version = get_distribution_version()
-    if distribution_version and LooseVersion(distribution_version) >= LooseVersion("12"):
-        strategy_class = SystemdStrategy
-    elif distribution_version and LooseVersion("10") <= LooseVersion(distribution_version) <= LooseVersion("12"):
+    if distribution_version and LooseVersion("10") <= LooseVersion(distribution_version) <= LooseVersion("12"):
         strategy_class = SLESStrategy
     else:
         strategy_class = UnimplementedStrategy
@@ -537,65 +539,37 @@ class RedHat5Hostname(Hostname):
 class RedHatServerHostname(Hostname):
     platform = 'Linux'
     distribution = 'Red hat enterprise linux server'
-    distribution_version = get_distribution_version()
-    if distribution_version and LooseVersion(distribution_version) >= LooseVersion("7"):
-        strategy_class = SystemdStrategy
-    else:
-        strategy_class = RedHatStrategy
+    strategy_class = RedHatStrategy
 
 class RedHatWorkstationHostname(Hostname):
     platform = 'Linux'
     distribution = 'Red hat enterprise linux workstation'
-    distribution_version = get_distribution_version()
-    if distribution_version and LooseVersion(distribution_version) >= LooseVersion("7"):
-        strategy_class = SystemdStrategy
-    else:
-        strategy_class = RedHatStrategy
+    strategy_class = RedHatStrategy
 
 class CentOSHostname(Hostname):
     platform = 'Linux'
     distribution = 'Centos'
-    distribution_version = get_distribution_version()
-    if distribution_version and LooseVersion(distribution_version) >= LooseVersion("7"):
-        strategy_class = SystemdStrategy
-    else:
-        strategy_class = RedHatStrategy
+    strategy_class = RedHatStrategy
 
 class CentOSLinuxHostname(Hostname):
     platform = 'Linux'
     distribution = 'Centos linux'
-    distribution_version = get_distribution_version()
-    if distribution_version and LooseVersion(distribution_version) >= LooseVersion("7"):
-        strategy_class = SystemdStrategy
-    else:
-        strategy_class = RedHatStrategy
+    strategy_class = RedHatStrategy
 
 class ScientificHostname(Hostname):
     platform = 'Linux'
     distribution = 'Scientific'
-    distribution_version = get_distribution_version()
-    if distribution_version and LooseVersion(distribution_version) >= LooseVersion("7"):
-        strategy_class = SystemdStrategy
-    else:
-        strategy_class = RedHatStrategy
+    strategy_class = RedHatStrategy
 
 class ScientificLinuxHostname(Hostname):
     platform = 'Linux'
     distribution = 'Scientific linux'
-    distribution_version = get_distribution_version()
-    if distribution_version and LooseVersion(distribution_version) >= LooseVersion("7"):
-        strategy_class = SystemdStrategy
-    else:
-        strategy_class = RedHatStrategy
+    strategy_class = RedHatStrategy
 
 class OracleLinuxHostname(Hostname):
     platform = 'Linux'
     distribution = 'Oracle linux server'
-    distribution_version = get_distribution_version()
-    if distribution_version and LooseVersion(distribution_version) >= LooseVersion("7"):
-        strategy_class = SystemdStrategy
-    else:
-        strategy_class = RedHatStrategy
+    strategy_class = RedHatStrategy
 
 class AmazonLinuxHostname(Hostname):
     platform = 'Linux'
@@ -658,7 +632,7 @@ class FreeBSDHostname(Hostname):
 def main():
     module = AnsibleModule(
         argument_spec = dict(
-            name=dict(required=True, type='str')
+            name=dict(required=True)
         )
     )
 
@@ -682,4 +656,5 @@ def main():
                                         ansible_fqdn=socket.getfqdn(),
                                         ansible_domain='.'.join(socket.getfqdn().split('.')[1:])))
 
-main()
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request [fixes #573, #3137, #3360, #2004]
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

hostname
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel 47acf55fa9) last updated 2016/08/10 14:22:55 (GMT -500)
  lib/ansible/modules/core: (hostname_systemd_fix 41e01e189e) last updated 2016/08/10 20:43:48 (GMT -500)
  lib/ansible/modules/extras: (devel 5fe51b4422) last updated 2016/08/10 14:22:29 (GMT -500)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Now that there is general purpose `Fact` helper to detect if systemd
is active, we would be able to rely on that to apply SystemdStrategy.

Detecting presence of systemd at runtime would be more reliable than
distribution version based heuristics that is currently being used. 
(e.g., Debian, Ubuntu allows user to change the default init system, 
Gentoo allows switching between openrc and systemd, and so on).

Notes:
- This is a first cut that transitions to different approach on systemd detection. 
  Once this is done, we would be able to further cleanup/refine the  `Hostname` 
  classes and have most of them subsumed into a common `LinuxHostname`.
- @bcoca, I picked up `is_systemd_managed()` that you [added recently](https://github.com/ansible/ansible/blob/c8f0cdbdfd1754219885287666d594f6fcd1993d/lib/ansible/module_utils/facts.py#L518). I am assuming it is acceptable to use that elsewhere -- if not, what would be a good alternative?
- @hnakamur, @saito-hideki, would be great to have this reviewed/tested.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->
