### PR TITLE
Use named parameters in new_droplet method call

### DIFF
--- a/cloud/digital_ocean/digital_ocean.py
+++ b/cloud/digital_ocean/digital_ocean.py
@@ -253,7 +253,9 @@ class Droplet(JsonfyMixIn):
         private_networking_lower = str(private_networking).lower()
         backups_enabled_lower = str(backups_enabled).lower()
         ipv6_lower = str(ipv6).lower()
-        json = cls.manager.new_droplet(name, size_id, image_id, region_id, ssh_key_ids, virtio, private_networking_lower, backups_enabled_lower,user_data, ipv6_lower)
+        json = cls.manager.new_droplet(name, size_id, image_id, region_id,
+            ssh_key_ids=ssh_key_ids, virtio=virtio, private_networking=private_networking_lower,
+            backups_enabled=backups_enabled_lower, user_data=user_data, ipv6=ipv6_lower)
         droplet = cls(json)
         return droplet
 


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

cloud/digital_ocean
##### ANSIBLE VERSION

```
ansible 2.1.1.0
  config file = /home/mlpizarro/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

This mirrors the original method signature and guards against any
change in order parameter

see original dopy.manager.DoManager.new_droplet signature at https://github.com/Wiredcraft/dopy/blob/master/dopy/manager.py#L66
