### PR TITLE
fixes user module not adding groups

### DIFF
--- a/system/user.py
+++ b/system/user.py
@@ -518,8 +518,10 @@ class User(object):
         if self.groups is None:
             return None
         info = self.user_info()
-        groups = set(filter(None, self.groups.split(',')))
-        for g in set(groups):
+        groups = set()
+        for g in filter(None, self.groups.strip('[]').split(',')):
+            groups.add( g.strip().strip( '"\'') )
+        for g in groups:
             if not self.group_exists(g):
                 self.module.fail_json(msg="Group %s does not exist" % (g))
             if info and remove_existing and self.group_info(g)[2] == info[3]:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

`user` module
##### ANSIBLE VERSION

```
ansible 2.1.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

The groups were not being properly parsed so I changed the way they are parsed from a list of strings converted to an string: stripping ' [' and ' ]' and then individually removing the string delimiters `'` or `"`.
## before

```
fatal: [anstest]: FAILED! => {"changed": false, "failed": true, "msg": "Group  'sftpjail'] does not exist"
```
## after

```
changed: [anstest]
```

Fixes #5163
