### PR TITLE
Return type 'string', not 'str'

### DIFF
--- a/cloud/azure/azure_rm_subnet.py
+++ b/cloud/azure/azure_rm_subnet.py
@@ -23,7 +23,7 @@ DOCUMENTATION = '''
 ---
 module: azure_rm_subnet
 version_added: "2.1"
-short_description: Manage the Azure subnets.
+short_description: Manage Azure subnets.
 description:
     - Create, update or delete a subnet within a given virtual network. Allows setting and updating the address
       prefix CIDR, which must be valid within the context of the virtual network. Use the azure_rm_networkinterface

--- a/cloud/azure/azure_rm_subnet.py
+++ b/cloud/azure/azure_rm_subnet.py
@@ -23,7 +23,7 @@ DOCUMENTATION = '''
 ---
 module: azure_rm_subnet
 version_added: "2.1"
-short_description: Manage Azure subnets.
+short_description: Manage the Azure subnets.
 description:
     - Create, update or delete a subnet within a given virtual network. Allows setting and updating the address
       prefix CIDR, which must be valid within the context of the virtual network. Use the azure_rm_networkinterface

--- a/cloud/azure/azure_rm_subnet.py
+++ b/cloud/azure/azure_rm_subnet.py
@@ -100,30 +100,30 @@ state:
     contains:
         address_prefix:
           description: IP address CIDR.
-          type: str
+          type: string
           example: "10.1.0.0/16"
         id:
           description: Subnet resource path.
-          type: str
+          type: string
           example: "/subscriptions/XXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXX/resourceGroups/Testing/providers/Microsoft.Network/virtualNetworks/My_Virtual_Network/subnets/foobar"
         name:
           description: Subnet name.
-          type: str
+          type: string
           example: "foobar"
         network_security_group:
           type: complex
           contains:
             id:
               description: Security group resource identifier.
-              type: str
+              type: string
               example: "/subscriptions/XXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXX/resourceGroups/Testing/providers/Microsoft.Network/networkSecurityGroups/secgroupfoo"
             name:
               description: Name of the security group.
-              type: str
+              type: string
               example: "secgroupfoo"
         provisioning_state:
           description: Success or failure of the provisioning event.
