### PR TITLE
docker_service: fix files/project_files typo

### DIFF
--- a/cloud/docker/docker_service.py
+++ b/cloud/docker/docker_service.py
@@ -85,7 +85,7 @@ options:
   definition:
       description:
         - Provide docker-compose yaml describing one or more services, networks and volumes.
-        - Mutually exclusive with C(project_src) and C(project_files).
+        - Mutually exclusive with C(project_src) and C(files).
       type: complex
       required: false
   hostname_check:


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Docs Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

docker_service
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

The original decision to rename from `project_files` to `files` was in
3a5dd0007634c9d4e379f20cac77c8fd64b67f42.
