### PR TITLE
Update redhat_subscription.py

### DIFF
--- a/packaging/os/redhat_subscription.py
+++ b/packaging/os/redhat_subscription.py
@@ -275,6 +275,8 @@ class Rhsm(RegistrationBase):
         args = ['subscription-manager', 'register']
 
         # Generate command arguments
+        if force_register:
+            args.extend(['--force'])
         if activationkey:
             args.extend(['--activationkey', activationkey])
             if org_id:
@@ -292,8 +294,6 @@ class Rhsm(RegistrationBase):
                 args.extend(['--name', consumer_name])
             if consumer_id:
                 args.extend(['--consumerid', consumer_id])
-            if force_register:
-                args.extend(['--force'])
             if environment:
                 args.extend(['--environment', environment])
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

redhat_subscription
##### ANSIBLE VERSION

ansible 2.1.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
##### SUMMARY

Before change '--force' could not be used with '--activationkey'.
It is just as important to be able to use '--force' with and without '--activationkey'.  They are not mutually exclusive.  Assume this as a logic bug.

Fix '--force' so is available with '--activationkey' switch.
