### PR TITLE
Document ability to disable external IP with 'none' setting.  Closes …

### DIFF
--- a/cloud/google/gce.py
+++ b/cloud/google/gce.py
@@ -142,7 +142,7 @@ options:
   external_ip:
     version_added: "1.9"
     description:
-      - type of external ip, ephemeral by default; alternatively, a list of fixed gce ips or ip names can be given (if there is not enough specified ip, 'ephemeral' will be used)
+      - type of external ip, ephemeral by default; alternatively, a list of fixed gce ips or ip names can be given (if there is not enough specified ip, 'ephemeral' will be used). Specify 'none' if no external ip is desired.
     required: false
     default: "ephemeral"
   disk_auto_delete:


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Docs Pull Request
##### COMPONENT NAME

GCE
##### ANSIBLE VERSION

ansible 2.2.0 (gce_docfix b93de25204) last updated 2016/09/15 20:47:51 (GMT +000)
  lib/ansible/modules/core: (gce-docfix 0ae42d6324) last updated 2016/09/15 21:03:19 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD aa45bd8a94) last updated 2016/09/15 17:27:45 (GMT +000)
  config file = /home/supertom/.ansible.cfg
  configured module search path = Default w/o overrides
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Disable External IP during instance creation by setting external_ip: none

Closes #2562 

/cc @ryansb 
