### PR TITLE
Fixed incorrect usage of user_data variable in rackspace module rax

### DIFF
--- a/cloud/rackspace/rax.py
+++ b/cloud/rackspace/rax.py
@@ -182,7 +182,7 @@ options:
     description:
       - how long before wait gives up, in seconds
     default: 300
-author: 
+author:
     - "Jesse Keating (@j2sol)"
     - "Matt Martz (@sivel)"
 notes:
@@ -287,7 +287,7 @@ def create(module, names=[], flavor=None, image=None, meta={}, key_name=None,
 
     if user_data and os.path.isfile(os.path.expanduser(user_data)):
         try:
-            user_data = os.path.expanduser('user_data')
+            user_data = os.path.expanduser(user_data)
             f = open(user_data)
             user_data = f.read()
             f.close()


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

Rackspace cloud module rax.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.1.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

The user_data variable was not used when looking up the path to the file;  instead the string 'user_data' was used.  This results in a failure if you try to pass in a path to e.g. a cloud-config file.
