### PR TITLE
Select EC2 classic security group if vpc_id is not set

### DIFF
--- a/cloud/amazon/ec2_group.py
+++ b/cloud/amazon/ec2_group.py
@@ -276,13 +276,13 @@ def main():
         groups[curGroup.id] = curGroup
         if curGroup.name in groups:
             # Prioritise groups from the current VPC
-            if vpc_id is None or curGroup.vpc_id == vpc_id:
+            if curGroup.vpc_id == vpc_id:
                 groups[curGroup.name] = curGroup
         else:
             groups[curGroup.name] = curGroup
 
-        if curGroup.name == name and (vpc_id is None or curGroup.vpc_id == vpc_id):
-            group = curGroup
+    if name in groups:
+        group = groups[name]
 
     # Ensure requested group is absent
     if state == 'absent':


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

`ec2_group` module
##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.1.1.0 (meredith 780c363482) last updated 2016/08/29 08:40:32 (GMT -500)
  lib/ansible/modules/core: (ec2_group_find_classic 684e933e54) last updated 2016/09/29 12:32:57 (GMT -500)
  lib/ansible/modules/extras: (detached HEAD 14887a9ea8) last updated 2016/08/29 08:39:19 (GMT -500)
  config file = /home/ssiefkas/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

The `ec2_group` module takes a `name` parameter and searches for groups with that exact name via EC2 API.  If `vpc_id` is specified and a security group with a matching name exists in the VPC a strict match is performed.  If no `vpc_id` is provided then the last security group enumerated will be returned.  This precludes the ability to perform a strict match for EC2 classic groups.  This change will always select an EC2 class security group if one exists and no `vpc_id` parameter is provided.
