### PR TITLE
cron: replacement for os.getlogin()

### DIFF
--- a/system/cron.py
+++ b/system/cron.py
@@ -200,6 +200,7 @@ EXAMPLES = '''
 '''
 
 import os
+import pwd
 import re
 import tempfile
 import platform
@@ -479,7 +480,7 @@ class CronTab(object):
                 return "%s -l %s" % (pipes.quote(CRONCMD), pipes.quote(self.user))
             elif platform.system() == 'HP-UX':
                 return "%s %s %s" % (CRONCMD , '-l', pipes.quote(self.user))
-            elif os.getlogin() != self.user:
+            elif pwd.getpwuid(os.getuid())[0] != self.user:
                 user = '-u %s' % pipes.quote(self.user)
         return "%s %s %s" % (CRONCMD , user, '-l')
 
@@ -491,7 +492,7 @@ class CronTab(object):
         if self.user:
             if platform.system() in ['SunOS', 'HP-UX', 'AIX']:
                 return "chown %s %s ; su '%s' -c '%s %s'" % (pipes.quote(self.user), pipes.quote(path), pipes.quote(self.user), CRONCMD, pipes.quote(path))
-            elif os.getlogin() != self.user:
+            elif pwd.getpwuid(os.getuid())[0] != self.user:
                 user = '-u %s' % pipes.quote(self.user)
         return "%s %s %s" % (CRONCMD , user, pipes.quote(path))
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

`modules/system/cron`
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel cfc0753e83) last updated 2016/09/06 20:51:24 (GMT +200)
  lib/ansible/modules/core: (devel 3ccddc9ab9) last updated 2016/09/10 13:28:10 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 06bd2a5ce2) last updated 2016/09/10 13:32:50 (GMT +200)
  config file = 
  configured module search path = 
```
##### SUMMARY

`os.getlogin()` returns the user logged in on the controlling terminal. However
'crontab' only looks for the login name of the process' real user id which
`pwd.getpwuid(os.getuid())[0]` does provide. 
(cf. https://docs.python.org/2/library/os.html#os.getlogin)

While in most cases there is no difference, the former might fail under certain
circumstances (e.g. a lxc container connected by attachment without login),
throwing the error `OSError: [Errno 25] Inappropriate ioctl for device`.

Note: Pull Request #4270 introduced the change which uses `os.getlogin`.

Example:

```
# ansible -m cron -a "name=test user=testuser minute=10 job=echo" testhost

# before:

An exception occurred during task execution. To see the full traceback, use -vvv. The error was: OSE
rror: [Errno 25] Inappropriate ioctl for device
testhost | FAILED! => {
    "changed": false, 
    "failed": true, 
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_Day9eL/ansible_modul
e_cron.py\", line 700, in <module>\n    main()\n  File \"/tmp/ansible_Day9eL/ansible_module_cron.py\
", line 575, in main\n    crontab = CronTab(module, user, cron_file)\n  File \"/tmp/ansible_Day9eL/a
nsible_module_cron.py\", line 233, in __init__\n    self.read()\n  File \"/tmp/ansible_Day9eL/ansibl
e_module_cron.py\", line 251, in read\n    (rc, out, err) = self.module.run_command(self._read_user_
execute(), use_unsafe_shell=True)\n  File \"/tmp/ansible_Day9eL/ansible_module_cron.py\", line 480, 
in _read_user_execute\n    elif os.getlogin() != self.user:\nOSError: [Errno 25] Inappropriate ioctl
 for device\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE"
}

# after:

testhost | SUCCESS => {
    "changed": true, 
    "envs": [], 
    "jobs": [
        "test"
    ]
}
```
