### PR TITLE
Issue 3231: reloaded state recreates docker container every time

### DIFF
--- a/cloud/docker/docker.py
+++ b/cloud/docker/docker.py
@@ -1279,8 +1279,8 @@ class DockerManager(object):
 
             # NETWORK MODE
 
-            expected_netmode = self.module.params.get('net') or 'bridge'
-            actual_netmode = container['HostConfig']['NetworkMode'] or 'bridge'
+            expected_netmode = self.module.params.get('net') or 'default'
+            actual_netmode = container['HostConfig']['NetworkMode'] or 'default'
             if actual_netmode != expected_netmode:
                 self.reload_reasons.append('net ({0} => {1})'.format(actual_netmode, expected_netmode))
                 differing.append(container)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

cloud/docker
##### ANSIBLE VERSION

```
ansible 2.0.2.0 (detached HEAD 24d9e5e0b4) last updated 2016/08/16 16:15:56 (GMT -700)
  lib/ansible/modules/core: (detached HEAD e1cedb1633) last updated 2016/08/16 16:15:56 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 4eb177e545) last updated 2016/08/16 16:15:56 (GMT -700)
  config file = /home/shaun/machome/Seafile/scripts/mtn/ansible/ansible-docker-sdas-530/ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

This "fixes" an issue in the docker module on the stable-2.0 branch where (under some combination of circumstances) the net param in the docker module is seen as "default" and shows up out of compliance every time it is run.  The problem is with the lines of code assuming "or bridge".  It is not entirely clear why those were set, as it seems to work just fine 100% of the time by removing the ors on both lines.  

If this fix is not the "best" solution, please comment so we can patch this PR and get this into stable-2.0.  It is unclear if this issue is present in stable-2.1 branch as there are other bugs in ansible core 2.1.x that prevent my team from using that for anything yet. 
