### PR TITLE
Document `backup` option in eos_config and nxos_config

### DIFF
--- a/network/eos/eos_config.py
+++ b/network/eos/eos_config.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
+
 DOCUMENTATION = """
 ---
 module: eos_config
@@ -108,6 +109,17 @@ options:
     required: false
     default: false
     choices: ['yes', 'no']
+  backup:
+    description:
+      - This argument will cause the module to create a full backup of
+        the current C(running-config) from the remote device before any
+        changes are made.  The backup file is written to the C(backup)
+        folder in the playbook root directory.  If the directory does not
+        exist, it is created.
+    required: false
+    default: no
+    choices: ['yes', 'no']
+    version_added: "2.2"
   config:
     description:
       - The module, by default, will connect to the remote device and
@@ -270,10 +282,10 @@ def main():
     """ main entry point for module execution
     """
     argument_spec = dict(
+        src=dict(type='path'),
+
         lines=dict(aliases=['commands'], type='list'),
         parents=dict(type='list'),
-
-        src=dict(type='path'),
 
         before=dict(type='list'),
         after=dict(type='list'),
@@ -285,11 +297,10 @@ def main():
         # it will be removed in a future version
         force=dict(default=False, type='bool'),
 
-        backup=dict(type='bool', default=False),
-
         config=dict(),
         defaults=dict(type='bool', default=False),
 
+        backup=dict(type='bool', default=False),
         save=dict(default=False, type='bool'),
     )
 

--- a/network/ios/ios_config.py
+++ b/network/ios/ios_config.py
@@ -63,7 +63,7 @@ options:
         a change needs to be made.  This allows the playbook designer
         the opportunity to perform configuration commands prior to pushing
         any changes without affecting how the set of commands are matched
-        against the system
+        against the system.
     required: false
     default: null
   after:
@@ -322,8 +322,8 @@ def main():
         config=dict(),
         default=dict(type='bool', default=False),
 
-        save=dict(type='bool', default=False),
         backup=dict(type='bool', default=False),
+        save=dict(default=False, type='bool'),
     )
 
     mutually_exclusive = [('lines', 'src')]

--- a/network/nxos/nxos_config.py
+++ b/network/nxos/nxos_config.py
@@ -112,6 +112,17 @@ options:
     required: false
     default: false
     choices: [ "true", "false" ]
+  backup:
+    description:
+      - This argument will cause the module to create a full backup of
+        the current C(running-config) from the remote device before any
+        changes are made.  The backup file is written to the C(backup)
+        folder in the playbook root directory.  If the directory does not
+        exist, it is created.
+    required: false
+    default: no
+    choices: ['yes', 'no']
+    version_added: "2.2"
   config:
     description:
       - The module, by default, will connect to the remote device and
@@ -145,7 +156,6 @@ options:
     default: false
     version_added: "2.2"
 """
-
 
 EXAMPLES = """
 # Note: examples below use the following provider dict to handle


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

eos_config
nxos_config
##### ANSIBLE VERSION

```
ansible --version
ansible 2.2.0 (devel 4e325274d6) last updated 2016/09/12 15:33:57 (GMT +100)
  lib/ansible/modules/core: (devel 9bb0c498df) last updated 2016/09/12 15:34:21 (GMT +100)
  lib/ansible/modules/extras: (devel 67a1bebbd3) last updated 2016/09/12 12:05:15 (GMT +100)
```
##### SUMMARY

Document `backup` option that was adding during 2.2.

To make future diffing easier, use consistent ordering
