### PR TITLE
5150 Cron module: Move job parameter to meet expected requirements

### DIFF
--- a/system/cron.py
+++ b/system/cron.py
@@ -645,10 +645,10 @@ def main():
                 crontab.remove_env(name)
                 changed = True
     else:
-        job = crontab.get_cron_job(minute, hour, day, month, weekday, job, special_time, disabled)
         old_job = crontab.find_job(name)
 
         if do_install:
+            job = crontab.get_cron_job(minute, hour, day, month, weekday, job, special_time, disabled)
             if len(old_job) == 0:
                 crontab.add_job(name, job)
                 changed = True


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

Cron

Details in #5150 :
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.2.0
  config file = /Users/stevendevries/somewhere/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### CONFIGURATION

<!---
Mention any settings you have changed/added/removed in ansible.cfg
(or using the ANSIBLE_* environment variables).
-->
##### OS / ENVIRONMENT

<!---
Mention the OS you are running Ansible from, and the OS you are
managing, or say “N/A” for anything that is not platform-specific.
-->

N/A
##### SUMMARY

<!--- Explain the problem briefly -->

I want to make sure an old cronjob is not present anymore, using the following task:

```
- name: Make sure an old cronjob is not present anymore
  cron: name="aws_scripts_mon" user="{{ ansible_user }}" state=absent
```

This works fine with Ansible 2.1.1.0 after updating to 2.1.2.0 this breaks.
##### STEPS TO REPRODUCE

<!---
For bugs, show exactly how to reproduce the problem.
For new features, show how the feature would be used.
-->

Run this task and it fails:

<!--- Paste example playbooks or commands between quotes below -->

```
- name: Make sure an old cronjob is not present anymore
  cron: name="aws_scripts_mon" user="{{ ansible_user }}" state=absent
```

Run this task and it works (just a random string in job parameter)

```
- name: Make sure an old cronjob is not present anymore
  cron: name="aws_scripts_mon" job="something" user="{{ ansible_user }}" state=absent
```
##### EXPECTED RESULTS

<!--- What did you expect to happen when running the steps above? -->

I should work without a job parameter.
##### ACTUAL RESULTS

```
TASK [aws : Make sure an old cronjob is not present anymore] *******************
task path: /srv/http/mmim-leveranciersportaal/ansible/roles/aws/tasks/main.yml:43
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'NoneType' object has no attribute 'strip'
fatal: [somewhere]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_yPdq_U/ansible_module_cron.py\", line 700, in <module>\n    main()\n  File \"/tmp/ansible_yPdq_U/ansible_module_cron.py\", line 645, in main\n    job = crontab.get_cron_job(minute, hour, day, month, weekday, job, special_time, disabled)\n  File \"/tmp/ansible_yPdq_U/ansible_module_cron.py\", line 385, in get_cron_job\n    job = job.strip('\\r\\n')\nAttributeError: 'NoneType' object has no attribute 'strip'\n", "module_stdout": "", "msg": "MODULE FAILURE"}
```
