### PR TITLE
fixes #4520 os_user does not honor OS env variables

### DIFF
--- a/cloud/openstack/os_user.py
+++ b/cloud/openstack/os_user.py
@@ -161,12 +161,16 @@ def main():
     enabled = module.params['enabled']
     state = module.params['state']
 
+    shade_params = { key: module.params[key]
+                 for key in module.params
+                 if key != 'password' }
+
     try:
-        cloud = shade.openstack_cloud(**module.params)
+        cloud = shade.openstack_cloud(**shade_params)
         user = cloud.get_user(name)
 
         if domain:
-            opcloud = shade.operator_cloud(**module.params)
+            opcloud = shade.operator_cloud(**shade_params)
             try:
                 # We assume admin is passing domain id
                 dom = opcloud.get_domain(domain)['id']


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

cloud/openstack/os_user
##### ANSIBLE VERSION

```
ansible 2.1.1.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fixes #4520 by filtering password out of params passed to init shade

Tested on mitaka

```

---
- hosts: localhost
  connection: local

  tasks:
  - name: create_user
    os_user:
      name: testuser
      password: testpass
      state: present
      domain: Default
    environment: 
      LC_ALL: C
      OS_ENDPOINT_TYPE: internalURL
      OS_USERNAME: REDACTED
      OS_PASSWORD: REDACTED
      OS_PROJECT_NAME: REDACTED
      OS_TENANT_NAME: REDACTED
      OS_AUTH_URL: REDACTED
      OS_NO_CACHE: 1
      OS_USER_DOMAIN_NAME: REDACTED
      OS_PROJECT_DOMAIN_NAME: REDACTED
      OS_IDENTITY_API_VERSION: 3
      OS_AUTH_VERSION: 3
```

```
ansible-playbook main.yml -i inventory
 [WARNING]: provided hosts list is empty, only localhost is available


PLAY [localhost] **************************************************************

GATHERING FACTS ***************************************************************
ok: [localhost]

TASK: [create_user] ***********************************************************
changed: [localhost]

PLAY RECAP ********************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0
```
