### PR TITLE
Improve error handling in docker_service module

### DIFF
--- a/cloud/docker/docker_service.py
+++ b/cloud/docker/docker_service.py
@@ -655,7 +655,7 @@ class ContainerManager(DockerBaseClass):
                     detached=detached,
                     remove_orphans=self.remove_orphans)
             except Exception as exc:
-                self.client.fail("Error bring %s up - %s" % (self.project.name, str(exc)))
+                self.client.fail("Error starting project - %s" % str(exc))
 
         if self.stopped:
             result.update(self.cmd_stop(service_names))
@@ -804,7 +804,7 @@ class ContainerManager(DockerBaseClass):
             try:
                 self.project.down(image_type, self.remove_volumes, self.remove_orphans)
             except Exception as exc:
-                self.client.fail("Error bringing %s down - %s" % (self.project.name, str(exc)))
+                self.client.fail("Error stopping project - %s" % str(exc))
 
         return result
 

--- a/cloud/docker/docker_service.py
+++ b/cloud/docker/docker_service.py
@@ -877,7 +877,7 @@ class ContainerManager(DockerBaseClass):
                         result['actions'][service.name]['scale'] = self.scale[service.name] - len(containers)
                     if not self.check_mode:
                         try:
-                            service.scale(self.scale[service.name])
+                            service.scale(int(self.scale[service.name]))
                         except Exception as exc:
                             self.client.fail("Error scaling %s - %s" % (service.name, str(exc)))
         return result


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### COMPONENT NAME

docker_service.py 
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 547cea556f) last updated 2016/09/20 09:43:36 (GMT -400)
  lib/ansible/modules/core: (devel 5ab1a6f88d) last updated 2016/09/20 09:47:08 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD f83aa9fff3) last updated 2016/09/09 21:43:17 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY
- Small improvement to error handling when call to compose up() or down() methods fails. 
- Fixes #4592 by casting scale value to int.
