### PR TITLE
Check whether yum file or URL install is an upgrade

### DIFF
--- a/packaging/os/yum.py
+++ b/packaging/os/yum.py
@@ -477,24 +477,11 @@ def local_nvra(module, path):
     finally:
         os.close(fd)
 
-    return '%s-%s-%s.%s' % (header[rpm.RPMTAG_NAME], 
+    return '%s-%s-%s.%s' % (header[rpm.RPMTAG_NAME],
                             header[rpm.RPMTAG_VERSION],
                             header[rpm.RPMTAG_RELEASE],
                             header[rpm.RPMTAG_ARCH])
-    
-def local_name(module, path):
-    """return package name of a local rpm passed in"""
 
-    ts = rpm.TransactionSet()
-    ts.setVSFlags(rpm._RPMVSF_NOSIGNATURES)
-    fd = os.open(path, os.O_RDONLY)
-    try:
-        header = ts.hdrFromFdno(fd)
-    finally:
-        os.close(fd)
-
-    return header[rpm.RPMTAG_NAME]
-    
 def pkg_to_dict(pkgstr):
 
     if pkgstr.strip():
@@ -569,9 +556,10 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
                 res['msg'] += "No Package file matching '%s' found on system" % spec
                 module.fail_json(**res)
 
-            pkg_name = local_name(module, spec)
+            nvra = local_nvra(module, spec)
+
             # look for them in the rpmdb
-            if is_installed(module, repoq, pkg_name, conf_file, en_repos=en_repos, dis_repos=dis_repos):
+            if is_installed(module, repoq, nvra, conf_file, en_repos=en_repos, dis_repos=dis_repos):
                 # if they are there, skip it
                 continue
             pkg = spec
@@ -592,8 +580,8 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
                 shutil.rmtree(tempdir)
                 module.fail_json(msg="Failure downloading %s, %s" % (spec, e))
 
-            pkg_name = local_name(module, package)
-            if is_installed(module, repoq, pkg_name, conf_file, en_repos=en_repos, dis_repos=dis_repos):
+            nvra = local_nvra(module, package)
+            if is_installed(module, repoq, nvra, conf_file, en_repos=en_repos, dis_repos=dis_repos):
                 # if it's there, skip it
                 continue
             pkg = package


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

yum
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel e375bfd6a5) last updated 2016/08/26 09:55:20 (GMT +1000)
  lib/ansible/modules/core: (detached HEAD ef84dbbddd) last updated 2016/08/26 11:07:18 (GMT +1000)
  lib/ansible/modules/extras: (detached HEAD f29efb5626) last updated 2016/08/26 09:55:24 (GMT +1000)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Yum was not upgrading new packages that were specified as local files or RPMs, as it was checking
whether the package existed, not whether the specified package was newer

Rather than just checking whether a package with the right
name is installed, use `local_nvra` to check whether the
version/release/arch differs too.

Remove `local_name` as it is a shortcut too far.

Fixes #3807
Fixes #4529
