### PR TITLE
Fix #3153 again

### DIFF
--- a/system/mount.py
+++ b/system/mount.py
@@ -375,7 +375,7 @@ def mount(module, **kwargs):
 
     if get_platform().lower() == 'freebsd':
         cmd += ['-F', args['fstab']]
-    elif get_platform().lower() == 'linux':
+    elif get_platform().lower() == 'linux' and args['fstab'] != '/etc/fstab':
         cmd += ['-T', args['fstab']]
 
     cmd += [name]


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

mount.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
devel, stable-2.1
```
##### SUMMARY

-T was not a valid option to the mount command at one time.
