### PR TITLE
Adding Windows shortcut support to `win_file`

### DIFF
--- a/windows/win_file.ps1
+++ b/windows/win_file.ps1
@@ -88,12 +88,14 @@ If (Test-Path $path)
             Fail-Json (New-Object psobject) "path is not a file"
         }
 
-        If ( $state -eq "shortcut" ) {
-            If ( $fileinfo.PsIsContainer -or (-not ( $path -like "*.lnk" ) ) ) )
+        If ( $state -eq "shortcut" ) 
+        {
+            If ( $fileinfo.PsIsContainer -or (-not ( $path -like "*.lnk" ) ) )
             {
                 Fail-Json (New-Object psobject) "path is not a shortcut"
             }
-            Else {
+            Else 
+            {
                 $sh = New-Object -COM WScript.Shell
                 $Shortcut = $sh.CreateShortcut($path)
                 If ( $target -ne $null -and $Shortcut.TargetPath -ne $target )

--- a/windows/win_file.ps1
+++ b/windows/win_file.ps1
@@ -88,36 +88,38 @@ If (Test-Path $path)
             Fail-Json (New-Object psobject) "path is not a file"
         }
 
-        If ( $state -eq "shortcut" -and ( $fileinfo.PsIsContainer -or (-not ( $path -like "*.lnk" ) ) ) )
-        {
-            Fail-Json (New-Object psobject) "path is not a shortcut"
-        }
-        Else {
-            $sh = New-Object -COM WScript.Shell
-            $Shortcut = $sh.CreateShortcut($path)
-            If ( $target -ne $null -and $Shortcut.TargetPath -ne $target )
+        If ( $state -eq "shortcut" ) {
+            If ( $fileinfo.PsIsContainer -or (-not ( $path -like "*.lnk" ) ) ) )
             {
-               $oldTarget = $Shortcut.TargetPath
-               $Shortcut.TargetPath = $target
-               $Shortcut.Save()
-               $result.changed = $TRUE
-               $result.msg = "Changed target to $target from $oldTarget."
+                Fail-Json (New-Object psobject) "path is not a shortcut"
             }
-
-            If ( $argumentsList -ne $null -and $Shortcut.Arguments -ne $argumentsList )
-            {
-               $Shortcut.Arguments  = $argumentsList
-               $Shortcut.Save()
-               $result.changed = $TRUE
-               $result.msg = "Changed arguments."
-            }
-
-            If ( $workDir -ne $null -and $Shortcut.WorkingDirectory -ne $workDir )
-            {
-               $Shortcut.WorkingDirectory = $workDir
-               $Shortcut.Save()
-               $result.changed = $TRUE
-               $result.msg = "Changed working directory."
+            Else {
+                $sh = New-Object -COM WScript.Shell
+                $Shortcut = $sh.CreateShortcut($path)
+                If ( $target -ne $null -and $Shortcut.TargetPath -ne $target )
+                {
+                   $oldTarget = $Shortcut.TargetPath
+                   $Shortcut.TargetPath = $target
+                   $Shortcut.Save()
+                   $result.changed = $TRUE
+                   $result.msg = "Changed target to $target from $oldTarget."
+                }
+    
+                If ( $argumentsList -ne $null -and $Shortcut.Arguments -ne $argumentsList )
+                {
+                   $Shortcut.Arguments  = $argumentsList
+                   $Shortcut.Save()
+                   $result.changed = $TRUE
+                   $result.msg = "Changed arguments."
+                }
+    
+                If ( $workDir -ne $null -and $Shortcut.WorkingDirectory -ne $workDir )
+                {
+                   $Shortcut.WorkingDirectory = $workDir
+                   $Shortcut.Save()
+                   $result.changed = $TRUE
+                   $result.msg = "Changed working directory."
+                }
             }
         }
     }

--- a/windows/win_file.py
+++ b/windows/win_file.py
@@ -39,27 +39,43 @@ options:
     required: true
     default: []
     aliases: ['dest', 'name']
+  target:
+    description:
+      - 'path for a Windows shortcut (only applies to c(state=shortcut))'
+    required: false
+    default: []
+  arguments:
+    description:
+      - 'arguments for a Windows shortcut (only applies to c(state=shortcut))'
+    required: false
+    default: []
+  working_directory:
+    description:
+      - 'working directory for a Windows shortcut (only applies to c(state=shortcut))'
+    required: false
+    default: []
   state:
     description:
       - If C(directory), all immediate subdirectories will be created if they
         do not exist.
         If C(file), the file will NOT be created if it does not exist, see the M(copy)
-        or M(template) module if you want that behavior.  If C(absent),
+        or M(template) module if you want that behavior.  If C(shortcut), a Windows
+        shortcut will be created or changed, pointing to c(target).  If C(absent),
         directories will be recursively deleted, and files will be removed.
         If C(touch), an empty file will be created if the c(path) does not
         exist, while an existing file or directory will receive updated file access and
         modification times (similar to the way `touch` works from the command line).
     required: false
     default: file
-    choices: [ file, directory, touch, absent ]
+    choices: [ file, directory, shortcut, touch, absent ]
 '''
 
 EXAMPLES = '''
 # create a file
-- win_file: path=C:\\temp\\foo.conf 
+- win_file: path=C:\\temp\\foo.conf
 
 # touch a file (creates if not present, updates modification time if present)
-- win_file: path=C:\\temp\\foo.conf state=touch 
+- win_file: path=C:\\temp\\foo.conf state=touch
 
 # remove a file, if present
 - win_file: path=C:\\temp\\foo.conf state=absent
@@ -69,4 +85,7 @@ EXAMPLES = '''
 
 # remove directory structure
 - win_file: path=C:\\temp state=absent
+
+# chreate a shortcut
+- win_file: path=C:\\temp\\foo.lnk target='bar.exe' arguments='1 2 3' state=shortcut
 '''

--- a/windows/win_file.py
+++ b/windows/win_file.py
@@ -44,16 +44,19 @@ options:
       - 'path for a Windows shortcut (only applies to c(state=shortcut))'
     required: false
     default: []
+    version_added: 2.2
   arguments:
     description:
       - 'arguments for a Windows shortcut (only applies to c(state=shortcut))'
     required: false
     default: []
+    version_added: 2.2
   working_directory:
     description:
       - 'working directory for a Windows shortcut (only applies to c(state=shortcut))'
     required: false
     default: []
+    version_added: 2.2
   state:
     description:
       - If C(directory), all immediate subdirectories will be created if they


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

win_file
##### ANSIBLE VERSION

```
ansible 2.1.1.0
  config file = /home/bjackson/git/adg-server-config/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

This adds Windows shortcut support to `win_file`. It is modeled after the `state=link` support
in `file`.  It adds several new parameters to `win_file` that are exclusively used when `state=shortcut`
- target
- arguments
- working_directory
