### PR TITLE
Don't change to root dir in async_wrapper

### DIFF
--- a/utilities/logic/async_wrapper.py
+++ b/utilities/logic/async_wrapper.py
@@ -52,7 +52,6 @@ def daemonize_self():
         sys.exit("fork #1 failed: %d (%s)\n" % (e.errno, e.strerror))
 
     # decouple from parent environment
-    os.chdir("/")
     os.setsid()
     os.umask(int('022', 8))
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

async_wrapper

The daemonizing code here is taken from an ActiveState recipe, which
includes changing to / as a general best practice. While that is
normally true to allow for deleting the directory that the daemon
process started in, in this case it is not relevant as this is not
intended to be an actual long-running daemon.

Issue ansible/ansible#17466
