### PR TITLE
Default restart_retries to None rather than 0. Fixes #4534.

### DIFF
--- a/cloud/docker/docker_container.py
+++ b/cloud/docker/docker_container.py
@@ -1927,7 +1927,7 @@ def main():
         recreate=dict(type='bool', default=False),
         restart=dict(type='bool', default=False),
         restart_policy=dict(type='str', choices=['no', 'on-failure', 'always', 'unless-stopped']),
-        restart_retries=dict(type='int', default=0),
+        restart_retries=dict(type='int', default=None),
         shm_size=dict(type='str'),
         security_opts=dict(type='list'),
         state=dict(type='str', choices=['absent', 'present', 'started', 'stopped'], default='started'),


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### COMPONENT NAME

docker_container.py 
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel d3d53e2850) last updated 2016/09/09 21:41:42 (GMT -400)
  lib/ansible/modules/core: (detached HEAD bf5b3de83e) last updated 2016/09/09 21:43:17 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD f83aa9fff3) last updated 2016/09/09 21:43:17 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

To avoid restart_retries from being used in the comparison between the requested config and the existing container config, it has to be None rather than 0. If it's None, then the module knows that the user is not requesting a change. If it's 0, then it appears the user wants it to be 0, and a container that has a restart_retries value > 0 gets destroyed and recreated. 

Fixes #4534 - docker_container removes published_ports when restarted. In the test case presented by the user, the restart_retries is set to 5. In the next task a restart is requested. The module does a config comparison and decides that because the restart_retries are different it should re-create the container. The config for the second task does not include published_ports, and thus no published_ports is set on the new container.
