### PR TITLE
Remove 'Standby' instances when deleting ASG

### DIFF
--- a/cloud/amazon/ec2_asg.py
+++ b/cloud/amazon/ec2_asg.py
@@ -518,6 +518,11 @@ def delete_autoscaling_group(connection, module):
         group.min_size = 0
         group.desired_capacity = 0
         group.update()
+        # Instances with lifecycle_state of 'Standby' are not impacted by
+        # desired_capacity/max_size = 0, and therefore won't be deleted.
+        for inst in group.instances:
+            if inst.lifecycle_state == 'Standby':
+                connection.terminate_instance(inst.instance_id)
         instances = True
         while instances:
             tmp_groups = connection.get_all_groups(names=[group_name])


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

cloud/amazon/ec2_asg.py
##### ANSIBLE VERSION

```
$ ansible-playbook --version
  config file = /home/sbrady/git/sites/ansible/ansible.cfg
  configured module search path = ['/usr/share/ansible', 'library']
```
##### SUMMARY

Running: 

```
- name: Delete any Auto Scale Groups we will later create                                                                                                              
  delegate_to: 127.0.0.1
  ec2_asg:
    name: "{{ asgs[item].asg_name }}"
    region: "{{ asgs[item].asg_vpc_region }}"
    state: "absent"
  with_items: "{{ asgs }}"
```

hangs indefinitely.

When removing an Auto Scaling Group, should one or more instances be in
'Standby' mode, the ec2_asg will hang indefinitely waiting for all
instances to be gone (group.instances == []).

This is normally accomplished by setting max_size, min_size, and
desired_capacity all to 0, which causes the ASG to terminate all
instances.

Instances with lifecycle_state of 'Standby' are not terminated by the
above action.  Using the AWS Console to delete an ASG, these instances
are deleted.  To mirror this behavior, we iterate over the instances member,
and specifically terminate those with life_cycle_state of 'Standby'.
