### PR TITLE
Exposing tcp and udp for same port fails. Fixes issue #4354.

### DIFF
--- a/cloud/docker/docker_container.py
+++ b/cloud/docker/docker_container.py
@@ -1012,7 +1012,8 @@ class TaskParameters(DockerBaseClass):
                 protocol = 'tcp'
                 match = re.search(r'(/.+$)', port)
                 if match:
-                    protocol = match.group(1)
+                    protocol = match.group(1).replace('/', '')
+                    port = re.sub(r'/.+$', '', port)
                 exposed.append((port, protocol))
         if published_ports:
             # Any published port should also be exposed


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

docker_container.py 
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel a2d0bbed8c) last updated 2016/08/17 15:40:39 (GMT -400)
  lib/ansible/modules/core: (devel c0c1651619) last updated 2016/08/17 16:58:58 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD a6b34973a8) last updated 2016/08/17 15:40:48 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fix for #4354. Exposing upd and tcp for the same port was not working as expected.
