### PR TITLE
Add ignore_time_wait option

### DIFF
--- a/utilities/logic/wait_for.py
+++ b/utilities/logic/wait_for.py
@@ -183,7 +183,7 @@ class TCPConnectionInfo(object):
         self.exclude_ips = self._get_exclude_ips()
         if not HAS_PSUTIL:
             module.fail_json(msg="psutil module required for wait_for")
-        if (module.params['ignore_time_wait'] is None):
+        if module.params['ignore_time_wait'] is None:
             connection_states['06'] = 'TIME_WAIT'
 
     def _get_exclude_ips(self):
@@ -365,7 +365,7 @@ def main():
             delay=dict(default=0, type='int'),
             port=dict(default=None, type='int'),
             path=dict(default=None, type='path'),
-            ignore_time_wait=dict(default=None),
+            ignore_time_wait=dict(required=False, default=False, type='bool'),
             search_regex=dict(default=None),
             state=dict(default='started', choices=['started', 'stopped', 'present', 'absent', 'drained']),
             exclude_hosts=dict(default=None, type='list')

--- a/utilities/logic/wait_for.py
+++ b/utilities/logic/wait_for.py
@@ -85,6 +85,10 @@ options:
       - When checking for a file or a search string C(present) or C(started) will ensure that the file or string is present before continuing, C(absent) will check that file is absent or removed
     choices: [ "present", "started", "stopped", "absent", "drained" ]
     default: "started"
+  ignore_time_wait:
+    description:
+      - ignore time_wait socket states when waiting for connections to be drained
+    required: false
   path:
     version_added: "1.4"
     required: false
@@ -167,7 +171,6 @@ class TCPConnectionInfo(object):
         '03': 'SYN_RECV',
         '04': 'FIN_WAIT1',
         '05': 'FIN_WAIT2',
-        '06': 'TIME_WAIT',
     }
 
     def __new__(cls, *args, **kwargs):
@@ -180,6 +183,8 @@ class TCPConnectionInfo(object):
         self.exclude_ips = self._get_exclude_ips()
         if not HAS_PSUTIL:
             module.fail_json(msg="psutil module required for wait_for")
+        if (module.params['ignore_time_wait'] is None):
+            connection_states['06'] = 'TIME_WAIT'
 
     def _get_exclude_ips(self):
         exclude_hosts = self.module.params['exclude_hosts']
@@ -360,6 +365,7 @@ def main():
             delay=dict(default=0, type='int'),
             port=dict(default=None, type='int'),
             path=dict(default=None, type='path'),
+            ignore_time_wait=dict(default=None),
             search_regex=dict(default=None),
             state=dict(default='started', choices=['started', 'stopped', 'present', 'absent', 'drained']),
             exclude_hosts=dict(default=None, type='list')
@@ -372,6 +378,7 @@ def main():
     timeout = params['timeout']
     connect_timeout = params['connect_timeout']
     delay = params['delay']
+    ignore_time_wait = params['ignore_time_wait']
     port = params['port']
     state = params['state']
     path = params['path']


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

wait_for
##### ANSIBLE VERSION

```
ansible 2.1.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

This adds a "ignore_time_wait" option for the wait_for module. 
When using the wait_for module for waiting for all connections to be drained on a loadbalanced node,  it can take very long time (in my expirience more than 10 minutes - I haven't had the patience to wait much longer than that, before my ansible task would timeout). 
I have seen this behaviour on all kinds of linux systems which were running java application servers. 
My understanding is, that time_wait state connections actually are closed, but are waiting to be "recycled". 
I have added as a option to be backwards compatible, but maybe it would even make more sense to completely ignore time_wait connections completely.

Before change:

```
TASK [loadbalancer : Wait for connections to be drained] ********
Friday 07 October 2016  21:15:02 +0200 (0:00:01.261)       0:00:04.732 ******** 
failed: [appserver] (item={u'port': 8080, u'pool': u'appserver-8080'}) => {"elapsed": 900, "failed": true, "item": {"pool": "appserver-8080", "port": 8080}, "msg": "Timeout when waiting for 192.168.1.2:8080 to drain"}
```

After change:

```
TASK [loadbalancer : Wait for connections to be drained] ********
Friday 07 October 2016  22:46:47 +0200 (0:00:01.005)       0:00:04.392 ******** 
ok: [appserver] => (item={u'port': 8080, u'pool': u'appserver-8080'})
```
