### PR TITLE
Fix network alias and network link comparison.

### DIFF
--- a/cloud/docker/docker_container.py
+++ b/cloud/docker/docker_container.py
@@ -1373,16 +1373,18 @@ class Container(DockerBaseClass):
                 if network.get('aliases') and not connected_networks[network['name']].get('Aliases'):
                     diff = True
                 if network.get('aliases') and connected_networks[network['name']].get('Aliases'):
-                    if set(network.get('aliases')) != set(connected_networks[network['name']].get('Aliases')):
-                        diff = True
+                    for alias in network.get('aliases'):
+                        if alias not in connected_networks[network['name']].get('Aliases', []):
+                            diff = True
                 if network.get('links') and not connected_networks[network['name']].get('Links'):
                     diff = True
                 if network.get('links') and connected_networks[network['name']].get('Links'):
                     expected_links = []
                     for link, alias in network['links'].iteritems():
                         expected_links.append("%s:%s" % (link, alias))
-                    if set(expected_links) != set(connected_networks[network['name']].get('Links', [])):
-                        diff = True
+                    for link in expected_links:
+                        if link not in connected_networks[network['name']].get('Links', []):
+                            diff = True
                 if diff:
                     different = True
                     differences.append(dict(


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

docker_container.py 
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 8fa5e88b55) last updated 2016/08/05 03:46:47 (GMT -400)
  lib/ansible/modules/core: (devel e7abbbf134) last updated 2016/08/12 18:01:11 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD db979dde74) last updated 2016/08/02 04:22:23 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

As detailed in the commit fixed the comparison of network aliases and network links. 
