### PR TITLE
Docker module: add support for OomScoreAdj

### DIFF
--- a/cloud/docker/docker_container.py
+++ b/cloud/docker/docker_container.py
@@ -276,6 +276,12 @@ options:
       - Whether or not to disable OOM Killer for the container.
     default: false
     required: false
+  oom_score_adj:
+    description:
+      - An integer value containing the score given to the container in order to tune OOM killer preferences.
+    default: 0
+    required: false
+    version_added: "2.2"
   paused:
     description:
       - Use with the started state to pause running processes inside the container.
@@ -713,6 +719,7 @@ class TaskParameters(DockerBaseClass):
         self.network_mode = None
         self.networks = None
         self.oom_killer = None
+        self.oom_score_adj = None
         self.paused = None
         self.pid_mode = None
         self.privileged = None
@@ -909,6 +916,7 @@ class TaskParameters(DockerBaseClass):
             mem_limit='memory',
             memswap_limit='memory_swap',
             mem_swappiness='memory_swappiness',
+            oom_score_adj='oom_score_adj',
             shm_size='shm_size',
             group_add='groups',
             devices='devices',
@@ -1218,6 +1226,7 @@ class Container(DockerBaseClass):
             memory_swappiness=host_config.get('MemorySwappiness'),
             network_mode=host_config.get('NetworkMode'),
             oom_killer=host_config.get('OomKillDisable'),
+            oom_score_adj=host_config.get('OomScoreAdj'),
             pid_mode=host_config.get('PidMode'),
             privileged=host_config.get('Privileged'),
             expected_ports=host_config.get('PortBindings'),
@@ -1329,6 +1338,7 @@ class Container(DockerBaseClass):
             memory=host_config.get('Memory'),
             memory_reservation=host_config.get('MemoryReservation'),
             memory_swap=host_config.get('MemorySwap'),
+            oom_score_adj=host_config.get('OomScoreAdj'),
         )
 
         differences = []
@@ -1917,6 +1927,7 @@ def main():
         network_mode=dict(type='str'),
         networks=dict(type='list'),
         oom_killer=dict(type='bool'),
+        oom_score_adj=dict(type='int'),
         paused=dict(type='bool', default=False),
         pid_mode=dict(type='str'),
         privileged=dict(type='bool', default=False),


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

docker_container
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel bfe341177b) last updated 2016/09/12 13:32:48 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 432ee70da1) last updated 2016/09/12 13:32:53 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 67a1bebbd3) last updated 2016/09/12 13:32:59 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Adding support for OomScoreAdj. This is useful for setting container's oom kill priority so that when the machine runs out of memory, less critical containers are killed before more critical ones.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
##### COMMAND

`ansible-playbook -vvv docker.yml`
##### TEST (docker.yml)

```

---
- hosts: all
  tasks:
  - name: test container
    docker_container:
      name: test
      image: ubuntu:14.04
      state: present
      oom_score_adj: 8
```
##### BEFORE

```
PLAYBOOK: docker.yml ***********************************************************
1 plays in docker.yml

PLAY [all] *********************************************************************

TASK [setup] *******************************************************************
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: *****
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1473813711.13-248925612640005 `" && echo ansible-tmp-1473813711.13-248925612640005="` echo $HOME/.ansible/tmp/ansible-tmp-1473813711.13-248925612640005 `" ) && sleep 0'
<localhost> PUT /var/folders/9p/b1snycq90q16g6blc94_k43h393fxp/T/tmpAxT_Yn TO /Users/*****/.ansible/tmp/ansible-tmp-1473813711.13-248925612640005/setup
<localhost> EXEC /bin/sh -c 'LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/python /Users/*****/.ansible/tmp/ansible-tmp-1473813711.13-248925612640005/setup; rm -rf "/Users/*****/.ansible/tmp/ansible-tmp-1473813711.13-248925612640005/" > /dev/null 2>&1 && sleep 0'
ok: [localhost]

TASK [data container] **********************************************************
task path: /Users/*****/git/ansible/adi/docker.yml:4
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: *****
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1473813711.54-25087418408317 `" && echo ansible-tmp-1473813711.54-25087418408317="` echo $HOME/.ansible/tmp/ansible-tmp-1473813711.54-25087418408317 `" ) && sleep 0'
<localhost> PUT /var/folders/9p/b1snycq90q16g6blc94_k43h393fxp/T/tmpUs7hHC TO /Users/*****/.ansible/tmp/ansible-tmp-1473813711.54-25087418408317/docker_container
<localhost> EXEC /bin/sh -c 'LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/python /Users/*****/.ansible/tmp/ansible-tmp-1473813711.54-25087418408317/docker_container; rm -rf "/Users/*****/.ansible/tmp/ansible-tmp-1473813711.54-25087418408317/" > /dev/null 2>&1 && sleep 0'
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "invocation": {"module_args": {"image": "ubuntu:14.04", "name": "test", "oom_score_adj": 8, "state": "present"}, "module_name": "docker_container"}, "msg": "unsupported parameter for module: oom_score_adj"}


PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1   

```
##### AFTER

