### PR TITLE
Addition of InstanceUUID to  facts

### DIFF
--- a/cloud/vmware/vsphere_guest.py
+++ b/cloud/vmware/vsphere_guest.py
@@ -1547,6 +1547,7 @@ def gather_facts(vm):
         'hw_guest_full_name':  vm.properties.config.guestFullName,
         'hw_guest_id': vm.properties.config.guestId,
         'hw_product_uuid': vm.properties.config.uuid,
+        'hw_instance_uuid': vm.properties.config.instanceUuid,
         'hw_processor_count': vm.properties.config.hardware.numCPU,
         'hw_memtotal_mb': vm.properties.config.hardware.memoryMB,
         'hw_interfaces':[],


### PR DESCRIPTION
The Instance UUID(refered to as PersistenceUUID in the API) is the ID
vcenter uses to idenify VMs.
My use case for this is that I configure Zabbix using ansible and its
vmware module relies on using these to identify VMs.
