### PR TITLE
amazon returns connection_draining_timeout as an int

### DIFF
--- a/cloud/amazon/ec2_elb_lb.py
+++ b/cloud/amazon/ec2_elb_lb.py
@@ -962,7 +962,7 @@ class ElbManager(object):
         attributes = self.elb.get_attributes()
         if self.connection_draining_timeout is not None:
             if not attributes.connection_draining.enabled or \
-                    attributes.connection_draining.timeout != self.connection_draining_timeout:
+                    str(attributes.connection_draining.timeout) != str(self.connection_draining_timeout):
                 self.changed = True
             attributes.connection_draining.enabled = True
             attributes.connection_draining.timeout = self.connection_draining_timeout


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

cloud/amazon/ec2_elb_lb.py
##### ANSIBLE VERSION

```
ansible 2.3.0
```
##### SUMMARY

All this does is cast `connection_draining_timeout` to a string on both sides of the comparison (local vs the returned data from amazon), as amazon returns this value as a string but locally it's an integer.

Before the change, an elb command would always be marked as having changed, afterwards if everything remains the same, it is correctly noted as no change.
