### PR TITLE
Add audit argument to put the module in noop

### DIFF
--- a/network/eos/eos_config.py
+++ b/network/eos/eos_config.py
@@ -111,6 +111,20 @@ options:
     required: false
     default: false
     choices: ['yes', 'no']
+  audit:
+    description:
+      - This argument will cause the module to run as usual and perform
+        all necessary analysis between the designed configuration and
+        the current running-config, however, it will prohibit the module
+        from sending any commands to the switch. It will still output
+        which commands would have been run, and will return changed=True
+        since a change would have occurred. This argument allows you to run
+        the playbook in normal mode (not --check) and still gather useful
+        audit information.
+    required: false
+    default: false
+    choices: ['yes', 'no']
+    version_added: "2.2"
   backup:
     description:
       - This argument will cause the module to create a full backup of

--- a/network/eos/eos_config.py
+++ b/network/eos/eos_config.py
@@ -281,10 +281,13 @@ def run(module, result):
             result['updates'] = commands
 
         module.log('commands: %s' % commands)
-        load_config(module, commands, result)
+        if not module.params['audit']:
+            load_config(module, commands, result)
+        else:
+            result['changed'] = True
 
     if module.params['save']:
-        if not module.check_mode:
+        if not module.check_mode and not module.params['audit']:
             module.config.save_config()
         result['changed'] = True
 
@@ -310,6 +313,7 @@ def main():
         config=dict(),
         defaults=dict(type='bool', default=False),
 
+        audit=dict(type='bool', default=False),
         backup=dict(type='bool', default=False),
         save=dict(default=False, type='bool'),
     )


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

eos_config
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0.0 (detached HEAD 44faad0593) last updated 2016/10/13 17:08:12 (GMT +000)
  lib/ansible/modules/core: (detached HEAD d66983b43e) last updated 2016/10/13 17:08:40 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD 35132b892f) last updated 2016/10/13 17:08:40 (GMT +000)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

This argument allows a user to run the playbook in normal mode, and report back
what config changes _would_ have been made without actually making them.  This is
useful since some implementations require playbooks that query external APIs to gather
information that influences the configuration template.  This way, a user does not have to run
in check mode.

Sample playbook:

```

---
- hosts: eos
  gather_facts: no
  connection: local

  tasks:
    - name: "Tests audit feature"
      eos_config:
        "provider": "{{ eapi }}"
        "lines":
          - "hostname newhostname"
        "audit": True
```