```
Loading callback plugin default of type stdout, v2.0 from /Users/*****/git/ansible/lib/ansible/plugins/callback/__init__.pyc

PLAYBOOK: docker.yml ***********************************************************
1 plays in docker.yml

PLAY [all] *********************************************************************

TASK [setup] *******************************************************************
Using module file /Users/*****/git/ansible/lib/ansible/modules/core/system/setup.py
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: *****
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1473813584.64-125848809553558 `" && echo ansible-tmp-1473813584.64-125848809553558="` echo $HOME/.ansible/tmp/ansible-tmp-1473813584.64-125848809553558 `" ) && sleep 0'
<localhost> PUT /var/folders/9p/b1snycq90q16g6blc94_k43h393fxp/T/tmp5yuqUi TO /Users/*****/.ansible/tmp/ansible-tmp-1473813584.64-125848809553558/setup.py
<localhost> EXEC /bin/sh -c 'chmod u+x /Users/*****/.ansible/tmp/ansible-tmp-1473813584.64-125848809553558/ /Users/*****/.ansible/tmp/ansible-tmp-1473813584.64-125848809553558/setup.py && sleep 0'
<localhost> EXEC /bin/sh -c '/usr/bin/python /Users/*****/.ansible/tmp/ansible-tmp-1473813584.64-125848809553558/setup.py && sleep 0'
ok: [localhost]

