### PR TITLE
Add use_proxy parameter to uri module for parity with get_url module

### DIFF
--- a/network/basics/uri.py
+++ b/network/basics/uri.py
@@ -133,12 +133,13 @@ options:
     required: false
     default: 30
   use_proxy:
-      description:
-        - if C(no), it will not use a proxy, even if one is defined in
-          an environment variable on the target hosts.
-      required: false
-      default: 'yes'
-      choices: ['yes', 'no']
+    description:
+      - if C(no), it will not use a proxy, even if one is defined in
+        an environment variable on the target hosts.
+    required: false
+    default: 'yes'
+    choices: ['yes', 'no']
+    version_added: '2.2'
   HEADER_:
     description:
       - Any parameter starting with "HEADER_" is a sent with your request as a header.


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

network/basics/uri.py
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel cb3653295f) last updated 2016/08/18 11:46:39 (GMT -400)
  lib/ansible/modules/core: (use-proxy-for-uri-module a2909d16f2) last updated 2016/08/18 16:42:57 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 101f9f5f46) last updated 2016/08/15 15:23:55 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

This change adds support for the `use_proxy` attribute, presently only supported by `get_url`, to the `uri` module. Whilst there are other ways to achieve the same behaviour (i.e. preventing the module from automatically using a proxy defined by the environment) this arguably improves consistency between the modules.
