### PR TITLE
fix ansible-modules-core issue #4958

### DIFF
--- a/cloud/amazon/ec2_ami_find.py
+++ b/cloud/amazon/ec2_ami_find.py
@@ -374,7 +374,7 @@ def main():
             'ami_id': image.id,
             'architecture': image.architecture,
             'block_device_mapping': get_block_device_mapping(image),
-            'creationDate': image.creationDate,
+            'creationDate': getattr(image, 'creationDate', None),
             'description': image.description,
             'hypervisor': image.hypervisor,
             'is_public': image.is_public,


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

ec2_aim_find
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Helion Eucalyptus EC2 would not have a creationDate in the list of Image attributes, as discussed in issue #4958, leading to a failure when trying to access that attribute.
Wrapping with `getattr` to set a default value of `None` fixed this.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

before: failure and stacktrace

```
Traceback (most recent call last):
  File "/tmp/ansible_2KmiX9/ansible_module_ec2_ami_find.py", line 423, in <module>
    main()
  File "/tmp/ansible_2KmiX9/ansible_module_ec2_ami_find.py", line 377, in main
    'creationDate': image.creationDate,
AttributeError: 'Image' object has no attribute 'creationDate'
```

now: success

```
ok: [localhost] => {
    "msg": {
        "changed": false,
        "results": [
            {
                "ami_id": "emi-c684b521",
                "creationDate": null,
...
          },
...    
```