-          type: str
+          type: string
           example: "Succeeded"
 '''
 

--- a/cloud/docker/docker_image.py
+++ b/cloud/docker/docker_image.py
@@ -151,7 +151,7 @@ options:
         type: int
       cpusetcpus:
         description: CPUs in which to allow execution, e.g., "0-3", "0,1"
-        type: str
+        type: string
   use_tls:
     description:
       - "DEPRECATED. Whether to use tls to connect to the docker server. Set to C(no) when TLS will not be used. Set to

--- a/cloud/docker/docker_service.py
+++ b/cloud/docker/docker_service.py
@@ -46,7 +46,7 @@ options:
       description:
         - Provide a project name. If not provided, the project name is taken from the basename of C(project_src).
         - Required when no C(definition) is provided.
-      type: str
+      type: string
       required: false
   files:
       description:
@@ -63,7 +63,7 @@ options:
         - absent
         - present
       default: present
-      type: str
+      type: string
       required: false
   services:
       description:
@@ -99,7 +99,7 @@ options:
         - By default containers will be recreated when their configuration differs from the service definition.
         - Setting to I(never) ignores configuration differences and leaves existing containers unchanged.
         - Setting to I(always) forces recreation of all existing containers.
-      type: str
+      type: string
       required: false
       choices:
         - always
@@ -135,7 +135,7 @@ options:
   remove_images:
       description:
         - Use with state I(absent) to remove the all images or only local images.
-      type: str
+      type: string
       required: false
       default: null
   remove_volumes:
@@ -327,7 +327,7 @@ service:
               image:
                   description: Name of the image from which the container was built.
                   returned: success
-                  type: str
+                  type: string
                   example: postgres
               labels:
                   description: Meta data assigned to the container.
@@ -357,7 +357,7 @@ service:
                       globalIPv6:
                           description: IPv6 address assigned to the container.
                           returned: success
-                          type: str
+                          type: string
                           example: ''
                       globalIPv6PrefixLen:
                           description: IPv6 subnet length.
@@ -372,7 +372,7 @@ service:
                       macAddress:
                           description: Mac Address assigned to the virtual NIC.
                           returned: success
-                          type: str
+                          type: string
                           example: "02:42:ac:11:00:02"
               state:
                   description: Information regarding the current disposition of the container.
@@ -387,7 +387,7 @@ service:
                       status:
                           description: Description of the running state.
                           returned: success
-                          type: str
+                          type: string
                           example: running
 
 actions:

--- a/network/eos/eos_config.py
+++ b/network/eos/eos_config.py
@@ -189,7 +189,7 @@ RETURN = """
 updates:
   description: The set of commands that will be pushed to the remote device
   returned: when lines is specified
-  type: when lines is specified
+  type: list
   sample: ['...', '...']
 backup_path:
   description: The full path to the backup file

--- a/network/eos/eos_facts.py
+++ b/network/eos/eos_facts.py
@@ -80,26 +80,27 @@ ansible_net_gather_subset:
 ansible_net_model:
   description: The model name returned from the device
   returned: always
-  type: str
+  type: string
 ansible_net_serialnum:
   description: The serial number of the remote device
   returned: always
+  type: string
 ansible_net_version:
   description: The operating system version running on the remote device
   returned: always
-  type: str
+  type: string
 ansible_net_hostname:
   description: The configured hostname of the device
   returned: always
-  type: str
+  type: string
 ansible_net_image:
   description: The image file the device is running
   returned: always
-  type: str
+  type: string
 ansible_net_fqdn:
   description: The fully qualified domain name of the device
   returned: always
-  type: str
+  type: string
 
 # hardware
 ansible_net_filesystems:
@@ -119,7 +120,7 @@ ansible_net_memtotal_mb:
 ansible_net_config:
   description: The current active config from the device
   returned: when config is configured
-  type: str
+  type: string
 
 # interfaces
 ansible_net_all_ipv4_addresses:

--- a/network/ios/ios_config.py
+++ b/network/ios/ios_config.py
@@ -204,8 +204,8 @@ vars:
 RETURN = """
 updates:
   description: The set of commands that will be pushed to the remote device
-  returned: always
-  type: when lines is defined
+  returned: when lines is defined
+  type: list
   sample: ['...', '...']
 backup_path:
   description: The full path to the backup file

--- a/network/ios/ios_facts.py
+++ b/network/ios/ios_facts.py
@@ -67,15 +67,15 @@ ansible_net_gather_subset:
 ansible_net_model:
   description: The model name returned from the device
   returned: always
-  type: str
+  type: string
 ansible_net_serialnum:
   description: The serial number of the remote device
   returned: always
-  type: str
+  type: string
 ansible_net_version:
   description: The operating system version running on the remote device
   returned: always
-  type: str
+  type: string
 ansible_net_hostname:
   description: The configured hostname of the device
   returned: always
@@ -103,7 +103,7 @@ ansible_net_memtotal_mb:
 ansible_net_config:
   description: The current active config from the device
   returned: when config is configured
-  type: str
+  type: string
 
 # interfaces
 ansible_net_all_ipv4_addresses:

--- a/network/iosxr/iosxr_config.py
+++ b/network/iosxr/iosxr_config.py
@@ -176,9 +176,9 @@ vars:
 
 RETURN = """
 updates:
-  description: The set of commands that will be pushed to the remote device
-  returned: always
-  type: when lines is defined
+  description: The set of commands that will be pushed to the remote device.
+  returned: when lines is defined
+  type: list
   sample: ['...', '...']
 backup_path:
   description: The full path to the backup file

--- a/network/iosxr/iosxr_config.py
+++ b/network/iosxr/iosxr_config.py
@@ -177,7 +177,7 @@ vars:
 RETURN = """
 updates:
   description: The set of commands that will be pushed to the remote device.
-  returned: when lines is defined
+  returned: Only when lines is specified.
   type: list
   sample: ['...', '...']
 backup_path:

--- a/network/iosxr/iosxr_facts.py
+++ b/network/iosxr/iosxr_facts.py
@@ -67,7 +67,7 @@ ansible_net_gather_subset:
 ansible_net_version:
   description: The operating system version running on the remote device
   returned: always
-  type: str
+  type: string
 ansible_net_hostname:
   description: The configured hostname of the device
   returned: always
@@ -95,7 +95,7 @@ ansible_net_memtotal_mb:
 ansible_net_config:
   description: The current active config from the device
   returned: when config is configured
-  type: str
+  type: string
 
 # interfaces
 ansible_net_all_ipv4_addresses:

--- a/network/nxos/nxos_facts.py
+++ b/network/nxos/nxos_facts.py
@@ -80,15 +80,15 @@ ansible_net_gather_subset:
 ansible_net_model:
   description: The model name returned from the device
   returned: always
-  type: str
+  type: string
 ansible_net_serialnum:
   description: The serial number of the remote device
   returned: always
-  type: str
+  type: string
 ansible_net_version:
   description: The operating system version running on the remote device
   returned: always
-  type: str
+  type: string
 ansible_net_hostname:
   description: The configured hostname of the device
   returned: always
@@ -116,7 +116,7 @@ ansible_net_memtotal_mb:
 ansible_net_config:
   description: The current active config from the device
   returned: when config is configured
-  type: str
+  type: string
 
 # interfaces
 ansible_net_all_ipv4_addresses:
@@ -152,7 +152,7 @@ interfaces_list:
 kickstart:
   description: The software version used to boot the system
   returned: when legacy is configured
-  type: str
+  type: string
 module:
   description: A hash of facts about the modules in a remote device
   returned: when legacy is configured
@@ -160,11 +160,11 @@ module:
 platform:
   description: The hardware platform reported by the remote device
   returned: when legacy is configured
-  type: str
+  type: string
 power_supply_info:
   description: A hash of facts about the power supplies in the remote device
   returned: when legacy is configured
-  type: str
+  type: string
 vlan_list:
   description: The list of VLAN IDs configured on the remote device
   returned: when legacy is configured

--- a/network/openswitch/ops_command.py
+++ b/network/openswitch/ops_command.py
@@ -121,7 +121,7 @@ stdout_lines:
   sample: [['...', '...'], ['...'], ['...']]
 
 failed_conditions:
-  description: the conditionals that failed
+  description: The conditionals that failed
   retured: failed
   type: list
   sample: ['...', '...']

--- a/network/openswitch/ops_command.py
+++ b/network/openswitch/ops_command.py
@@ -122,7 +122,7 @@ stdout_lines:
 
 failed_conditions:
   description: The conditionals that failed
-  retured: failed
+  returned: failed
   type: list
   sample: ['...', '...']
 """

--- a/network/openswitch/ops_facts.py
+++ b/network/openswitch/ops_facts.py
@@ -123,15 +123,15 @@ ansible_net_gather_subset:
 ansible_net_model:
   description: The model name returned from the device
   returned: when transport is cli
-  type: str
+  type: string
 ansible_net_serialnum:
   description: The serial number of the remote device
   returned: when transport is cli
-  type: str
+  type: string
 ansible_net_version:
   description: The operating system version running on the remote device
   returned: always
-  type: str
+  type: string
 ansible_net_hostname:
   description: The configured hostname of the device
   returned: always
@@ -145,7 +145,7 @@ ansible_net_image:
 ansible_net_config:
   description: The current active config from the device
   returned: when config is enabled
-  type: str
+  type: string
 
 # legacy (pre Ansible 2.2)
 config:

--- a/network/openswitch/ops_template.py
+++ b/network/openswitch/ops_template.py
@@ -90,7 +90,7 @@ updates:
   type: dict
   sample: {obj, obj}
 responses:
-  desription: returns the responses when configuring using cli
+  description: returns the responses when configuring using cli
   returned: when transport == cli
   type: list
   sample: [...]

--- a/network/sros/sros_config.py
+++ b/network/sros/sros_config.py
@@ -63,7 +63,7 @@ options:
         a change needs to be made.  This allows the playbook designer
         the opportunity to perform configuration commands prior to pushing
         any changes without affecting how the set of commands are matched
-        against the system
+        against the system.
     required: false
     default: null
   after:
@@ -94,7 +94,7 @@ options:
         the modified lines are pushed to the device in configuration
         mode.  If the replace argument is set to I(block) then the entire
         command block is pushed to the device in configuration mode if any
-        line is not correct
+        line is not correct.
     required: false
     default: line
     choices: ['line', 'block']

--- a/network/sros/sros_rollback.py
+++ b/network/sros/sros_rollback.py
@@ -33,15 +33,15 @@ options:
     description:
       - The I(rollback_location) specifies the location and filename
         of the rollback checkpoint files.   This argument supports any
-        valid local or remote URL as specified in SROS
+        valid local or remote URL as specified in SROS.
     required: false
     default: null
   remote_max_checkpoints:
     description:
       - The I(remote_max_checkpoints) argument configures the maximum
-        number of rollback files that can be transfered and saved to
+        number of rollback files that can be transferred and saved to
         a remote location.  Valid values for this argument are in the
-        range of 1 to 50
+        range of 1 to 50.
     required: false
     default: null
   local_max_checkpoints:
@@ -49,14 +49,14 @@ options:
       - The I(local_max_checkpoints) argument configures the maximum
         number of rollback files that can be saved on the devices local
         compact flash.  Valid values for this argument are in the range
-        of 1 to 50
+        of 1 to 50.
     required: false
     default: null
   rescue_location:
     description:
       - The I(rescue_location) specifies the location of the
         rescue file.  This argument supports any valid local
-        or remote URL as specified in SROS
+        or remote URL as specified in SROS.
     required: false
     default: null
   state:

--- a/network/sros/sros_rollback.py
+++ b/network/sros/sros_rollback.py
@@ -33,7 +33,7 @@ options:
     description:
       - The I(rollback_location) specifies the location and filename
         of the rollback checkpoint files.   This argument supports any
-        valid local or remote URL as specified in SROS.
+        valid local or remote URL as specified in SR OS.
     required: false
     default: null
   remote_max_checkpoints:
@@ -56,7 +56,7 @@ options:
     description:
       - The I(rescue_location) specifies the location of the
         rescue file.  This argument supports any valid local
-        or remote URL as specified in SROS.
+        or remote URL as specified in SR OS.
     required: false
     default: null
   state:

--- a/network/vyos/vyos_config.py
+++ b/network/vyos/vyos_config.py
@@ -61,7 +61,7 @@ options:
       - The C(backup) argument will backup the current devices active
         configuration to the Ansible control host prior to making any
         changes.  The backup file will be located in the backup folder
-        in the root of the playbook
+        in the root of the playbook.
     required: false
     default: false
     choices: ['yes', 'no']

--- a/network/vyos/vyos_facts.py
+++ b/network/vyos/vyos_facts.py
@@ -68,7 +68,7 @@ RETURN = """
 ansible_net_config:
   description: The running-config from the device
   returned: when config is configured
-  type: str
+  type: string
 ansible_net_commits:
   descrption: The set of available configuration revisions
   returned: when present
@@ -76,19 +76,19 @@ ansible_net_commits:
 ansible_net_hostname:
   description: The configured system hostname
   returned: always
-  type: str
+  type: string
 ansible_net_model:
   description: The device model string
   returned: always
-  type: str
+  type: string
 ansible_net_serialnum:
   description: The serial number of the device
   returned: always
-  type: str
+  type: string
 ansible_net_version:
   description: The version of the software running
   returned: always
-  type: str
+  type: string
 ansible_net_neighbors:
   description: The set of LLDP neighbors
   returned: when interface is configured


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

eos_facts
##### ANSIBLE VERSION

n/a
##### SUMMARY

I noticed in a few places we were documenting return type as `str`, rather than `string`.

Also tidy up a few typos/formatting issues spotted when doing this

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible-modules-core/4794)

<!-- Reviewable:end -->
