### PR TITLE
typo in stat.executable (was stat.excutable)

### DIFF
--- a/files/stat.py
+++ b/files/stat.py
@@ -369,7 +369,7 @@ def format_output(module, path, st, follow, get_md5, get_checksum,
         isgid=bool(mode & stat.S_ISGID),
         readable=os.access(path, os.R_OK),
         writeable=os.access(path, os.W_OK),
-        excutable=os.access(path, os.X_OK),
+        executable=os.access(path, os.X_OK),
     )
 
     if stat.S_ISLNK(mode):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

stat
##### ANSIBLE VERSION

```
ansible 2.0.0-0.5.beta3
```
##### SUMMARY

Fixes a small typo. The docs were correct, but the code misspelled 'executable' as 'excutable' (missing the second 'e').
Note: I did not test this because it seemed so simple.
