### PR TITLE
Found a small bug related to excluding files

### DIFF
--- a/files/unarchive.py
+++ b/files/unarchive.py
@@ -439,6 +439,7 @@ class ZipArchive(object):
                         itemized[4] = 't'
                     elif stat.S_ISREG(st.st_mode) and timestamp < st.st_mtime:
                         # Add to excluded files, ignore other changes
+                        self.excludes.append(path)
                         out += 'File %s is newer, excluding file\n' % path
                         self.excludes.append(path)
                         continue


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

unarchive
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

Due to the change (includes list to excludes list) one specific case was
missing from the exclude list.

This is a must-have fix for devel and stable-2.1.
