### PR TITLE
Add gather_network_interfaces parameter to setup

### DIFF
--- a/system/setup.py
+++ b/system/setup.py
@@ -118,6 +118,7 @@ def main():
         argument_spec = dict(
             gather_subset=dict(default=["all"], required=False, type='list'),
             gather_timeout=dict(default=10, required=False, type='int'),
+            gather_network_interfaces=dict(default=None, required=False, type='list'),
             filter=dict(default="*", required=False),
             fact_path=dict(default='/etc/ansible/facts.d', required=False),
         ),


### PR DESCRIPTION
This is part of a PR in https://github.com/ansible/ansible/pull/17586 to add the possibility of limiting the examined network interfaces.
