### PR TITLE
Fix openstack security group rule vrrp choice apostrophe error

### DIFF
--- a/cloud/openstack/os_security_group_rule.py
+++ b/cloud/openstack/os_security_group_rule.py
@@ -39,7 +39,7 @@ options:
    protocol:
       description:
         - IP protocols TCP UDP ICMP 112 (VRRP)
-      choices: ['tcp', 'udp', 'icmp', 112, None]
+      choices: ['tcp', 'udp', 'icmp', '112', None]
       default: None
    port_range_min:
       description:
@@ -257,7 +257,7 @@ def main():
         # NOTE(Shrews): None is an acceptable protocol value for
         # Neutron, but Nova will balk at this.
         protocol         = dict(default=None,
-                                choices=[None, 'tcp', 'udp', 'icmp', 112]),
+                                choices=[None, 'tcp', 'udp', 'icmp', '112']),
         port_range_min   = dict(required=False, type='int'),
         port_range_max   = dict(required=False, type='int'),
         remote_ip_prefix = dict(required=False, default=None),


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

Cloud > openstack > security group rule
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel 81a4164207) last updated 2016/09/08 14:45:45 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 982c4557d2) last updated 2016/09/06 09:58:16 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 06bd2a5ce2) last updated 2016/09/06 09:58:16 (GMT -400)
  config file = /home/aszekely/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Fixes the inclusion of 112 protocol for OS security group rule. 

Even with the merge of bugfix #4444 there was an error:

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
fatal: [localhost]: FAILED! => {
    "changed": false, 
    "failed": true
}

MSG:

value of protocol must be one of: None,tcp,udp,icmp,112, got: 112
```

Now this is fixed and tested on an openstack Juno installation.
