### PR TITLE
Remove incorrect version_added for regexp param

### DIFF
--- a/files/lineinfile.py
+++ b/files/lineinfile.py
@@ -45,7 +45,6 @@ options:
       - The file to modify.
   regexp:
     required: false
-    version_added: 1.7
     description:
       - The regular expression to look for in every line of the file. For
         C(state=present), the pattern to replace if found; only the last line


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

lineinfile module
##### ANSIBLE VERSION

2.1
##### SUMMARY

We had an issue using an old version of Ansible where we thought the `regexp` param wasn't supported by the `lineinfile` module, since the docs say the param was added in 1.7. However, checking the source code, it's clear the `regexp` param is much older--here it is in the 1.5.4 release: https://github.com/ansible/ansible/blob/release1.5.4/library/files/lineinfile#L42

So I removed the incorrect `version_added` tag to avoid confusion.

I'm not sure why this was added originally in https://github.com/ansible/ansible-modules-core/commit/c05a5eba58632ecd935521a46d10e9ec250f9694
