### PR TITLE
Remove colors from git-branch output for correct local search

### DIFF
--- a/source_control/git.py
+++ b/source_control/git.py
@@ -486,7 +486,7 @@ def is_remote_tag(git_path, module, dest, remote, version):
 
 def get_branches(git_path, module, dest):
     branches = []
-    cmd = '%s branch -a' % (git_path,)
+    cmd = '%s branch --no-color -a' % (git_path,)
     (rc, out, err) = module.run_command(cmd, cwd=dest)
     if rc != 0:
         module.fail_json(msg="Could not determine branch data - received %s" % out, stdout=out, stderr=err)


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

git
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.1.0
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Remove color from git-branch output to correct local branch search

We got an error while switching on existent local branch
because git module can not find branch in function get_branches
if we have color.branch=always in git config.
