### PR TITLE
(re)add post-watchdog-launch sleep to Windows async_wrapper

### DIFF
--- a/windows/async_wrapper.ps1
+++ b/windows/async_wrapper.ps1
@@ -324,6 +324,10 @@ Function Start-Watchdog {
     # FUTURE: use CreateProcess + stream redirection to watch for/return quick watchdog failures?
     $result = $([wmiclass]"Win32_Process").Create($exec_path, $null, $pstartup)
 
+    # On fast + idle machines, the process never starts without this delay. Hopefully the switch to
+    # Win32 process launch will make this unnecessary.
+    Sleep -Seconds 1
+
     $watchdog_pid = $result.ProcessId
 
     return $watchdog_pid


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

async_wrapper.ps1
##### SUMMARY

fixed apparent race where subprocess appears to never start
