### PR TITLE
Add an option lock_wait to the apt module

### DIFF
--- a/packaging/os/apt.py
+++ b/packaging/os/apt.py
@@ -197,7 +197,7 @@ EXAMPLES = '''
 - name: Install a .deb package from the internet.
   apt:
     deb: https://example.com/python-ppq_0.1-1_all.deb
-    
+
 - Install nginx. If another process is using apt, wait a maximum of 60 seconds.
   apt: 
     name=nginx 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

apt
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

Add an option to the apt module to wait a certain amount of time for the dpkg lock.

Fixes  #4717 

<!--- Paste verbatim command output below, e.g. before and after your change -->

```

```
