### PR TITLE
Fixes #3270. Allows ec2_vol to create volumes of specific size from s…

### DIFF
--- a/cloud/amazon/ec2_vol.py
+++ b/cloud/amazon/ec2_vol.py
@@ -569,8 +569,8 @@ def main():
     if not volume_size and not (id or name or snapshot):
         module.fail_json(msg="You must specify volume_size or identify an existing volume by id, name, or snapshot")
 
-    if volume_size and (id or snapshot):
-        module.fail_json(msg="Cannot specify volume_size together with id or snapshot")
+    if volume_size and id:
+        module.fail_json(msg="Cannot specify volume_size together with id")
 
     if state == 'present':
         volume, changed = create_volume(module, ec2, zone)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

ec2_vol
##### ANSIBLE VERSION

```
ansible 2.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fixes #3270

See issue for the history of this issue, as well as https://github.com/ansible/ansible-modules-core/pull/1747 and https://github.com/ansible/ansible-modules-core/issues/139 for the cause of the regression.

This fix removes a module check that prevents you specifying a snapshot ID and a volume size as module parameters. This causes the AWS API to create a volume with the specified size from the specified snapshot, which is an supported and useful parameter combination.

Note that the other changes from #1747 as discussed in #139 are not reverted by this fix, just this one seemingly overzealous validation check.
