### PR TITLE
Fix docker image always changed even if image has not been updated.

### DIFF
--- a/cloud/docker/docker_image.py
+++ b/cloud/docker/docker_image.py
@@ -335,6 +335,8 @@ class ImageManager(DockerBaseClass):
                 self.results['changed'] = True
                 if not self.check_mode:
                     self.results['image'] = self.client.pull_image(self.name, tag=self.tag)
+            if image and image['Id'] == self.results['image']['Id']:
+                self.results['changed'] = False
 
         if self.archive_path:
             self.archive_image(self.name, self.tag)


### PR DESCRIPTION
While using force mode in docker module,  always return Changed=True even if the image has not been updated.

This pull request fixes this issue, so we can always use force in docker image and recreate docker container only if the upstream image is updated.
