### PR TITLE
Fix user module under python3

### DIFF
--- a/system/user.py
+++ b/system/user.py
@@ -221,6 +221,7 @@ import grp
 import platform
 import socket
 import time
+from ansible.module_utils._text import to_native
 
 try:
     import spwd
@@ -402,7 +403,7 @@ class User(object):
         helpout = data1 + data2
 
         # check if --append exists
-        lines = helpout.split('\n')
+        lines = to_native(helpout).split('\n')
         for line in lines:
             if line.strip().startswith('-a, --append'):
                 return True


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

user
##### SUMMARY

Using something like:

```
- name: Create ssh keys
  user:
    name: root
    generate_ssh_key: yes
  register: key
```

result into this traceback on F24

```
Traceback (most recent call last):
  File \"/tmp/ansible_jm5d4vlh/ansible_module_user.py\", line 2170, in <module>
    main()
  File \"/tmp/ansible_jm5d4vlh/ansible_module_user.py\", line 2108, in main
    (rc, out, err) = user.modify_user()
  File \"/tmp/ansible_jm5d4vlh/ansible_module_user.py\", line 660, in modify_user
    return self.modify_user_usermod()
  File \"/tmp/ansible_jm5d4vlh/ansible_module_user.py\", line 417, in modify_user_usermod
    has_append = self._check_usermod_append()
  File \"/tmp/ansible_jm5d4vlh/ansible_module_user.py\", line 405, in _check_usermod_append
    lines = helpout.split('\\n')
TypeError: a bytes-like object is required, not 'str'
```
