### PR TITLE
Add support for boolean substitution

### DIFF
--- a/system/seboolean.py
+++ b/system/seboolean.py
@@ -182,6 +182,11 @@ def main():
     result = {}
     result['name'] = name
 
+    if hasattr(selinux, 'selinux_boolean_sub'):
+        # selinux_boolean_sub allows sites to rename a boolean and alias the old name
+        # Feature only available in selinux library since 2012.
+        name = selinux.selinux_boolean_sub(name)
+
     if not has_boolean_value(module, name):
         module.fail_json(msg="SELinux boolean %s does not exist." % name)
 


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

seboolean
##### SUMMARY

SELinux since 2012 use a configuration file to
convert boolean names from a old name to a new name,
for preserving backward compatibility.

However, this has to be done explicitely when using the python
bindings, and the module was not doing it.

Openshift ansible script use this construct to detect if
a boolean exist or not:

```
- name: Check for existence of virt_sandbox_use_nfs seboolean
  command: getsebool virt_sandbox_use_nfs
  register: virt_sandbox_use_nfs_output
  failed_when: false
  changed_when: false

- name: Set seboolean to allow nfs storage plugin access from containers(sandbox)
  seboolean:
    name: virt_sandbox_use_nfs
    state: yes
    persistent: yes
  when: virt_sandbox_use_nfs_output.rc == 0
```

On a system where virt_sandbox_use_nfs do not exist, this work. But
on a system where virt_sandbox_use_nfs is a alias to virt_use_nfs (like
Fedora 24), this fail because the seboolean is not aware of the alias.
