### PR TITLE
Fix cloudformation error invocation and whitespace

### DIFF
--- a/cloud/amazon/cloudformation.py
+++ b/cloud/amazon/cloudformation.py
@@ -94,9 +94,9 @@ EXAMPLES = '''
 # Basic task example
 - name: launch ansible cloudformation example
   cloudformation:
-    stack_name: "ansible-cloudformation" 
+    stack_name: "ansible-cloudformation"
     state: "present"
-    region: "us-east-1" 
+    region: "us-east-1"
     disable_rollback: true
     template: "files/cloudformation-example.json"
     template_parameters:
@@ -110,9 +110,9 @@ EXAMPLES = '''
 # Basic role example
 - name: launch ansible cloudformation example
   cloudformation:
-    stack_name: "ansible-cloudformation" 
+    stack_name: "ansible-cloudformation"
     state: "present"
-    region: "us-east-1" 
+    region: "us-east-1"
     disable_rollback: true
     template: "roles/cloudformation/files/cloudformation-example.json"
     template_parameters:
@@ -263,7 +263,7 @@ def main():
 
     if module.params['template'] is None and module.params['template_url'] is None:
         if state == 'present':
-            module.fail_json('Module parameter "template" or "template_url" is required if "state" is "present"')
+            module.fail_json(msg='Module parameter "template" or "template_url" is required if "state" is "present"')
 
     if module.params['template'] is not None:
         template_body = open(module.params['template'], 'r').read()
@@ -362,7 +362,7 @@ def main():
         for output in stack.outputs:
             stack_outputs[output.key] = output.value
         result['stack_outputs'] = stack_outputs
-        stack_resources = [] 
+        stack_resources = []
         for res in cfn.list_stack_resources(stack_name):
             stack_resources.append({
                 "last_updated_time": res.last_updated_time,


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

cloudformation module
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
Since this is a core fix, the VERSION file at the time of writing said:

2.0.0-0.5.beta3
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Removing some extraneous whitespace from the cloudformation module. Also fixing the `module.fail_json` invocation that was incorrect. `fail_json` expects `**kwargs` and no positional arguments. In the fixed instance, the method was invoked with a string as a positional argument, leading to a weird stack-track when invoking the module under the failing scenarios.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

``` bash
dev $ ansible localhost -m cloudformation -a stack_name=some-stack-name
 [WARNING]: Host file not found: /usr/local/etc/ansible/hosts

 [WARNING]: provided hosts list is empty, only localhost is available

An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: fail_json() takes exactly 1 argument (2 given)
localhost | FAILED! => {
    "changed": false,
    "failed": true,
    "module_stderr": "Traceback (most recent call last):\n  File \"/var/folders/zp/_1zrf10d547gdxmy9gz95725ys87z1/T/ansible_Fiqoj6/ansible_module_cloudformation.py\", line 401, in <module>\n    main()\n  File \"/var/folders/zp/_1zrf10d547gdxmy9gz95725ys87z1/T/ansible_Fiqoj6/ansible_module_cloudformation.py\", line 266, in main\n    module.fail_json('Module parameter \"template\" or \"template_url\" is required if \"state\" is \"present\"')\nTypeError: fail_json() takes exactly 1 argument (2 given)\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE",
    "parsed": false
}

After:
dev $ ansible localhost -m cloudformation -a stack_name=some-stack-name
 [WARNING]: Host file not found: /usr/local/etc/ansible/hosts

localhost | FAILED! => {
    "changed": false,
    "failed": true,
    "msg": "Module parameter \"template\" or \"template_url\" is required if \"state\" is \"present\""
}
```
