### PR TITLE
fixes issue where the configobjs are not deserialized to a list

### DIFF
--- a/network/ios/ios_config.py
+++ b/network/ios/ios_config.py
@@ -288,7 +288,7 @@ def load_config(module, commands, result):
     if not module.check_mode and module.params['update'] != 'check':
         module.config(commands)
     result['changed'] = module.params['update'] != 'check'
-    result['updates'] = commands.split('\n')
+    result['updates'] = commands
 
 def run(module, result):
     match = module.params['match']
@@ -304,7 +304,7 @@ def run(module, result):
         configobjs = candidate.items
 
     if configobjs:
-        commands = dumps(configobjs, 'commands')
+        commands = dumps(configobjs, 'commands').split('\n')
 
         if module.params['before']:
             commands[:0] = module.params['before']

--- a/network/iosxr/iosxr_config.py
+++ b/network/iosxr/iosxr_config.py
@@ -264,7 +264,7 @@ def run(module, result):
         configobjs = candidate.items
 
     if configobjs:
-        commands = dumps(configobjs, 'commands')
+        commands = dumps(configobjs, 'commands').split('\n')
 
         if module.params['before']:
             commands[:0] = module.params['before']
@@ -272,7 +272,7 @@ def run(module, result):
         if module.params['after']:
             commands.extend(module.params['after'])
 
-        result['updates'] = commands.split('\n')
+        result['updates'] = commands
 
         if update != 'check':
             load_config(module, commands, result)

--- a/network/openswitch/ops_config.py
+++ b/network/openswitch/ops_config.py
@@ -237,7 +237,7 @@ def load_config(module, commands, result):
     if not module.check_mode and module.params['update'] != 'check':
         module.config(commands)
     result['changed'] = module.params['update'] != 'check'
-    result['updates'] = commands.split('\n')
+    result['updates'] = commands
 
 def run(module, result):
     match = module.params['match']
@@ -253,7 +253,7 @@ def run(module, result):
         configobjs = candidate.items
 
     if configobjs:
-        commands = dumps(configobjs, 'commands')
+        commands = dumps(configobjs, 'commands').split('\n')
 
         if module.params['before']:
             commands[:0] = module.params['before']


### PR DESCRIPTION
When the configuration is compared and the results deserialized, the
dumps() function returns a string.  This coherences the return to a list
in case before and/or after needs to be applied

fixes #4707
