### PR TITLE
Update vsphere_guest.py to include parameter for eagerly_scrub vmdisk part 2.

### DIFF
--- a/cloud/vmware/vsphere_guest.py
+++ b/cloud/vmware/vsphere_guest.py
@@ -359,7 +359,9 @@ def add_disk(module, s, config_target, config, devices, datastore, type="thin", 
         "disk_backing").pyclass()
     disk_backing.set_element_fileName(datastore_name)
     disk_backing.set_element_diskMode("persistent")
-    if type != "thick":
+    if type == "eager":
+        disk_backing.set_element_eagerlyScrub("eager_zero")
+    elif type == "thin":
         disk_backing.set_element_thinProvisioned(1)
     disk_ctlr.set_element_key(key)
     disk_ctlr.set_element_controllerKey(int(disk_ctrl_key))


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

 cloud/vmware/vsphere_guest.py 
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Continued from pull request #4170
Deleted and recreated repo fork and had to make new pull request for this change.
"Need this change to allow for VMware disk to be Thick Provision Eager Zeroed."

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```

```
