### PR TITLE
Added work around for Ubuntu Xenial calling php7_module php7.0

### DIFF
--- a/web_infrastructure/apache2_module.py
+++ b/web_infrastructure/apache2_module.py
@@ -80,6 +80,12 @@ def _module_is_enabled(module):
 
     result, stdout, stderr = module.run_command("%s -M" % control_binary)
 
+    """
+    Work around for Ubuntu Xenial listing php7_module as php7.0
+    """
+    if name == "php7.0":
+        name = "php7"
+
     if result != 0:
         module.fail_json(msg="Error executing %s: %s" % (control_binary, stderr))
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

apache2_module
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel 982db58aff) last updated 2016/09/08 11:50:49 (GMT +100)
  lib/ansible/modules/core: (detached HEAD db38f0c876) last updated 2016/09/08 13:03:40 (GMT +100)
  lib/ansible/modules/extras: (detached HEAD 8bfdcfcab2) last updated 2016/09/08 11:51:00 (GMT +100)
  config file = /home/rowan/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fixes #4744
