### PR TITLE
Fix YAML syntax in NXOS documentation

### DIFF
--- a/network/nxos/nxos_aaa_server.py
+++ b/network/nxos/nxos_aaa_server.py
@@ -86,33 +86,33 @@ EXAMPLES = '''
 # Radius Server Basic settings
   - name: "Radius Server Basic settings"
     nxos_aaa_server:
-        server_type=radius
-        server_timeout=9
-        deadtime=20
-        directed_request=enabled
-        host={{ inventory_hostname }}
-        username={{ un }}
-        password={{ pwd }}
+        server_type: radius
+        server_timeout: 9
+        deadtime: 20
+        directed_request: enabled
+        host:  inventory_hostname }}
+        username:  un }}
+        password:  pwd }}
 
 # Tacacs Server Basic settings
   - name: "Tacacs Server Basic settings"
     nxos_aaa_server:
-        server_type=tacacs
-        server_timeout=8
-        deadtime=19
-        directed_request=disabled
-        host={{ inventory_hostname }}
-        username={{ un }}
-        password={{ pwd }}
+        server_type: tacacs
+        server_timeout: 8
+        deadtime: 19
+        directed_request: disabled
+        host:  inventory_hostname }}
+        username:  un }}
+        password:  pwd }}
 
 # Setting Global Key
   - name: "AAA Server Global Key"
     nxos_aaa_server:
-        server_type=radius
-        global_key=test_key
-        host={{ inventory_hostname }}
-        username={{ un }}
-        password={{ pwd }}
+        server_type: radius
+        global_key: test_key
+        host:  inventory_hostname }}
+        username:  un }}
+        password:  pwd }}
 '''
 
 RETURN = '''

--- a/network/nxos/nxos_aaa_server_host.py
+++ b/network/nxos/nxos_aaa_server_host.py
@@ -83,38 +83,38 @@ EXAMPLES = '''
 # Radius Server Host Basic settings
   - name: "Radius Server Host Basic settings"
     nxos_aaa_server_host:
-        state=present
-        server_type=radius
-        address=1.2.3.4
-        acct_port=2084
-        host_timeout=10
-        host={{ inventory_hostname }}
-        username={{ un }}
-        password={{ pwd }}
+        state: present
+        server_type: radius
+        address: 1.2.3.4
+        acct_port: 2084
+        host_timeout: 10
+        host: {{ inventory_hostname }}
+        username: {{ un }}
+        password: {{ pwd }}
 
 # Radius Server Host Key Configuration
   - name: "Radius Server Host Key Configuration"
     nxos_aaa_server_host:
-        state=present
-        server_type=radius
-        address=1.2.3.4
-        key=hello
-        encrypt_type=7
-        host={{ inventory_hostname }}
-        username={{ un }}
-        password={{ pwd }}
+        state: present
+        server_type: radius
+        address: 1.2.3.4
+        key: hello
+        encrypt_type: 7
+        host:  inventory_hostname }}
+        username: {{ un }}
+        password: {{ pwd }}
 
 # TACACS Server Host Configuration
   - name: "Tacacs Server Host Configuration"
     nxos_aaa_server_host:
-        state=present
-        server_type=tacacs 
-        tacacs_port=89
-        host_timeout=10
-        address=5.6.7.8
-        host={{ inventory_hostname }}
-        username={{ un }}
-        password={{ pwd }}
+        state: present
+        server_type: tacacs 
+        tacacs_port: 89
+        host_timeout: 10
+        address: 5.6.7.8
+        host:  inventory_hostname }}
+        username:  un }}
+        password:  pwd }}
 '''
 
 RETURN = '''

--- a/network/nxos/nxos_bgp.py
+++ b/network/nxos/nxos_bgp.py
@@ -288,10 +288,10 @@ options:
 EXAMPLES = '''
 # configure a simple asn
 - nxos_bgp:
-      asn=65535
-      vrf=test
-      router_id=1.1.1.1
-      state=present
+      asn: 65535
+      vrf: test
+      router_id: 1.1.1.1
+      state: present
       username: "{{ un }}"
       password: "{{ pwd }}"
       host: "{{ inventory_hostname }}"

--- a/network/nxos/nxos_bgp_af.py
+++ b/network/nxos/nxos_bgp_af.py
@@ -242,12 +242,12 @@ options:
 EXAMPLES = '''
 # configure a simple address-family
 - nxos_bgp_af:
