### PR TITLE
Validate rule fails when rule is an empty string.

### DIFF
--- a/cloud/amazon/ec2_group.py
+++ b/cloud/amazon/ec2_group.py
@@ -163,6 +163,10 @@ def validate_rule(module, rule):
     VALID_PARAMS = ('cidr_ip',
                     'group_id', 'group_name', 'group_desc',
                     'proto', 'from_port', 'to_port')
+
+    if not isinstance(rule, dict):
+        module.fail_json(msg='Invalid rule parameter type [%s].' % type(rule))
+
     for k in rule:
         if k not in VALID_PARAMS:
             module.fail_json(msg='Invalid rule parameter \'{}\''.format(k))


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### COMPONENT NAME

cloud/amazon/ec2_group.py
##### ANSIBLE VERSION

```
ansible 2.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

I don't think this is dependent on ansible version.
##### SUMMARY

```
Using module file /usr/lib/python2.7/site-packages/ansible/modules/core/cloud/amazon/ec2_group.py
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: kwoodson
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python2 && sleep 0'
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_Noe2He/ansible_module_ec2_group.py", line 474, in <module>
    main()
  File "/tmp/ansible_Noe2He/ansible_module_ec2_group.py", line 348, in main
    if rule['proto'] in ('all', '-1', -1):
TypeError: string indices must be integers, not str

fatal: [localhost]: FAILED! => {
    "changed": false, 
    "failed": true, 
    "invocation": {
        "module_name": "ec2_group"
    }, 
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_Noe2He/ansible_module_ec2_group.py\", line 474, in <module>\n    main()\n  File \"/tmp/ansible_Noe2He/ansible_module_ec2_group.py\", line 348, in main\n    if rule['proto'] in ('all', '-1', -1):\nTypeError: string indices must be integers, not str\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE", 
    "parsed": false
}
```

The rule parameter being passed in is an empty string.  It needs to be validated as a dict and an exception thrown if it does not have the attributes expected.