TASK [data container] **********************************************************
task path: /Users/*****/git/ansible/adi/docker.yml:4
Using module file /Users/*****/git/ansible/lib/ansible/modules/core/cloud/docker/docker_container.py
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: *****
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1473813585.04-187823837390513 `" && echo ansible-tmp-1473813585.04-187823837390513="` echo $HOME/.ansible/tmp/ansible-tmp-1473813585.04-187823837390513 `" ) && sleep 0'
<localhost> PUT /var/folders/9p/b1snycq90q16g6blc94_k43h393fxp/T/tmp1xFUOg TO /Users/*****/.ansible/tmp/ansible-tmp-1473813585.04-187823837390513/docker_container.py
<localhost> EXEC /bin/sh -c 'chmod u+x /Users/*****/.ansible/tmp/ansible-tmp-1473813585.04-187823837390513/ /Users/*****/.ansible/tmp/ansible-tmp-1473813585.04-187823837390513/docker_container.py && sleep 0'
<localhost> EXEC /bin/sh -c '/usr/bin/python /Users/*****/.ansible/tmp/ansible-tmp-1473813585.04-187823837390513/docker_container.py && sleep 0'
changed: [localhost] => {
    "ansible_facts": {
        "ansible_docker_container": {
            "AppArmorProfile": "", 
            "Args": [], 
            "Config": {
                "AttachStderr": false, 
                "AttachStdin": false, 
                "AttachStdout": false, 
                "Cmd": [
                    "/bin/bash"
                ], 
                "Domainname": "", 
                "Entrypoint": null, 
                "Env": [
                    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
                ], 
                "Hostname": "30af233c83fc", 
                "Image": "ubuntu:14.04", 
                "Labels": {}, 
                "OnBuild": null, 
                "OpenStdin": false, 
                "StdinOnce": false, 
                "Tty": false, 
                "User": "", 
                "Volumes": null, 
                "WorkingDir": ""
            }, 
            "Created": "2016-09-14T00:39:45.440238015Z", 
            "Driver": "aufs", 
            "ExecIDs": null, 
            "GraphDriver": {
                "Data": null, 
                "Name": "aufs"
            }, 
            "HostConfig": {
                "AutoRemove": false, 
                "Binds": [], 
                "BlkioDeviceReadBps": null, 
                "BlkioDeviceReadIOps": null, 
                "BlkioDeviceWriteBps": null, 
                "BlkioDeviceWriteIOps": null, 
                "BlkioWeight": 0, 
                "BlkioWeightDevice": null, 
                "CapAdd": null, 
                "CapDrop": null, 
                "Cgroup": "", 
                "CgroupParent": "", 
                "ConsoleSize": [
                    0, 
                    0
                ], 
                "ContainerIDFile": "", 
                "CpuCount": 0, 
                "CpuPercent": 0, 
                "CpuPeriod": 0, 
                "CpuQuota": 0, 
                "CpuShares": 0, 
                "CpusetCpus": "", 
                "CpusetMems": "", 
                "Devices": null, 
                "DiskQuota": 0, 
                "Dns": null, 
                "DnsOptions": null, 
                "DnsSearch": null, 
                "ExtraHosts": null, 
                "GroupAdd": null, 
                "IOMaximumBandwidth": 0, 
                "IOMaximumIOps": 0, 
                "IpcMode": "", 
                "Isolation": "", 
                "KernelMemory": 0, 
                "Links": null, 
                "LogConfig": {
                    "Config": {}, 
                    "Type": "json-file"
                }, 
                "Memory": 0, 
                "MemoryReservation": 0, 
                "MemorySwap": 0, 
                "MemorySwappiness": -1, 
                "NetworkMode": "default", 
                "OomKillDisable": false, 
                "OomScoreAdj": 8, 
                "PidMode": "", 
                "PidsLimit": 0, 
                "PortBindings": null, 
                "Privileged": false, 
                "PublishAllPorts": false, 
                "ReadonlyRootfs": false, 
                "RestartPolicy": {
                    "MaximumRetryCount": 0, 
                    "Name": ""
                }, 
                "Runtime": "runc", 
                "SecurityOpt": null, 
                "ShmSize": 67108864, 
                "UTSMode": "", 
                "Ulimits": null, 
                "UsernsMode": "", 
                "VolumeDriver": "", 
                "VolumesFrom": null
            }, 
            "HostnamePath": "", 
            "HostsPath": "", 
            "Id": "30af233c83fc1b0b0addb4db62884f090a2b6a4933cc104f78282ef6a1fdd625", 
            "Image": "sha256:4a725d3b3b1cc18c8cbd05358ffbbfedfe1eb947f58061e5858f08e2899731ee", 
            "LogPath": "", 
            "MountLabel": "", 
            "Mounts": [], 
            "Name": "/test", 
            "NetworkSettings": {
                "Bridge": "", 
                "EndpointID": "", 
                "Gateway": "", 
                "GlobalIPv6Address": "", 
                "GlobalIPv6PrefixLen": 0, 
                "HairpinMode": false, 
                "IPAddress": "", 
                "IPPrefixLen": 0, 
                "IPv6Gateway": "", 
                "LinkLocalIPv6Address": "", 
                "LinkLocalIPv6PrefixLen": 0, 
                "MacAddress": "", 
                "Networks": {
                    "bridge": {
                        "Aliases": null, 
                        "EndpointID": "", 
                        "Gateway": "", 
                        "GlobalIPv6Address": "", 
                        "GlobalIPv6PrefixLen": 0, 
                        "IPAMConfig": null, 
                        "IPAddress": "", 
                        "IPPrefixLen": 0, 
                        "IPv6Gateway": "", 
                        "Links": null, 
                        "MacAddress": "", 
                        "NetworkID": ""
                    }
                }, 
                "Ports": null, 
                "SandboxID": "", 
                "SandboxKey": "", 
                "SecondaryIPAddresses": null, 
                "SecondaryIPv6Addresses": null
            }, 
            "Path": "/bin/bash", 
            "ProcessLabel": "", 
            "ResolvConfPath": "", 
            "RestartCount": 0, 
            "State": {
                "Dead": false, 
                "Error": "", 
                "ExitCode": 0, 
                "FinishedAt": "0001-01-01T00:00:00Z", 
                "OOMKilled": false, 
                "Paused": false, 
                "Pid": 0, 
                "Restarting": false, 
                "Running": false, 
                "StartedAt": "0001-01-01T00:00:00Z", 
                "Status": "created"
            }
        }
    }, 
    "changed": true, 
    "invocation": {
        "module_args": {
            "api_version": null, 
            "blkio_weight": null, 
            "cacert_path": null, 
            "capabilities": null, 
            "cert_path": null, 
            "cleanup": false, 
            "command": null, 
            "cpu_period": null, 
            "cpu_quota": null, 
            "cpu_shares": null, 
            "cpuset_cpus": null, 
            "cpuset_mems": null, 
            "debug": false, 
            "detach": true, 
            "devices": null, 
            "dns_opts": null, 
            "dns_search_domains": null, 
            "dns_servers": null, 
            "docker_host": null, 
            "entrypoint": null, 
            "env": null, 
            "env_file": null, 
            "etc_hosts": null, 
            "exposed_ports": null, 
            "filter_logger": false, 
            "force_kill": false, 
            "groups": null, 
            "hostname": null, 
            "ignore_image": false, 
            "image": "ubuntu:14.04", 
            "interactive": false, 
            "ipc_mode": null, 
            "keep_volumes": true, 
            "kernel_memory": null, 
            "key_path": null, 
            "kill_signal": null, 
            "labels": null, 
            "links": null, 
            "log_driver": null, 
            "log_options": null, 
            "mac_address": null, 
            "memory": "0", 
            "memory_reservation": null, 
            "memory_swap": null, 
            "memory_swappiness": null, 
            "name": "test", 
            "network_mode": null, 
            "networks": null, 
            "oom_killer": null, 
            "oom_score_adj": 8, 
            "paused": false, 
            "pid_mode": null, 
            "privileged": false, 
            "published_ports": null, 
            "pull": false, 
            "purge_networks": null, 
            "read_only": false, 
            "recreate": false, 
            "restart": false, 
            "restart_policy": null, 
            "restart_retries": null, 
            "security_opts": null, 
            "shm_size": null, 
            "ssl_version": null, 
            "state": "present", 
            "stop_signal": null, 
            "stop_timeout": null, 
            "timeout": null, 
            "tls": null, 
            "tls_hostname": null, 
            "tls_verify": null, 
            "trust_image_content": false, 
            "tty": false, 
            "ulimits": null, 
            "user": null, 
            "uts": null, 
            "volume_driver": null, 
            "volumes": null, 
            "volumes_from": null
        }, 
        "module_name": "docker_container"
    }
}

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0   

```
