### PR TITLE
Set default log_driver to None

### DIFF
--- a/cloud/docker/docker_container.py
+++ b/cloud/docker/docker_container.py
@@ -200,7 +200,7 @@ options:
     required: false
   log_driver:
     description:
-      - Specify the logging driver.
+      - Specify the logging driver. Docker uses json-file by default.
     choices:
       - json-file
       - syslog
@@ -209,7 +209,7 @@ options:
       - fluentd
       - awslogs
       - splunk
-    default: json-file
+    default: null
     required: false
   log_options:
     description:
@@ -1906,7 +1906,7 @@ def main():
         kill_signal=dict(type='str'),
         labels=dict(type='dict'),
         links=dict(type='list'),
-        log_driver=dict(type='str', choices=['json-file', 'syslog', 'journald', 'gelf', 'fluentd', 'awslogs', 'splunk'], default='json-file'),
+        log_driver=dict(type='str', choices=['json-file', 'syslog', 'journald', 'gelf', 'fluentd', 'awslogs', 'splunk'], default=None),
         log_options=dict(type='dict', aliases=['log_opt']),
         mac_address=dict(type='str'),
         memory=dict(type='str', default='0'),


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### COMPONENT NAME

docker_container.py
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel d3d53e2850) last updated 2016/09/09 21:41:42 (GMT -400)
  lib/ansible/modules/core: (devel de0122fdaf) last updated 2016/09/10 01:33:19 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD f83aa9fff3) last updated 2016/09/09 21:43:17 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fixes #4600 - cannot use state _started_ when specifying log_driver.

Defaulting log_driver to None prevents config comparison between requested config and config of existing container. 
