### PR TITLE
Purge networks by network name

### DIFF
--- a/cloud/docker/docker_container.py
+++ b/cloud/docker/docker_container.py
@@ -1767,9 +1767,9 @@ class ContainerManager(DockerBaseClass):
     def _purge_networks(self, container, networks):
         for network in networks:
             self.results['actions'].append(dict(removed_from_network=network['name']))
-            if not self.check_mode and network.get('id'):
+            if not self.check_mode:
                 try:
-                    self.client.disconnect_container_from_network(container.Id, network['id'])
+                    self.client.disconnect_container_from_network(container.Id, network['name'])
                 except Exception as exc:
                     self.fail("Error disconnecting container from network %s - %s" % (network['name'],
                                                                                       str(exc)))


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### COMPONENT NAME

docker_container.py 
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel d3d53e2850) last updated 2016/09/09 21:41:42 (GMT -400)
  lib/ansible/modules/core: (devel e723d36a07) last updated 2016/09/10 00:46:30 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD f83aa9fff3) last updated 2016/09/09 21:43:17 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fixes #4596 - newly created containers always have default networks, even when purge_networks set.
