### PR TITLE
Shows uncaught exceptions from called modules in async_wrapper

### DIFF
--- a/utilities/logic/async_wrapper.py
+++ b/utilities/logic/async_wrapper.py
@@ -105,6 +105,7 @@ def _run_module(wrapped_cmd, jid, job_path):
             "failed" : 1,
             "cmd" : wrapped_cmd,
             "data" : outdata, # temporary notice only
+            "stderr": stderr,
             "msg" : traceback.format_exc()
         }
         result['ansible_job_id'] = jid


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

async_wrapper
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel c16f34bf8e) last updated 2016/08/29 09:59:17 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 6eab2b3d40) last updated 2016/08/29 10:33:34 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 628ee6864d) last updated 2016/08/29 10:33:34 (GMT -400)
  config file = /Users/myser/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

If a module fails with an uncaught exception, when run asynchronously, there is not a way to determine why that module failed.  This introduces a new field to capture that error and display it to the user.

**BEFORE PATCH**

> TASK [Check Results] ***********************************************************
> fatal: [localhost]: FAILED! => {"ansible_job_id": "582859376104.32557", "changed": false, "cmd": "/Users/myuser/.ansible/tmp/ansible-tmp-1472492948.1-250819334868650/cloudformation", "data": "", "failed": 1, "finished": 1, "msg": "Traceback (most recent call last):\n  File \"/Users/myuser/.ansible/tmp/ansible-tmp-1472492948.1-250819334868650/async_wrapper\", line 92, in _run_module\n    result = json.loads(outdata)\n  File \"/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/__init__.py\", line 338, in loads\n    return _default_decoder.decode(s)\n  File \"/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/decoder.py\", line 366, in decode\n    obj, end = self.raw_decode(s, idx=_w(s, 0).end())\n  File \"/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/decoder.py\", line 384, in raw_decode\n    raise ValueError(\"No JSON object could be decoded\")\nValueError: No JSON object could be decoded\n"}

**AFTER PATCH**

> TASK [Check Results] ***********************************************************
> fatal: [localhost]: FAILED! => {"ansible_job_id": "526454754111.32625", "changed": false, "cmd": "/Users/myuser/.ansible/tmp/ansible-tmp-1472493011.2-210717104906365/cloudformation", "data": "", "failed": 1, "finished": 1, "msg": "Traceback (most recent call last):\n  File \"/Users/myuser/.ansible/tmp/ansible-tmp-1472493011.2-210717104906365/async_wrapper\", line 92, in _run_module\n    result = json.loads(outdata)\n  File \"/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/__init__.py\", line 338, in loads\n    return _default_decoder.decode(s)\n  File \"/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/decoder.py\", line 366, in decode\n    obj, end = self.raw_decode(s, idx=_w(s, 0).end())\n  File \"/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/decoder.py\", line 384, in raw_decode\n    raise ValueError(\"No JSON object could be decoded\")\nValueError: No JSON object could be decoded\n", "stderr": "Traceback (most recent call last):\n  File \"/var/folders/h5/trswlc4n1056qz7d1bz9fx9h0000gn/T/ansible_0pY9Ap/ansible_module_cloudformation.py\", line 405, in <module>\n    main()\n  File \"/var/folders/h5/trswlc4n1056qz7d1bz9fx9h0000gn/T/ansible_0pY9Ap/ansible_module_cloudformation.py\", line 270, in main\n    template_body = open(module.params['template'], 'r').read()\nIOError: [Errno 2] No such file or directory: 'secgroup.json'\n"}

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

As you can see the the patch exposes the uncaught exception from the cloudformation module :
