### PR TITLE
Fix duplicate required key error

### DIFF
--- a/network/junos/junos_config.py
+++ b/network/junos/junos_config.py
@@ -112,7 +112,6 @@ options:
         the equivalent, set the I(update) argument to C(replace).  This argument
         will be removed in a future release.
     required: false
-    required: true
     choices: ['yes', 'no']
     default: false
   backup:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

junos_config
##### SUMMARY

ansible-doc -vvvv -l show this warning:

```
   [WARNING]: While constructing a mapping from /home/misc/checkout/git/ansible/lib/ansible/modules/core/network/junos/junos_config.py,
   line 88, column 5, found a duplicate dict key (required). Using last defined value only.
```
