### PR TITLE
Update ec2_metric_alarm documentation

### DIFF
--- a/cloud/amazon/ec2_metric_alarm.py
+++ b/cloud/amazon/ec2_metric_alarm.py
@@ -19,7 +19,7 @@ module: ec2_metric_alarm
 short_description: "Create/update or delete AWS Cloudwatch 'metric alarms'"
 description:
  - Can create or delete AWS metric alarms.
- - Metrics you wish to alarm on must already exist.
+ - Metrics you wish to alarm on and actions to take must already exist.
 version_added: "1.6"
 author: "Zacharie Eakin (@zeekin)"
 options:
@@ -39,7 +39,9 @@ options:
         required: false
     namespace:
         description:
-          - Name of the appropriate namespace ('AWS/EC2', 'System/Linux', etc.), which determines the category it will appear under in cloudwatch
+          - Name of the appropriate namespace ('AWS/EC2', 'System/Linux', etc.),
+            which determines the category it will appear under in cloudwatch. 
+            See U(http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/aws-namespaces.html)
         required: false
     statistic:
         description:
@@ -79,11 +81,11 @@ options:
         required: false
     alarm_actions:
         description:
-          - A list of the names action(s) taken when the alarm is in the 'alarm' status
+          - A list of ARN(s) of action taken when the alarm is in the 'alarm' status.
         required: false
     insufficient_data_actions:
         description:
-          - A list of the names of action(s) to take when the alarm is in the 'insufficient_data' status
+          - A list of ARN(s) of actions to take when the alarm is in the 'insufficient_data' status
         required: false
     ok_actions:
         description:
@@ -110,7 +112,7 @@ EXAMPLES = '''
       unit: "Percent"
       description: "This will alarm when a bamboo slave's cpu usage average is lower than 5% for 15 minutes "
       dimensions: {'InstanceId':'i-XXX'}
-      alarm_actions: ["action1","action2"]
+      alarm_actions: ["arn:aws:sns:us-west-2:XXXX:XXXX","arn:aws:sns:us-west-2:XXXX:XXXX"]
 
 
 '''


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Docs Pull Request
##### COMPONENT NAME

ec2_metric_alarm
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
```
##### SUMMARY

Add information about alarm_actions and AWS Namespace
