### PR TITLE
Insert missing option line before blank lines at the end of the section

### DIFF
--- a/files/ini_file.py
+++ b/files/ini_file.py
@@ -155,8 +155,12 @@ def do_ini(module, filename, section=None, option=None, value=None, state='prese
             if within_section:
                 if state == 'present':
                     # insert missing option line at the end of the section
-                    ini_lines.insert(index, assignment_format % (option, value))
-                    changed = True
+                    for i in range(index, 0, -1):
+                        # search backwards for previous non-blank or non-comment line
+                        if not re.match(r'^[ \t]*([#;].*)?$', ini_lines[i - 1]):
+                            ini_lines.insert(i, assignment_format % (option, value))
+                            changed = True
+                            break
                 elif state == 'absent' and not option:
                     # remove the entire section
                     del ini_lines[section_start:index]


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

ini_file
##### ANSIBLE VERSION

```
ansible 2.1.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

This patch searches backwards for a non-blank (and non-comment) line before inserting new option lines to keep sections grouped together if they are separated by blank lines.

It gives the expected results as described in #4746. Also tested ok with samples from https://github.com/noseka1/ini_file2

Fixes #4746
