### PR TITLE
Removed leading and trailing whitespace chars from stdout and stderr

### DIFF
--- a/windows/win_shell.ps1
+++ b/windows/win_shell.ps1
@@ -83,8 +83,8 @@ Catch [System.ComponentModel.Win32Exception] {
 # TODO: resolve potential deadlock here if stderr fills buffer (~4k) before stdout is closed,
 # perhaps some async stream pumping with Process Output/ErrorDataReceived events...
 
-$result.stdout = $proc.StandardOutput.ReadToEnd()
-$result.stderr = $proc.StandardError.ReadToEnd()
+$result.stdout = $proc.StandardOutput.ReadToEnd().Trim()
+$result.stderr = $proc.StandardError.ReadToEnd().Trim()
 
 # TODO: decode CLIXML stderr output (and other streams?)
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

win_shell
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel 23651b657e) last updated 2016/09/21 13:45:09 (GMT -500)
  lib/ansible/modules/core: (detached HEAD 3486395970) last updated 2016/09/21 13:53:27 (GMT -500)
  lib/ansible/modules/extras: (detached HEAD 1f2319c3f3) last updated 2016/09/21 13:53:35 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/vagrant/ansibleinventory/library']

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

this small change removes whitespace characters from the stdout and stderr streams. This prevents unexpected problems when assigning variables via register: and passing these variables to other commands inside of the playbook.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```

```
