### PR TITLE
Fixes #79. Add a non_unique option to the group module.

### DIFF
--- a/system/group.py
+++ b/system/group.py
@@ -292,6 +292,7 @@ class DarwinGroup(Group):
             cmd += [ '-i', self.gid ]
         cmd += [ '-L', self.name ]
         (rc, out, err) = self.execute_command(cmd)
+        #FIXME : Add a support of non_unique with dseditgroup ?
         return (rc, out, err)
 
     def group_del(self):
@@ -310,6 +311,7 @@ class DarwinGroup(Group):
                 cmd += [ '-i', gid ]
             cmd += [ '-L', self.name ]
             (rc, out, err) = self.execute_command(cmd)
+            #FIXME : Add a support of non_unique with dseditgroup ?
             return (rc, out, err)
         return (None, '', '')
 

--- a/system/group.py
+++ b/system/group.py
@@ -372,6 +372,8 @@ class NetBsdGroup(Group):
         if self.gid is not None:
             cmd.append('-g')
             cmd.append('%d' % int(self.gid))
+            if self.non_unique:
+                cmd.append('-o')
         cmd.append(self.name)
         return self.execute_command(cmd)
 
@@ -382,6 +384,8 @@ class NetBsdGroup(Group):
         if self.gid is not None and int(self.gid) != info[2]:
             cmd.append('-g')
             cmd.append('%d' % int(self.gid))
+            if self.non_unique:
+                cmd.append('-o')
         if len(cmd) == 1:
             return (None, '', '')
         if self.module.check_mode:

--- a/system/group.py
+++ b/system/group.py
@@ -202,6 +202,7 @@ class AIX(Group):
                 cmd.append('id='+kwargs[key])
             elif key == 'system' and kwargs[key] == True:
                 cmd.append('-a')
+            #FIXME : Add a support of non_unique with mkgroup ?
         cmd.append(self.name)
         return self.execute_command(cmd)
 
@@ -212,6 +213,7 @@ class AIX(Group):
             if key == 'gid':
                 if kwargs[key] is not None and info[2] != int(kwargs[key]):
                     cmd.append('id='+kwargs[key])
+            #FIXME : Add a support of non_unique with chgroup ?
         if len(cmd) == 1:
             return (None, '', '')
         if self.module.check_mode:

--- a/system/group.py
+++ b/system/group.py
@@ -105,7 +105,6 @@ class Group(object):
             elif key == 'system' and kwargs[key] == True:
                 cmd.append('-r')
         cmd.append(self.name)
-        self.module.debug(msg=str(cmd))
         return self.execute_command(cmd)
 
     def group_mod(self, **kwargs):

--- a/system/group.py
+++ b/system/group.py
@@ -48,6 +48,14 @@ options:
         choices: [ "yes", "no" ]
         description:
             - If I(yes), indicates that the group created is a system group.
+    non_unique:
+        required: false
+        default: "no"
+        choices: [ "yes", "no" ]
+        description:
+            - Optionally when used with the -g option, this option allows to
+              create groups with a non unique gid.
+        version_added: "2.2"
 
 '''
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

group
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel 04165fb6c0) last updated 2016/09/21 18:54:42 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 3486395970) last updated 2016/09/21 18:55:09 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 1f2319c3f3) last updated 2016/09/21 18:55:09 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Fixes #79 .
Tested on CentOS 7 with the following playbook : 

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
- hosts: host

  tasks:

      - group:
            name="group1"
            state=absent

      - group:
            name="group2"
            state=absent

      - group:
            name="group1"
            gid=2000
            non_unique=yes
            state=present

      - group:
            name="group2"
            gid=2000
            non_unique=yes
            state=present
```