-    asn=65535
-    vrf=TESTING
-    afi=ipv4
-    safi=unicast
-    advertise_l2vpn_evpn=true
-    state=present
+    asn: 65535
+    vrf: TESTING
+    afi: ipv4
+    safi: unicast
+    advertise_l2vpn_evpn: true
+    state: present
 '''
 
 RETURN = '''

--- a/network/nxos/nxos_evpn_global.py
+++ b/network/nxos/nxos_evpn_global.py
@@ -34,7 +34,7 @@ options:
 '''
 EXAMPLES = '''
 - nxos_evpn_global:
-    nv_overlay_evpn=true
+    nv_overlay_evpn: true
     username: "{{ un }}"
     password: "{{ pwd }}"
     host: "{{ inventory_hostname }}"

--- a/network/nxos/nxos_igmp_snooping.py
+++ b/network/nxos/nxos_igmp_snooping.py
@@ -72,10 +72,10 @@ options:
 EXAMPLES = '''
 # ensure igmp snooping params supported in this module are in there default state
 - nxos_igmp_snooping:
-    state=default
-    host={{ inventory_hostname }}
-    username={{ un }}
-    password={{ pwd }}
+    state: default
+    host:  inventory_hostname }}
+    username:  un }}
+    password:  pwd }}
 
 # ensure following igmp snooping params are in the desired state
 - nxos_igmp_snooping:
@@ -86,8 +86,8 @@ EXAMPLES = '''
    report_supp: true
    v3_report_supp: true
    host: "{{ inventory_hostname }}"
-   username={{ un }}
-   password={{ pwd }}
+   username: {{ un }}
+   password: {{ pwd }}
 '''
 
 RETURN = '''

--- a/network/nxos/nxos_interface_ospf.py
+++ b/network/nxos/nxos_interface_ospf.py
@@ -115,9 +115,9 @@ options:
 '''
 EXAMPLES = '''
 - nxos_interface_ospf:
-    interface=ethernet1/32
-    ospf=1
-    area=1
+    interface: ethernet1/32
+    ospf: 1
+    area: 1
     cost=default
     username: "{{ un }}"
     password: "{{ pwd }}"

--- a/network/nxos/nxos_mtu.py
+++ b/network/nxos/nxos_mtu.py
@@ -56,34 +56,35 @@ options:
 EXAMPLES = '''
 # Ensure system mtu is 9126
 - nxos_mtu:
-    sysmtu=9216
-    host={{ inventory_hostname }}
-    username={{ un }}
-    password={{ pwd }}
+    sysmtu: 9216
+    host: {{ inventory_hostname }}
+    username: {{ un }}
+    password: {{ pwd }}
 
 # Config mtu on Eth1/1 (routed interface)
 - nxos_mtu:
-    interface=Ethernet1/1
-    mtu=1600
-    host={{ inventory_hostname }}
-    username={{ un }}
-    password={{ pwd }}
+    interface: Ethernet1/1
+    mtu: 1600
+    host: {{ inventory_hostname }}
+    username: {{ un }}
+    password: {{ pwd }}
 
 # Config mtu on Eth1/3 (switched interface)
 - nxos_mtu:
-    interface=Ethernet1/3
-    mtu=9216
-    host={{ inventory_hostname }}
-    username={{ un }}
-    password={{ pwd }}
+    interface: Ethernet1/3
+    mtu: 9216
+    host: {{ inventory_hostname }}
+    username: {{ un }}
+    password: {{ pwd }}
 
 # Unconfigure mtu on a given interface
 - nxos_mtu:
-    interface=Ethernet1/3
-    mtu=9216 host={{ inventory_hostname }}
-    username={{ un }}
-    password={{ pwd }}
-    state=absent
+    interface: Ethernet1/3
+    mtu: 9216
+    host: {{ inventory_hostname }}
+    username: {{ un }}
+    password: {{ pwd }}
+    state: absent
 '''
 
 RETURN = '''

--- a/network/nxos/nxos_ntp.py
+++ b/network/nxos/nxos_ntp.py
@@ -78,12 +78,12 @@ options:
 EXAMPLES = '''
 # Set NTP Server with parameters
 - nxos_ntp:
-    server=1.2.3.4
-    key_id=32
-    prefer=enabled
-    host={{ inventory_hostname }}
-    username={{ un }}
-    password={{ pwd }}
+    server: 1.2.3.4
+    key_id: 32
+    prefer: enabled
+    host: {{ inventory_hostname }}
+    username: {{ un }}
+    password: {{ pwd }}
 '''
 
 RETURN = '''

