### PR TITLE
Better filtering of unknown files.

### DIFF
--- a/source_control/git.py
+++ b/source_control/git.py
@@ -403,7 +403,7 @@ def has_local_mods(module, git_path, dest, bare):
     if bare:
         return False
 
-    cmd = "%s status --porcelain -uno" % (git_path)
+    cmd = "%s status --porcelain --untracked-files=no" % (git_path)
     rc, stdout, stderr = module.run_command(cmd, cwd=dest)
     return len(stdout) > 0
 

--- a/source_control/git.py
+++ b/source_control/git.py
@@ -403,12 +403,9 @@ def has_local_mods(module, git_path, dest, bare):
     if bare:
         return False
 
-    cmd = "%s status --porcelain" % (git_path)
+    cmd = "%s status --porcelain -uno" % (git_path)
     rc, stdout, stderr = module.run_command(cmd, cwd=dest)
-    lines = stdout.splitlines()
-    lines = list(filter(lambda c: not re.search('^\\?\\?.*$', c), lines))
-
-    return len(lines) > 0
+    return len(stdout) > 0
 
 def reset(git_path, module, dest):
     '''


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

Module: source_control/git
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

If the only thing that interests us is if there are any changed files in the repository, we can circumvent
parsing `git status` output.
Instead of capturing, splitting and regexp filtering unknown files, it's much easier to just tell git to ignore them.
