### PR TITLE
Added libcloud guard for Managed Instance Groups.

### DIFF
--- a/cloud/google/gce_mig.py
+++ b/cloud/google/gce_mig.py
@@ -596,7 +596,6 @@ def get_mig(gce, name, zone):
 
 
 def main():
-
     module = AnsibleModule(argument_spec=dict(
         name=dict(required=True),
         template=dict(),
@@ -619,7 +618,13 @@ def main():
             msg="GCE module requires python's 'ast' module, python v2.6+")
     if not HAS_LIBCLOUD:
         module.fail_json(
-            msg='libcloud with GCE Managed Instance Group support (1.1+) required for this module.')
+            msg='libcloud with GCE Managed Instance Group support (1.2+) required for this module.')
+
+    gce = gce_connect(module)
+    if not hasattr(gce, 'ex_create_instancegroupmanager'):
+        module.fail_json(
+            msg='libcloud with GCE Managed Instance Group support (1.2+) required for this module.',
+            changed=False)
 
     params = {}
     params['state'] = module.params.get('state')
@@ -634,7 +639,6 @@ def main():
     if not valid_autoscaling:
         module.fail_json(msg=as_msg, changed=False)
 
-    gce = gce_connect(module)
     changed = False
     json_output = {'state': params['state'], 'zone': params['zone']}
     mig = get_mig(gce, params['name'], params['zone'])


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

gce_mig
##### ANSIBLE VERSION

```
ansible 2.2.0 (gce_mig_tests ba942bcc6d) last updated 2016/08/25 19:00:31 (GMT +000)
  lib/ansible/modules/core: (gce_mig_libcloud f380d0fd89) last updated 2016/09/19 17:08:56 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD 101f9f5f46) last updated 2016/08/15 21:29:47 (GMT +000)
  config file = /home/supertom/.ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

Added libcloud guard to ensure the Managed Instance Group functionality is present.

No functionality changes.

/cc @ryansb 
