### PR TITLE
update iosxr_template to use network shared modules

### DIFF
--- a/network/iosxr/iosxr_template.py
+++ b/network/iosxr/iosxr_template.py
@@ -28,7 +28,7 @@ description:
     by evaluating the current running-config and only pushing configuration
     commands that are not already configured.  The config source can
     be a set of commands or a template.
-extends_documentation_fragment: ios
+extends_documentation_fragment: iosxr
 options:
   src:
     description:
@@ -73,20 +73,18 @@ options:
 EXAMPLES = """
 
 - name: push a configuration onto the device
-  net_config:
+  iosxr_template:
     src: config.j2
 
 - name: forceable push a configuration onto the device
-  net_config:
+  iosxr_template:
     src: config.j2
     force: yes
 
 - name: provide the base configuration for comparison
-  net_config:
+  iosxr_template:
     src: candidate_config.txt
     config: current_config.txt
-
-
 """
 
 RETURN = """
@@ -102,11 +100,13 @@ responses:
   type: list
   sample: ['...', '...']
 """
+from ansible.module_utils.netcfg import NetworkConfig, dumps
+from ansible.module_utils.iosxr import NetworkModule
 
 def get_config(module):
     config = module.params['config'] or dict()
     if not config and not module.params['force']:
-        config = module.config
+        config = module.config.get_config()
     return config
 
 def main():
@@ -122,9 +122,9 @@ def main():
 
     mutually_exclusive = [('config', 'backup'), ('config', 'force')]
 
-    module = get_module(argument_spec=argument_spec,
-                        mutually_exclusive=mutually_exclusive,
-                        supports_check_mode=True)
+    module = NetworkModule(argument_spec=argument_spec,
+                           mutually_exclusive=mutually_exclusive,
+                           supports_check_mode=True)
 
     result = dict(changed=False)
 
@@ -133,17 +133,18 @@ def main():
     contents = get_config(module)
     if contents:
         config = NetworkConfig(contents=contents, indent=1)
-        result['_backup'] = contents
+        result['_backup'] = str(contents)
 
     if not module.params['force']:
         commands = candidate.difference(config)
+        commands = dumps(commands, 'commands').split('\n')
+        commands = [str(c) for c in commands if c]
     else:
         commands = str(candidate).split('\n')
 
     if commands:
         if not module.check_mode:
-            commands = [str(c).strip() for c in commands]
-            response = module.configure(commands)
+            response = module.config(commands)
             result['responses'] = response
         result['changed'] = True
 
@@ -151,10 +152,5 @@ def main():
     module.exit_json(**result)
 
 
-from ansible.module_utils.basic import *
-from ansible.module_utils.shell import *
-from ansible.module_utils.netcfg import *
-from ansible.module_utils.iosxr import *
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
This updates the iosxr_template module to make it work with the new
shared network modules introduced in Ansible 2.2

Tested on IOSXR 6.0.0