--- a/network/nxos/nxos_ntp_auth.py
+++ b/network/nxos/nxos_ntp_auth.py
@@ -74,12 +74,12 @@ options:
 EXAMPLES = '''
 # Basic NTP authentication configuration
 - nxos_ntp_auth:
-    key_id=32
-    md5string=hello
-    auth_type=text
-    host={{ inventory_hostname }}
-    username={{ un }}
-    password={{ pwd }}
+    key_id: 32
+    md5string: hello
+    auth_type: text
+    host: {{ inventory_hostname }}
+    username: {{ un }}
+    password: {{ pwd }}
 '''
 
 RETURN = '''

--- a/network/nxos/nxos_ntp_options.py
+++ b/network/nxos/nxos_ntp_options.py
@@ -63,12 +63,12 @@ options:
 EXAMPLES = '''
 # Basic NTP options configuration
 - nxos_ntp_options:
-    master=true
-    stratum=12
-    logging=false
-    host={{ inventory_hostname }}
-    username={{ un }}
-    password={{ pwd }}
+    master: true
+    stratum: 12
+    logging: false
+    host: {{ inventory_hostname }}
+    username: {{ un }}
+    password: {{ pwd }}
 '''
 
 RETURN = '''

--- a/network/nxos/nxos_ospf.py
+++ b/network/nxos/nxos_ospf.py
@@ -41,7 +41,7 @@ options:
 
 EXAMPLES = '''
 - nxos_ospf:
-    ospf=1
+    ospf: 1
     state: present
     username: "{{ un }}"
     password: "{{ pwd }}"

--- a/network/nxos/nxos_overlay_global.py
+++ b/network/nxos/nxos_overlay_global.py
@@ -39,7 +39,7 @@ options:
 
 EXAMPLES = '''
 - nxos_overlay_global:
-    anycast_gateway_mac="b.b.b"
+    anycast_gateway_mac: "b.b.b"
     username: "{{ un }}"
     password: "{{ pwd }}"
     host: "{{ inventory_hostname }}"

--- a/network/nxos/nxos_pim.py
+++ b/network/nxos/nxos_pim.py
@@ -34,7 +34,7 @@ options:
 '''
 EXAMPLES = '''
 - nxos_pim:
-    ssm_range="232.0.0.0/8"
+    ssm_range: "232.0.0.0/8"
     username: "{{ un }}"
     password: "{{ pwd }}"
     host: "{{ inventory_hostname }}"

--- a/network/nxos/nxos_pim_interface.py
+++ b/network/nxos/nxos_pim_interface.py
@@ -108,40 +108,40 @@ options:
 EXAMPLES = '''
 # ensure PIM is not running on the interface
 - nxos_pim_interface:
-    interface=eth1/33
-    state=absent
-    host={{ inventory_hostname }}
-    username={{ un }}
-    password={{ pwd }}
+    interface: eth1/33
+    state: absent
+    host: {{ inventory_hostname }}
+    username: {{ un }}
+    password: {{ pwd }}
 
 # ensure the interface has pim-sm enabled with the appropriate priority and hello interval
 - nxos_pim_interface:
-    interface=eth1/33
-    dr_prio=10
-    hello_interval=40
-    state=present
-    host={{ inventory_hostname }}
-    username={{ un }}
-    password={{ pwd }}
+    interface: eth1/33
+    dr_prio: 10
+    hello_interval: 40
+    state: present
+    host: {{ inventory_hostname }}
+    username: {{ un }}
+    password: {{ pwd }}
 
 # ensure join-prune policies exist
 - nxos_pim_interface:
-    interface=eth1/33
-    jp_policy_in=JPIN
-    jp_policy_out=JPOUT
-    jp_type_in=routemap
-    jp_type_out=routemap
-    host={{ inventory_hostname }}
-    username={{ un }}
-    password={{ pwd }}
+    interface: eth1/33
+    jp_policy_in: JPIN
+    jp_policy_out: JPOUT
+    jp_type_in: routemap
+    jp_type_out: routemap
+    host: {{ inventory_hostname }}
+    username: {{ un }}
+    password: {{ pwd }}
 
 # ensure defaults are in place
 - nxos_pim_interface:
-    interface=eth1/33
-    state=default
-    host={{ inventory_hostname }}
-    username={{ un }}
-    password={{ pwd }}
+    interface: eth1/33
+    state: default
+    host: {{ inventory_hostname }}
+    username: {{ un }}
+    password: {{ pwd }}
 '''
 
 RETURN = '''

--- a/network/nxos/nxos_snmp_community.py
+++ b/network/nxos/nxos_snmp_community.py
@@ -59,12 +59,12 @@ options:
 EXAMPLES = '''
 # ensure snmp community is configured
 - nxos_snmp_community:
