### PR TITLE
Async chdir

### DIFF
--- a/system/service.py
+++ b/system/service.py
@@ -1463,9 +1463,8 @@ def main():
             arguments = dict(aliases=['args'], default=''),
         ),
         supports_check_mode=True
+        required_one_of=[['state', 'enabled']],
     )
-    if module.params['state'] is None and module.params['enabled'] is None:
-        module.fail_json(msg="Neither 'state' nor 'enabled' set")
 
     service = Service(module)
 

--- a/utilities/logic/async_wrapper.py
+++ b/utilities/logic/async_wrapper.py
@@ -51,8 +51,7 @@ def daemonize_self():
         e = sys.exc_info()[1]
         sys.exit("fork #1 failed: %d (%s)\n" % (e.errno, e.strerror))
 
-    # decouple from parent environment
-    os.chdir("/")
+    # decouple from parent environment (does not chdir / to keep the directory context the same as for non async tasks)
     os.setsid()
     os.umask(int('022', 8))
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

async_wrapper
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.2
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Remove chdir as it changed the default directory for async tasks vs non async  ones.
