### PR TITLE
redhat_subcription module accepts id in the pool argument [#3898]

### DIFF
--- a/packaging/os/redhat_subscription.py
+++ b/packaging/os/redhat_subscription.py
@@ -444,6 +444,8 @@ class RhsmPools(object):
         for product in self.products:
             if r.search(product._name):
                 yield product
+            if r.search(product.PoolID):
+                yield product
 
 
 def main():


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

redhat_subscription
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 1c33b5a9f0) last updated 2016/08/30 13:36:06 (GMT +300)
  lib/ansible/modules/core: (detached HEAD 5310bab12f) last updated 2016/08/30 13:38:34 (GMT +300)
  lib/ansible/modules/extras: (detached HEAD 2ef4a34eee) last updated 2016/08/30 13:38:34 (GMT +300)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fixes #3898

Currently `redhat_subcription` module accepts only pool names in `pool` argument.
Unfortunately it is possible that different pools has the same name.
What even worse that `redhat_subscription` module can choose unsupported pools by name (for example pool for virtual machine on hardware host) which leads to module/playbook failure.

The change applies the regexp via `pool` argument to all available pool ids and lets user choose the specific required pool by id.
