### PR TITLE
enabling output format JSON for junos #4103 #4104

### DIFF
--- a/network/junos/junos_command.py
+++ b/network/junos/junos_command.py
@@ -97,6 +97,7 @@ options:
     choices: ['xml', 'text', 'json']
 requirements:
   - junos-eznc
+  - format choice json requires junos >= 14.2
 notes:
   - This module requires the netconf system service be enabled on
     the remote device being managed

--- a/network/junos/junos_command.py
+++ b/network/junos/junos_command.py
@@ -94,7 +94,7 @@ options:
         output and apply the conditionals path to the result set.
     required: false
     default: 'xml'
-    choices: ['xml', 'text']
+    choices: ['xml', 'text', 'json']
 requirements:
   - junos-eznc
 notes:
@@ -183,9 +183,9 @@ def parse(module, command_type):
             item = dict(command=item, output=None)
         elif 'command' not in item:
             module.fail_json(msg='command keyword argument is required')
-        elif item.get('output') not in [None, 'text', 'xml']:
+        elif item.get('output') not in [None, 'text', 'xml', 'json']:
             module.fail_json(msg='invalid output specified for command'
-                                 'Supported values are `text` or `xml`')
+                                 'Supported values are `text`, `xml` or `json`')
         elif not set(item.keys()).issubset(VALID_KEYS[command_type]):
             module.fail_json(msg='unknown command keyword specified.  Valid '
                                  'values are %s' % ', '.join(VALID_KEYS[command_type]))
@@ -208,7 +208,7 @@ def main():
         commands=dict(type='list'),
         rpcs=dict(type='list'),
 
-        display=dict(default='xml', choices=['text', 'xml'],
+        display=dict(default='xml', choices=['text', 'xml', 'json'],
                      aliases=['format', 'output']),
 
         wait_for=dict(type='list', aliases=['waitfor']),


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

network/junos/junos_command.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Just enabled JSON. This does not check the device version, this will be done in py-junos-eznc/device.py
Fixes #4103 
Modified PR #4104

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
"stdout": [{"multi-routing-engine-results": [{"multi-routing-engine-item": [{"re-name": [{"data": "fpc0"}], "software-information": [{"host-name": [{"data": "netlab-sw01-a"}], "junos-version": [{"data": "15.1R3.6"}], "package-information": [{"comment": [{"data": "JUNOS EX  Software Suite [15.1R3.6]"}], "name": [{"data": "junos"}]}, {"comment": [{"data": "JUNOS FIPS mode utilities [15.1R3.6]"}], "name": [{"data": "fips-mode-powerpc"}]}, {"comment": [{"data": "JUNOS Online Documentation [15.1R3.6]"}], "name": [{"data": "jdocs-ex"}]}, {"comment": [{"data": "JUNOS EX 4200 Software Suite [15.1R3.6]"}], "name": [{"data": "junos-ex-4200"}]}, {"comment": [{"data": "JUNOS Web Management Platform Package [15.1R3.6]"}], "name": [{"data": "jweb-ex"}]}], "product-model": [{"data": "ex4200-24t"}], "product-name": [{"data": "ex4200-24t"}]}]}]}]}], "stdout_lines": [{"multi-routing-engine-results": [{"multi-routing-engine-item": [{"re-name": [{"data": "fpc0"}], "software-information": [{"host-name": [{"data": "netlab-sw01-a"}], "junos-version": [{"data": "15.1R3.6"}], "package-information": [{"comment": [{"data": "JUNOS EX  Software Suite [15.1R3.6]"}], "name": [{"data": "junos"}]}, {"comment": [{"data": "JUNOS FIPS mode utilities [15.1R3.6]"}], "name": [{"data": "fips-mode-powerpc"}]}, {"comment": [{"data": "JUNOS Online Documentation [15.1R3.6]"}], "name": [{"data": "jdocs-ex"}]}, {"comment": [{"data": "JUNOS EX 4200 Software Suite [15.1R3.6]"}], "name": [{"data": "junos-ex-4200"}]}, {"comment": [{"data": "JUNOS Web Management Platform Package [15.1R3.6]"}], "name": [{"data": "jweb-ex"}]}], "product-model": [{"data": "ex4200-24t"}], "product-name": [{"data": "ex4200-24t"}]}]}]}]}]}
```
