### PR TITLE
Fix container labels expected vs actual comparison.

### DIFF
--- a/cloud/docker/_docker.py
+++ b/cloud/docker/_docker.py
@@ -1303,10 +1303,12 @@ class DockerManager(object):
             for name, value in self.module.params.get('labels').iteritems():
                 expected_labels[name] = str(value)
 
-            actual_labels = {}
-            for container_label in container['Config']['Labels'] or []:
-                name, value = container_label.split('=', 1)
-                actual_labels[name] = value
+            if type(container['Config']['Labels']) is dict:
+                actual_labels = container['Config']['Labels']
+            else:
+                for container_label in container['Config']['Labels'] or []:
+                    name, value = container_label.split('=', 1)
+                    actual_labels[name] = value
 
             if actual_labels != expected_labels:
                 self.reload_reasons.append('labels {0} => {1}'.format(actual_labels, expected_labels))


### PR DESCRIPTION
##### ISSUE TYPE

 Bugfix Pull Request
##### COMPONENT NAME

_docker.py
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel fdb5ecd7d1) last updated 2016/08/23 16:23:02 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 45c1ae0ac1) last updated 2016/08/17 15:40:47 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD a6b34973a8) last updated 2016/08/17 15:40:48 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Replaces PR #3005 - Given a container image with labels included. When the container is
reloaded the docker module complains about parsing the present
labels. This is because the labels datastructure changed from docker api
version 1.17 to 1.18. It was a list but it became a dictionary.

This commit parses both list and dictionary versions correctly.
