### PR TITLE
Fix mysql_user for python3

### DIFF
--- a/database/mysql/mysql_user.py
+++ b/database/mysql/mysql_user.py
@@ -166,6 +166,7 @@ except ImportError:
     mysqldb_found = False
 else:
     mysqldb_found = True
+from ansible.module_utils.six import iteritems
 
 VALID_PRIVS = frozenset(('CREATE', 'DROP', 'GRANT', 'GRANT OPTION',
                          'LOCK TABLES', 'REFERENCES', 'EVENT', 'ALTER',
@@ -234,9 +235,8 @@ def user_add(cursor, user, host, host_all, password, encrypted, new_priv, check_
         cursor.execute("CREATE USER %s@%s IDENTIFIED BY %s", (user,host,password))
     else:
         cursor.execute("CREATE USER %s@%s", (user,host))
-
     if new_priv is not None:
-        for db_table, priv in new_priv.iteritems():
+        for db_table, priv in iteritems(new_priv):
             privileges_grant(cursor, user,host,db_table,priv)
     return True
 
@@ -302,7 +302,7 @@ def user_mod(cursor, user, host, host_all, password, encrypted, new_priv, append
 
             # If the user has privileges on a db.table that doesn't appear at all in
             # the new specification, then revoke all privileges on it.
-            for db_table, priv in curr_priv.iteritems():
+            for db_table, priv in iteritems(curr_priv):
                 # If the user has the GRANT OPTION on a db.table, revoke it first.
                 if "GRANT" in priv:
                     grant_option = True
@@ -315,7 +315,7 @@ def user_mod(cursor, user, host, host_all, password, encrypted, new_priv, append
 
             # If the user doesn't currently have any privileges on a db.table, then
             # we can perform a straight grant operation.
-            for db_table, priv in new_priv.iteritems():
+            for db_table, priv in iteritems(new_priv):
                 if db_table not in curr_priv:
                     if module.check_mode:
                         return True


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

mysql_user
##### SUMMARY

dict no longer have a iteritems method, it was replaced
by items. So we need to use six.

```
Traceback (most recent call last):
    File \"/tmp/ansible_hjd7d65c/ansible_module_mysql_user.py\", line 587, in <module>
        main()
    File \"/tmp/ansible_hjd7d65c/ansible_module_mysql_user.py\", line 571, in main
        changed = user_add(cursor, user, host, host_all, password, encrypted, priv, module.check_mode)
    File \"/tmp/ansible_hjd7d65c/ansible_module_mysql_user.py\", line 239, in user_add
        for db_table, priv in new_priv.iteritems():
    AttributeError: 'dict' object has no attribute 'iteritems'
```
