### PR TITLE
os_server: keep optional nic args for nics specified using net-name or port-name

### DIFF
--- a/cloud/openstack/os_server.py
+++ b/cloud/openstack/os_server.py
@@ -400,7 +400,10 @@ def _network_args(module, cloud):
                 module.fail_json(
                     msg='Could not find network by net-name: %s' %
                     net['net-name'])
-            args.append({'net-id': by_name['id']})
+            resolved_net = net.copy()
+            del resolved_net['net-name']
+            resolved_net['net-id'] = by_name['id']
+            args.append(resolved_net)
         elif net.get('port-id'):
             args.append(net)
         elif net.get('port-name'):
@@ -409,7 +412,10 @@ def _network_args(module, cloud):
                 module.fail_json(
                     msg='Could not find port by port-name: %s' %
                     net['port-name'])
-            args.append({'port-id': by_name['id']})
+            resolved_net = net.copy()
+            del resolved_net['port-name']
+            resolved_net['port-id'] = by_name['id']
+            args.append(resolved_net)
     return args
 
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

os_server
##### ANSIBLE VERSION

```
ansible 2.1.1.0
  config file = /Users/pwnall/workspace/igor/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

When creating a VM, OpenStack supports [specifying a fixed IP for a NIC](http://docs.openstack.org/cli-reference/nova.html#nova-boot) by adding a `v4-fixed-ip` or `v6-fixed-ip` key to the dictionary used to define the NIC.

When a NIC is defined (inside the `nics` array) using the `net-id` or `port-id` key, the `os_server` module passes the NIC's definition dictionary to boto as-is. In this case, optional configuration keys, such as `v4-fixed-ip` and `v6-fixed-ip`, can be passed into the dictionary, and they will work as intended.

However, when a NIC is defined using the `net-name` or `port-name` key, the `os-os_server` module looks up the network or port UUID, and creates a new dictionary that only has the `net-id` or `port-id` key. This discards optional parameters.

This PR changes the `os-server` code so that NICs defined using the `net-name` and `port-name` follow a similar logic to the `net-id` and `port-id` case, so optional configuration keys can be used. I tested it by using `v4-fixed-ip` against MIT CSAIL's OpenStack installation.