-    community=TESTING7
-    group=network-operator
-    state=present
-    host={{ inventory_hostname }}
-    username={{ un }}
-    password={{ pwd }}
+    community: TESTING7
+    group: network-operator
+    state: present
+    host: {{ inventory_hostname }}
+    username: {{ un }}
+    password: {{ pwd }}
 '''
 
 RETURN = '''

--- a/network/nxos/nxos_snmp_contact.py
+++ b/network/nxos/nxos_snmp_contact.py
@@ -45,11 +45,11 @@ options:
 EXAMPLES = '''
 # ensure snmp contact is configured
 - nxos_snmp_contact:
-    contact=Test
-    state=present
-    host={{ inventory_hostname }}
-    username={{ un }}
-    password={{ pwd }}
+    contact: Test
+    state: present
+    host: {{ inventory_hostname }}
+    username: {{ un }}
+    password: {{ pwd }}
 '''
 
 RETURN = '''

--- a/network/nxos/nxos_snmp_host.py
+++ b/network/nxos/nxos_snmp_host.py
@@ -84,12 +84,12 @@ options:
 EXAMPLES = '''
 # ensure snmp host is configured
 - nxos_snmp_host:
-    snmp_host=3.3.3.3
-    community=TESTING
-    state=present
-    host={{ inventory_hostname }}
-    username={{ un }}
-    password={{ pwd }}
+    snmp_host: 3.3.3.3
+    community: TESTING
+    state: present
+    host: {{ inventory_hostname }}
+    username: {{ un }}
+    password: {{ pwd }}
 '''
 
 RETURN = '''

--- a/network/nxos/nxos_snmp_location.py
+++ b/network/nxos/nxos_snmp_location.py
@@ -44,19 +44,19 @@ options:
 EXAMPLES = '''
 # ensure snmp location is configured
 - nxos_snmp_location:
-    location=Test
-    state=present
-    host={{ inventory_hostname }}
-    username={{ un }}
-    password={{ pwd }}
+    location: Test
+    state: present
+    host: {{ inventory_hostname }}
+    username: {{ un }}
+    password: {{ pwd }}
 
 # ensure snmp location is not configured
 - nxos_snmp_location:
-    location=Test
-    state=absent
-    host={{ inventory_hostname }}
-    username={{ un }}
-    password={{ pwd }}
+    location: Test
+    state: absent
+    host: {{ inventory_hostname }}
+    username: {{ un }}
+    password: {{ pwd }}
 '''
 
 RETURN = '''

--- a/network/nxos/nxos_snmp_traps.py
+++ b/network/nxos/nxos_snmp_traps.py
@@ -49,7 +49,7 @@ options:
         choices: ['enabled','disabled']
 '''
 
-EXAMPLES :  '''
+EXAMPLES =  '''
 # ensure lldp trap configured
 - nxos_snmp_traps:
     group: lldp

--- a/network/nxos/nxos_snmp_traps.py
+++ b/network/nxos/nxos_snmp_traps.py
@@ -49,22 +49,22 @@ options:
         choices: ['enabled','disabled']
 '''
 
-EXAMPLES = '''
+EXAMPLES :  '''
 # ensure lldp trap configured
 - nxos_snmp_traps:
-    group=lldp
-    state=enabled
-    host={{ inventory_hostname }}
-    username={{ un }}
-    password={{ pwd }}
+    group: lldp
+    state: enabled
+    host: {{ inventory_hostname }}
+    username: {{ un }}
+    password: {{ pwd }}
 
 # ensure lldp trap is not configured
 - nxos_snmp_traps:
-    group=lldp
-    state=disabled
-    host={{ inventory_hostname }}
-    username={{ un }}
-    password={{ pwd }}
+    group: lldp
+    state: disabled
+    host: {{ inventory_hostname }}
+    username: {{ un }}
+    password: {{ pwd }}
 '''
 
 RETURN = '''

--- a/network/nxos/nxos_snmp_user.py
+++ b/network/nxos/nxos_snmp_user.py
@@ -69,13 +69,13 @@ options:
 
 EXAMPLES = '''
 - nxos_snmp_user:
