### PR TITLE
Add a way to ignore failure when boolean do not exist

### DIFF
--- a/system/seboolean.py
+++ b/system/seboolean.py
@@ -42,6 +42,13 @@ options:
     required: true
     default: null
     choices: [ 'yes', 'no' ]
+  ignore_missing:
+    description:
+      - Ignore errors if the boolean do not exist in the policy
+    required: false
+    default: no
+    choices: ['yes', 'no' ]
+    version_added: "2.2"
 notes:
    - Not tested on any debian based system
 requirements: [ ]
@@ -162,6 +169,7 @@ def main():
         argument_spec = dict(
             name=dict(required=True),
             persistent=dict(default='no', type='bool'),
+            ignore_missing=dict(default='no', type='bool'),
             state=dict(required=True, type='bool')
         ),
         supports_check_mode=True
@@ -179,11 +187,15 @@ def main():
     name = module.params['name']
     persistent = module.params['persistent']
     state = module.params['state']
+    ignore_missing = module.params['ignore_missing']
     result = {}
     result['name'] = name
 
     if not has_boolean_value(module, name):
-        module.fail_json(msg="SELinux boolean %s does not exist." % name)
+        if ignore_missing:
+            module.exit_json(changed=False)
+        else:
+            module.fail_json(msg="SELinux boolean %s does not exist." % name)
 
     cur_value = get_boolean_value(module, name)
 


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

seboolean
##### SUMMARY

Ansible is used by various groups as a installer, and to be multi
platform, they sometime need to set selinux boolean
who may or may not be present in the current policy.
Testing them is cumbersome, so ignoring that specific error
permit to reduce code.

See https://github.com/ansible/ansible-modules-core/pull/4570#issuecomment-242858439

I am not 100% sure this is the right design for that problem (for one, this is a bit not generic enough), but since the code was fast enough to write, this permit to discuss the exact code of a proposed solution.
