### PR TITLE
Docker_image: Properly set changed events for pulls in force mode

### DIFF
--- a/cloud/docker/docker_image.py
+++ b/cloud/docker/docker_image.py
@@ -286,7 +286,7 @@ class ImageManager(DockerBaseClass):
         if repo_tag:
            self.name = repo
            self.tag = repo_tag
-        
+
         if self.state in ['present', 'build']:
             self.present()
         elif self.state == 'absent':
@@ -335,6 +335,8 @@ class ImageManager(DockerBaseClass):
                 self.results['changed'] = True
                 if not self.check_mode:
                     self.results['image'] = self.client.pull_image(self.name, tag=self.tag)
+                    if image and image == self.results['image']:
+                        self.results['changed'] = False
 
         if self.archive_path:
             self.archive_image(self.name, self.tag)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

docker_image
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o override
```
##### SUMMARY

Currently, when pulling an image with `force: true`, the docker_image module always creates a changed event. This PR makes the module test first if the pulled images is the same as a pre-existing one and if yes, sets changed to False. 

This fixes #4371 
