### PR TITLE
Fix incorrect line wrapping in output from yum check-updates

### DIFF
--- a/packaging/os/yum.py
+++ b/packaging/os/yum.py
@@ -796,6 +796,8 @@ def latest(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
         res['results'].append('Nothing to do here, all packages are up to date')
         return res
     elif rc == 100:
+        # remove incorrect new lines in longer columns in output from yum check-update
+        out=re.sub('\n\W+', ' ', out)
         available_updates = out.split('\n')
         # build update dictionary
         for line in available_updates:


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

packaging/os/yum.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.1.1.0, 2.1.2.0
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Read issue: https://github.com/ansible/ansible-modules-core/issues/4318
Fixes #4318 

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

Detailed description: https://github.com/ansible/ansible-modules-core/issues/4318#issuecomment-251416661
