### PR TITLE
Add support for SmartOS in hostname module

### DIFF
--- a/system/hostname.py
+++ b/system/hostname.py
@@ -569,7 +569,7 @@ class SmartOSStrategy(GenericStrategy):
         try:
             f = open(self.NODENAME_FILE, 'w+')
             try:
-                f.write("{}\n".format(name))
+                f.write("%s\n" % name)
             finally:
                 f.close()
         except Exception:

--- a/system/hostname.py
+++ b/system/hostname.py
@@ -518,8 +518,8 @@ class SolarisStrategy(GenericStrategy):
         cmd = [self.hostname_cmd, cmd_option, name]
         rc, out, err = self.module.run_command(cmd)
         if rc != 0:
-            self.module.fail_json(msg="Command failed rc=%d, out=%s, err=%s" %
-                (rc, out, err))
+            self.module.fail_json(msg="Command failed rc=%d, out=%s, err=%s, cmd=%s, strategy=%s" %
+                (rc, out, err, " ".join(cmd), type(self).__name__))
 
     def get_permanent_hostname(self):
         fmri = 'svc:/system/identity:node'

--- a/system/hostname.py
+++ b/system/hostname.py
@@ -752,10 +752,10 @@ class OpenBSDHostname(Hostname):
     distribution = None
     strategy_class = OpenBSDStrategy
 
-class SolarisHostname(Hostname):
-    platform = 'SunOS'
-    distribution = None
-    strategy_class = SolarisStrategy
+#class SolarisHostname(Hostname):
+#    platform = 'SunOS'
+#    distribution = None
+#    strategy_class = SolarisStrategy
 
 class SmartOSHostname(Hostname):
     platform = 'SunOS'


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

hostname
##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.2.0
  config file = /home/hnakamur/ghq/github.com/hnakamur/postgresql-pgpool2-failover-example-playbook/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fixes #4782

No output change since I don't have access to a SmartOS environment.
