### PR TITLE
removed feature check for nxos_interface

### DIFF
--- a/network/nxos/nxos_interface.py
+++ b/network/nxos/nxos_interface.py
@@ -157,33 +157,6 @@ def is_default_interface(interface, module):
         return 'DNE'
 
 
-def get_available_features(feature, module):
-    available_features = {}
-    command = 'show feature'
-    body = execute_show_command(command, module)
-
-    try:
-        body = body[0]['TABLE_cfcFeatureCtrlTable']['ROW_cfcFeatureCtrlTable']
-    except (TypeError, IndexError):
-        return available_features
-
-    for each_feature in body:
-        feature = each_feature['cfcFeatureCtrlName2']
-        state = each_feature['cfcFeatureCtrlOpStatus2']
-
-        if 'enabled' in state:
-            state = 'enabled'
-
-        if feature not in available_features.keys():
-            available_features[feature] = state
-        else:
-            if (available_features[feature] == 'disabled' and
-                    state == 'enabled'):
-                available_features[feature] = state
-
-    return available_features
-
-
 def get_interface_type(interface):
     """Gets the type of interface
 
@@ -625,15 +598,6 @@ def main():
 
     if normalized_interface == 'Vlan1' and state == 'absent':
         module.fail_json(msg='ERROR: CANNOT REMOVE VLAN 1!')
-
-    if intf_type == 'svi':
-        feature = 'interface-vlan'
-        available_features = get_available_features(feature, module)
-        svi_state = available_features[feature]
-        if svi_state == 'disabled':
-            module.fail_json(
-                msg='SVI (interface-vlan) feature needs to be enabled first',
-            )
 
     if intf_type == 'unknown':
         module.fail_json(


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

nxos_interface
##### ANSIBLE VERSION

```
ansible 2.1.0.0

```
##### SUMMARY

Fixes #4403 
We can now use this module on Nexus 7000. Moreover, the ansible user must be aware they need to configure and enable the interface-vlan feature before configuring SVIs just like they would on the CLI. This will also improve overall performance when using the module since we are now making one less API call.
