### PR TITLE
Add support for AWS China region (cn-north-1)

### DIFF
--- a/cloud/amazon/_ec2_ami_search.py
+++ b/cloud/amazon/_ec2_ami_search.py
@@ -57,8 +57,8 @@ options:
     required: false
     default: us-east-1
     choices: ["ap-northeast-1", "ap-southeast-1", "ap-northeast-2",
-              "ap-southeast-2", "eu-central-1", "eu-west-1", "sa-east-1",
-              "us-east-1", "us-west-1", "us-west-2", "us-gov-west-1"]
+              "ap-southeast-2", "cn-north-1", "eu-central-1", "eu-west-1", 
+              "sa-east-1", "us-east-1", "us-west-1", "us-west-2", "us-gov-west-1"]
   virt:
     description: virutalization type
     required: false
@@ -91,6 +91,7 @@ AWS_REGIONS = ['ap-northeast-1',
                'ap-northeast-2',
                'ap-southeast-2',
                'ap-south-1',
+               'cn-north-1',
                'eu-central-1',
                'eu-west-1',
                'sa-east-1',

--- a/cloud/amazon/ec2_facts.py
+++ b/cloud/amazon/ec2_facts.py
@@ -65,6 +65,7 @@ class Ec2Metadata(object):
                    'ap-southeast-1',
                    'ap-southeast-2',
                    'ap-south-1',
+                   'cn-north-1',
                    'eu-central-1',
                    'eu-west-1',
                    'sa-east-1',


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

ansible-modules-core/cloud/amazon/ec2_facts
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Before this patch, `ansible_ec2_placement_region` will just returns either "cn-north-1a" or "cn-north-1b" in AWS China region, which cannot be used directly, this is a quick fix for that.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
