### PR TITLE
Getting rid of a None type error when no resource tags are passed.

### DIFF
--- a/cloud/amazon/ec2_vpc.py
+++ b/cloud/amazon/ec2_vpc.py
@@ -408,7 +408,7 @@ def create_vpc(module, vpc_conn):
         for subnet in subnets:
             add_subnet = True
             subnet_tags_current = True
-            new_subnet_tags = subnet.get('resource_tags', None)
+            new_subnet_tags = subnet.get('resource_tags', {})
             subnet_tags_delete = []
 
             for csn in current_subnets:
@@ -444,7 +444,7 @@ def create_vpc(module, vpc_conn):
             if add_subnet:
                 try:
                     new_subnet = vpc_conn.create_subnet(vpc.id, subnet['cidr'], subnet.get('az', None))
-                    new_subnet_tags = subnet.get('resource_tags', None)
+                    new_subnet_tags = subnet.get('resource_tags', {})
                     if new_subnet_tags:
                         # Sometimes AWS takes its time to create a subnet and so using new subnets's id
                         # to create tags results in exception.


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### COMPONENT NAME

cloud/amazon/ec2_vpc.py
##### ANSIBLE VERSION

```
ansible 2.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

I don't think this is dependent on ansible version.
##### SUMMARY

```
Using module file /usr/lib/python2.7/site-packages/ansible/modules/core/cloud/amazon/ec2_vpc.py
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: kwoodson
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python2 && sleep 0'
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_yU0wjd/ansible_module_ec2_vpc.py", line 745, in <module>
    main()
  File "/tmp/ansible_yU0wjd/ansible_module_ec2_vpc.py", line 737, in main
    (vpc_dict, new_vpc_id, subnets_changed, igw_id, changed) = create_vpc(module, vpc_conn)
  File "/tmp/ansible_yU0wjd/ansible_module_ec2_vpc.py", line 419, in create_vpc
    existing_tags_subset_of_new_tags = (set(csn.tags.items()).issubset(set(new_subnet_tags.items())))
AttributeError: 'NoneType' object has no attribute 'items'

fatal: [localhost]: FAILED! => {
    "changed": false, 
    "failed": true, 
    "invocation": {
        "module_name": "ec2_vpc"
    }, 
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_yU0wjd/ansible_module_ec2_vpc.py\", line 745, in <module>\n    main()\n  File \"/tmp/ansible_yU0wjd/ansible_module_ec2_vpc.py\", line 737, in main\n    (vpc_dict, new_vpc_id, subnets_changed, igw_id, changed) = create_vpc(module, vpc_conn)\n  File \"/tmp/ansible_yU0wjd/ansible_module_ec2_vpc.py\", line 419, in create_vpc\n    existing_tags_subset_of_new_tags = (set(csn.tags.items()).issubset(set(new_subnet_tags.items())))\nAttributeError: 'NoneType' object has no attribute 'items'\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE", 
    "parsed": false
}

```

The code defaults to an empty dictionary instead of None.  This prevents the code from throwing the None type exception.
