### PR TITLE
hostname: Support "Scientific Linux CERN"

### DIFF
--- a/system/hostname.py
+++ b/system/hostname.py
@@ -567,6 +567,11 @@ class ScientificLinuxHostname(Hostname):
     distribution = 'Scientific linux'
     strategy_class = RedHatStrategy
 
+class ScientificLinuxCERNHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Scientific linux cern slc'
+    strategy_class = RedHatStrategy
+
 class OracleLinuxHostname(Hostname):
     platform = 'Linux'
     distribution = 'Oracle linux server'


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

hostname
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

CERN maintains its own fork of "Scientific Linux",
which identifies as "Scientific Linux CERN SLC".
This commit lets Ansible know that this is again
another variant of RHEL.