-    user=ntc
-    group=network-operator
-    auth=md5
-    pwd=test_password
-    host={{ inventory_hostname }}
-    username={{ un }}
-    password={{ pwd }}
+    user: ntc
+    group: network-operator
+    auth: md5
+    pwd: test_password
+    host: {{ inventory_hostname }}
+    username: {{ un }}
+    password: {{ pwd }}
 '''
 
 RETURN = '''

--- a/network/nxos/nxos_static_route.py
+++ b/network/nxos/nxos_static_route.py
@@ -67,10 +67,10 @@ options:
 
 EXAMPLES = '''
 - nxos_static_route:
-    prefix="192.168.20.64/24"
-    next_hop="3.3.3.3"
-    route_name=testing
-    pref=100
+    prefix: "192.168.20.64/24"
+    next_hop: "3.3.3.3"
+    route_name: testing
+    pref: 100
     username: "{{ un }}"
     password: "{{ pwd }}"
     host: "{{ inventory_hostname }}"

--- a/network/nxos/nxos_udld.py
+++ b/network/nxos/nxos_udld.py
@@ -60,19 +60,19 @@ options:
 EXAMPLES = '''
 # ensure udld aggressive mode is globally disabled and se global message interval is 20
 - nxos_udld:
-    aggressive=disabled
-    msg_time=20
-    host={{ inventory_hostname }}
-    username={{ un }}
-    password={{ pwd }}
+    aggressive: disabled
+    msg_time: 20
+    host: {{ inventory_hostname }}
+    username: {{ un }}
+    password: {{ pwd }}
 
 # Ensure agg mode is globally enabled and msg time is 15
 - nxos_udld:
-    aggressive=enabled
-    msg_time=15
-    host={{ inventory_hostname }}
-    username={{ un }}
-    password={{ pwd }}
+    aggressive: enabled
+    msg_time: 15
+    host: {{ inventory_hostname }}
+    username: {{ un }}
+    password: {{ pwd }}
 '''
 
 RETURN = '''

--- a/network/nxos/nxos_udld_interface.py
+++ b/network/nxos/nxos_udld_interface.py
@@ -48,29 +48,29 @@ options:
 EXAMPLES = '''
 # ensure Ethernet1/1 is configured to be in aggressive mode
 - nxos_udld_interface:
-    interface=Ethernet1/1
-    mode=aggressive
-    state=present
-    host={{ inventory_hostname }}
-    username={{ un }}
-    password={{ pwd }}
+    interface: Ethernet1/1
+    mode: aggressive
+    state: present
+    host: {{ inventory_hostname }}
+    username: {{ un }}
+    password: {{ pwd }}
 
 # Remove the aggressive config only if it's currently in aggressive mode and then disable udld (switch default)
 - nxos_udld_interface:
-    interface=Ethernet1/1
-    mode=aggressive
-    state=absent
-    host={{ inventory_hostname }}
-    username={{ un }}
-    password={{ pwd }}
+    interface: Ethernet1/1
+    mode: aggressive
+    state: absent
+    host: {{ inventory_hostname }}
+    username: {{ un }}
+    password: {{ pwd }}
 
 # ensure Ethernet1/1 has aggressive mode enabled
 - nxos_udld_interface:
-    interface=Ethernet1/1
-    mode=enabled
-    host={{ inventory_hostname }}
-    username={{ un }}
-    password={{ pwd }}
+    interface: Ethernet1/1
+    mode: enabled
+    host: {{ inventory_hostname }}
+    username: {{ un }}
+    password: {{ pwd }}
 '''
 
 RETURN = '''

--- a/network/nxos/nxos_vpc.py
+++ b/network/nxos/nxos_vpc.py
@@ -90,13 +90,13 @@ options:
 EXAMPLES = '''
 # configure a simple asn
 - nxos_vpc:
-    domain=100
-    role_priority=1000
-    system_priority=2000
-    pkl_dest=192.168.100.4
-    pkl_src=10.1.100.20
-    peer_gw=true
-    auto_recovery=true
+    domain: 100
+    role_priority: 1000
+    system_priority: 2000
+    pkl_dest: 192.168.100.4
+    pkl_src: 10.1.100.20
+    peer_gw: true
+    auto_recovery: true
     username: "{{ un }}"
     password: "{{ pwd }}"
     host: "{{ inventory_hostname }}"

