### PR TITLE
Fix unarchive on python3

### DIFF
--- a/files/unarchive.py
+++ b/files/unarchive.py
@@ -251,7 +251,7 @@ class ZipArchive(object):
             try:
                 for member in archive.namelist():
                     if member not in self.excludes:
-                        self._files_in_archive.append(member)
+                        self._files_in_archive.append(to_native(member))
             except:
                 archive.close()
                 raise UnarchiveError('Unable to list files in the archive')
@@ -623,7 +623,7 @@ class TgzArchive(object):
 #            filename = filename.decode('string_escape')
             filename = codecs.escape_decode(filename)[0]
             if filename and filename not in self.excludes:
-                self._files_in_archive.append(filename)
+                self._files_in_archive.append(to_native(filename))
         return self._files_in_archive
 
     def is_unarchived(self):
@@ -863,5 +863,7 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
+from ansible.module_utils._text import to_native
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

unarchive
##### SUMMARY

Since handler.files_in_archive is a list of files coming from
various executables output, that's a bytes list, and dest is a
str. So we need to convert to get the path.

I am however not 100% that's the right place and if that work fine with utf8 path.
