### PR TITLE
fix error in documentation for stat checksum

### DIFF
--- a/files/stat.py
+++ b/files/stat.py
@@ -272,13 +272,12 @@ stat:
                 supports hashing and md5 is supported
             type: string
             sample: f88fa92d8cf2eeecf4c0a50ccc96d0c0
-        checksum_algorithm:
+        checksum:
             description: hash of the path
             returned: success, path exists, user can read stats, path supports
                 hashing and supplied checksum algorithm is available
             type: string
             sample: 50ba294cdf28c0d5bcde25708df53346825a429f
-            aliases: ['checksum', 'checksum_algo']
         pw_name:
             description: User name of owner
             returned: success, path exists and user can read stats and installed python supports it


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

stat
##### ANSIBLE VERSION

```
devel
```
##### SUMMARY

The docs for the return value of checksum in the stat module seem to have been copied and pasted from the checksum_algorithm argument. It shows the returned attribute as being checksum_algorithm, when it is actually checksum, and it contains a list of two aliases which I don't think have any effect in the documentation for return parameters.

Before:

```
'dict object' has no attribute 'checksum_algorithm'
```

After:
(no error)
