### PR TITLE
re.match for numeric only for kwargs[key] = int(value)

### DIFF
--- a/network/junos/junos_command.py
+++ b/network/junos/junos_command.py
@@ -153,7 +153,7 @@ def rpc_args(args):
         key, value = arg.split('=')
         if str(value).upper() in ['TRUE', 'FALSE']:
             kwargs[key] = bool(value)
-        elif re.match(r'\d+', value):
+        elif re.match(r'^[0-9]+$', value):
             kwargs[key] = int(value)
         else:
             kwargs[key] = str(value)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

network/junos/junos_command.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/usr/share/ansible']
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

```
def rpc_args(args):
    kwargs = dict()
    args = split(args)
    name = args.pop(0)
    for arg in args:
        key, value = arg.split('=')
        if str(value).upper() in ['TRUE', 'FALSE']:
            kwargs[key] = bool(value)
        elif re.match(r'^[0-9]+$', value): <--- modified from '\d+'
            kwargs[key] = int(value)
        else:
            kwargs[key] = str(value)
    return (name, kwargs)
```

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Fixes strings that begin with integers from being incorrectly typed.

```
ValueError: invalid literal for int() with base 10: '10.0.254.0/24'
fatal: [host]: FAILED! => {"changed": false, "failed": true, "invocation": {"module_name": "junos_command"}, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_UJg1HI/ansible_module_junos_command.py\", line 261, in <module>\n    main()\n  File \"/tmp/ansible_UJg1HI/ansible_module_junos_command.py\", line 206, in main\n    rpcs = parse_rpcs(module.params['rpcs'])\n  File \"/tmp/ansible_UJg1HI/ansible_module_junos_command.py\", line 164, in parse_rpcs\n    parsed.append(rpc_args(rpc))\n  File \"/tmp/ansible_UJg1HI/ansible_module_junos_command.py\", line 156, in rpc_args\n    kwargs[key] = int(value)\nValueError: invalid literal for int() with base 10: '192.168.0.0/24'\n", "module_stdout": "", "msg": "MODULE FAILURE", "parsed": false}
```

this changes to 

```
<host> EXEC /bin/sh -c 'LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/python && sleep 0'
ok: [host] => {"changed": false, "invocation": {"module_args": {"commands": null, "format": "xml", "host": "host", "interval": 1, "logfile": "/home/local/crq-1075444/logs/host.log", "password": null, "port": null, "provider": null, "retries": 10, "rpcs": ["get-route-information table=vr-rimnet.inet.0 destination=10.0.254.0/24"], "ssh_keyfile": null, "timeout": 60, "transport": "netconf", "username": "admin", "waitfor": null}, "module_name": "junos_command"}, "stdout": [{"route-information": {"route-table": {"active-route-count": "76", "destination-count": "76", "hidden-route-count": "0", "holddown-route-count": "0", "rt": [{"rt-destination": "10.0.254.0/24", "rt-entry": {"active-tag": "*", "age": "02:12:22", "current-active": "", "last-active": "", "nh": {"selected-next-hop": "", "via": "irb.1224"}, "preference": "0", "protocol-name": "Direct"}}, {"rt-destination": "10.0.254.1/32", "rt-entry": {"active-tag": "*", "age": "02:12:22", "current-active": "", "last-active": "", "nh": {"nh-local-interface": "irb.1224"}, "nh-type": "Local", "preference": "0", "protocol-name": "Local"}}], "table-name": "vr-rimnet.inet.0", "total-route-count": "87"}}}], "stdout_lines": [{"route-information": {"route-table": {"active-route-count": "76", "destination-count": "76", "hidden-route-count": "0", "holddown-route-count": "0", "rt": [{"rt-destination": "10.0.254.0/24", "rt-entry": {"active-tag": "*", "age": "02:12:22", "current-active": "", "last-active": "", "nh": {"selected-next-hop": "", "via": "irb.1224"}, "preference": "0", "protocol-name": "Direct"}}, {"rt-destination": "10.0.254.1/32", "rt-entry": {"active-tag": "*", "age": "02:12:22", "current-active": "", "last-active": "", "nh": {"nh-local-interface": "irb.1224"}, "nh-type": "Local", "preference": "0", "protocol-name": "Local"}}], "table-name": "vr-rimnet.inet.0", "total-route-count": "87"}}}], "xml": ["<route-information>\n<!-- keepalive -->\n<route-table>\n<table-name>vr-rimnet.inet.0</table-name>\n<destination-count>76</destination-count>\n<total-route-count>87</total-route-count>\n<active-route-count>76</active-route-count>\n<holddown-route-count>0</holddown-route-count>\n<hidden-route-count>0</hidden-route-count>\n<rt style=\"brief\">\n<rt-destination>10.0.254.0/24</rt-destination>\n<rt-entry>\n<active-tag>*</active-tag>\n<current-active/>\n<last-active/>\n<protocol-name>Direct</protocol-name>\n<preference>0</preference>\n<age seconds=\"7942\">02:12:22</age>\n<nh>\n<selected-next-hop/>\n<via>irb.1224</via>\n</nh>\n</rt-entry>\n</rt>\n<rt style=\"brief\">\n<rt-destination>10.0.254.1/32</rt-destination>\n<rt-entry>\n<active-tag>*</active-tag>\n<current-active/>\n<last-active/>\n<protocol-name>Local</protocol-name>\n<preference>0</preference>\n<age seconds=\"7942\">02:12:22</age>\n<nh-type>Local</nh-type>\n<nh>\n<nh-local-interface>irb.1224</nh-local-interface>\n</nh>\n</rt-entry>\n</rt>\n</route-table>\n</route-information>\n"]}
```