--- a/network/nxos/nxos_vpc_interface.py
+++ b/network/nxos/nxos_vpc_interface.py
@@ -58,8 +58,8 @@ options:
 
 EXAMPLES = '''
 - nxos_vpc_portchannel:
-    portchannel=10
-    vpc=100
+    portchannel: 10
+    vpc: 100
     username: "{{ un }}"
     password: "{{ pwd }}"
     host: "{{ inventory_hostname }}"

--- a/network/nxos/nxos_vrf_af.py
+++ b/network/nxos/nxos_vrf_af.py
@@ -61,9 +61,9 @@ options:
 '''
 EXAMPLES = '''
 - nxos_vrf_af:
-    interface=nve1
-    vni=6000
-    ingress_replication=true
+    interface: nve1
+    vni: 6000
+    ingress_replication: true
     username: "{{ un }}"
     password: "{{ pwd }}"
     host: "{{ inventory_hostname }}"

--- a/network/nxos/nxos_vtp_domain.py
+++ b/network/nxos/nxos_vtp_domain.py
@@ -44,10 +44,10 @@ options:
 EXAMPLES = '''
 # ENSURE VTP DOMAIN IS CONFIGURED
 - nxos_vtp_domain:
-    domain=ntc
-    host={{ inventory_hostname }}
-    username={{ un }}
-    password={{ pwd }}
+    domain: ntc
+    host: {{ inventory_hostname }}
+    username: {{ un }}
+    password: {{ pwd }}
 '''
 
 

--- a/network/nxos/nxos_vtp_password.py
+++ b/network/nxos/nxos_vtp_password.py
@@ -54,19 +54,19 @@ options:
 EXAMPLES = '''
 # ENSURE VTP PASSWORD IS SET
 - nxos_vtp_password:
-    password=ntc
-    state=present
-    host={{ inventory_hostname }}
-    username={{ un }}
-    password={{ pwd }}
+    password: ntc
+    state: present
+    host: {{ inventory_hostname }}
+    username: {{ un }}
+    password: {{ pwd }}
 
 # ENSURE VTP PASSWORD IS REMOVED
 - nxos_vtp_password:
-    password=ntc
-    state=absent
-    host={{ inventory_hostname }}
-    username={{ un }}
-    password={{ pwd }}
+    password: ntc
+    state: absent
+    host: {{ inventory_hostname }}
+    username: {{ un }}
+    password: {{ pwd }}
 '''
 
 RETURN = '''

--- a/network/nxos/nxos_vtp_version.py
+++ b/network/nxos/nxos_vtp_version.py
@@ -42,10 +42,10 @@ options:
 EXAMPLES = '''
 # ENSURE VTP VERSION IS 2
 - nxos_vtp_version:
-    version=2
-    host={{ inventory_hostname }}
-    username={{ un }}
-    password={{ pwd }}
+    version: 2
+    host: {{ inventory_hostname }}
+    username: {{ un }}
+    password: {{ pwd }}
 '''
 
 RETURN = '''

--- a/network/nxos/nxos_vxlan_vtep.py
+++ b/network/nxos/nxos_vxlan_vtep.py
@@ -75,12 +75,12 @@ options:
 '''
 EXAMPLES = '''
 - nxos_vxlan_vtep:
-    interface=nve1
-    description=default
-    host_reachability=default
-    source_interface=Loopback0
-    source_interface_hold_down_time=30
-    shutdown=default
+    interface: nve1
+    description: default
+    host_reachability: default
+    source_interface: Loopback0
+    source_interface_hold_down_time: 30
+    shutdown: default
     username: "{{ un }}"
     password: "{{ pwd }}"
     host: "{{ inventory_hostname }}"

--- a/network/nxos/nxos_vxlan_vtep_vni.py
+++ b/network/nxos/nxos_vxlan_vtep_vni.py
@@ -101,9 +101,9 @@ options:
 '''
 EXAMPLES = '''
 - nxos_vxlan_vtep_vni:
-    interface=nve1
-    vni=6000
-    ingress_replication=default
+    interface: nve1
+    vni: 6000
+    ingress_replication: default
     username: "{{ un }}"
     password: "{{ pwd }}"
     host: "{{ inventory_hostname }}"


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

network/nxos
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel ded45fb535) last updated 2016/09/19 18:39:30 (GMT -500)
  lib/ansible/modules/core: (devel f2c2dddc01) last updated 2016/09/19 18:42:14 (GMT -500)
  lib/ansible/modules/extras: (detached HEAD 99c44d9640) last updated 2016/09/19 18:40:42 (GMT -500)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Updated the nxos module docs to use valid YAML syntax for multiple commands

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```

```

Use ':' and not '=' to ensure valid YAML
in the EXAMPLES
