### PR TITLE
Updated get_url module to process FTP results correctly [#3661]

### DIFF
--- a/network/basics/get_url.py
+++ b/network/basics/get_url.py
@@ -209,7 +209,7 @@ def url_get(module, url, dest, use_proxy, last_mod_time, force, timeout=10, head
         module.exit_json(url=url, dest=dest, changed=False, msg=info.get('msg', ''))
 
     # create a temporary file and copy content to do checksum-based replacement
-    if info['status'] != 200 and not url.startswith('file:/'):
+    if info['status'] != 200 and not url.startswith('file:/') and not (url.startswith('ftp:/') and info.get('msg', '').startswith('OK')):
         module.fail_json(msg="Request failed", status_code=info['status'], response=info['msg'], url=url, dest=dest)
 
     if tmp_dest != '':


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

get_url
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 1c33b5a9f0) last updated 2016/08/30 13:36:06 (GMT +300)
  lib/ansible/modules/core: (detached HEAD 5310bab12f) last updated 2016/08/30 13:38:34 (GMT +300)
  lib/ansible/modules/extras: (detached HEAD 2ef4a34eee) last updated 2016/08/30 13:38:34 (GMT +300)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fixes #3661 
Fixes #3511

`get_url` module uses `fetch_url` function which in turn uses `urllib2.urlopen`.
The latter function does not set `status` for FTP-based URLs.
But function `fetch_url` sets `msg` to `OK (%s bytes)` if there was no exception during download.

The solution in this pull requests uses `msg` to detect if FTP-based download actually succeed.
