### PR TITLE
Support --master-data in mysql_db dumps

### DIFF
--- a/database/mysql/mysql_db.py
+++ b/database/mysql/mysql_db.py
@@ -51,6 +51,12 @@ options:
       - Encoding mode to use, examples include C(utf8) or C(latin1_swedish_ci)
     required: false
     default: null
+  master_data:
+    description:
+      - Produce a dump from a master for seeding a slave. (1 to generate a 'CHANGE MASTER TO' statement; 2 to generate a commented 'CHANGE MASTER TO'; 0 or null to not include master data)
+    required: false
+    default: null
+    version_added: "2.3"
   target:
     description:
       - Location, on the remote host, of the dump file to read from or write to. Uncompressed SQL
@@ -117,7 +123,7 @@ def db_delete(cursor, db):
     cursor.execute(query)
     return True
 
-def db_dump(module, host, user, password, db_name, target, all_databases, port, config_file, socket=None, ssl_cert=None, ssl_key=None, ssl_ca=None, single_transaction=None, quick=None):
+def db_dump(module, host, user, password, db_name, target, all_databases, port, config_file, socket=None, ssl_cert=None, ssl_key=None, ssl_ca=None, single_transaction=None, quick=None, master_data=None):
     cmd = module.get_bin_path('mysqldump', True)
     # If defined, mysqldump demands --defaults-extra-file be the first option
     if config_file:
@@ -144,6 +150,8 @@ def db_dump(module, host, user, password, db_name, target, all_databases, port, 
         cmd += " --single-transaction=true"
     if quick:
         cmd += " --quick"
+    if master_data:
+        cmd += " --master-data=%s" % pipes.quote(master_data)
 
     path = None
     if os.path.splitext(target)[-1] == '.gz':
@@ -240,6 +248,7 @@ def main():
             encoding=dict(default=""),
             collation=dict(default=""),
             target=dict(default=None, type='path'),
+            master_data=dict(default=None, choices=["0", "1", "2"]),
             state=dict(default="present", choices=["absent", "present","dump", "import"]),
             ssl_cert=dict(default=None, type='path'),
             ssl_key=dict(default=None, type='path'),
@@ -269,6 +278,7 @@ def main():
     ssl_ca = module.params["ssl_ca"]
     connect_timeout = module.params['connect_timeout']
     config_file = module.params['config_file']
+    master_data = module.params["master_data"]
     login_password = module.params["login_password"]
     login_user = module.params["login_user"]
     login_host = module.params["login_host"]
@@ -317,7 +327,7 @@ def main():
             else:
                 rc, stdout, stderr = db_dump(module, login_host, login_user,
                                             login_password, db, target, all_databases,
-                                            login_port, config_file, socket, ssl_cert, ssl_key, ssl_ca, single_transaction, quick)
+                                            login_port, config_file, socket, ssl_cert, ssl_key, ssl_ca, single_transaction, quick, master_data)
                 if rc != 0:
                     module.fail_json(msg="%s" % stderr)
                 else:


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

mysql_db
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.1.1.0
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

This adds the ability for a user to specify the `--master-data` switch when dumping a mysql database. This is a rebase of #363 and closes #362.

Note that I didn't place the `master_data` parameter last so as to keep this solely a feature addition. #3687 fixes the issue where `single_transaction` and `quick` are not correctly handled. Happy to include the fix here or rebase after #3687 is merged if that is the preferred method of change tracking.
