### PR TITLE
fix bug in ios_template when include_defaults is set to true

### DIFF
--- a/network/ios/ios_template.py
+++ b/network/ios/ios_template.py
@@ -119,8 +119,9 @@ from ansible.module_utils.ios import NetworkModule, NetworkError
 
 def get_config(module):
     config = module.params['config'] or dict()
+    defaults = module.params['include_defaults']
     if not config and not module.params['force']:
-        config = module.config.get_config()
+        config = module.config.get_config(include_defaults=defaults)
     return config
 
 def main():


### PR DESCRIPTION
Module was ignoring  include_defaults argument.  This fixes the issue
such that the correct configuration is returned
