### PR TITLE
replace - Declare empty diff dict ahead of time

### DIFF
--- a/files/replace.py
+++ b/files/replace.py
@@ -131,6 +131,7 @@ def main():
 
     params = module.params
     dest = os.path.expanduser(params['dest'])
+    diff = dict()
 
     if os.path.isdir(dest):
         module.fail_json(rc=256, msg='Destination %s is a directory !' % dest)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

replace module
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 9963ae1)
```
##### SUMMARY

A local variable was not properly initialized, and the issue does not seem to present on all platforms. I could not reproduce on OSX for example, but could on Ubuntu. ¯\_(ツ)_/¯

Fixes #4634

Before:

```
vagrant@local:~$ sudo ansible all -i "localhost," -c local -m replace -a 'dest=/etc/hosts regexp="(\s+)localhost(\s+.*)?$" replace="\1localhost.localdomain localhost\2"'
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: UnboundLocalError: local variable 'diff' referenced before assignment
localhost | FAILED! => {
    "changed": false, 
    "failed": true, 
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_F4B6fl/ansible_module_replace.py\", line 179, in <module>\n    main()\n  File \"/tmp/ansible_F4B6fl/ansible_module_replace.py\", line 173, in main\n    module.exit_json(changed=changed, msg=msg, diff=diff)\nUnboundLocalError: local variable 'diff' referenced before assignment\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE"
}
```

After:

```
vagrant@local:~$ sudo ansible all -i "localhost," -c local -m replace -a 'dest=/etc/hosts regexp="(\s+)localhost(\s+.*)?$" replace="\1localhost.localdomain localhost\2"'
localhost | SUCCESS => {
    "changed": true, 
    "msg": "1 replacements made"
}
```
