### PR TITLE
Make subversion module work on python 3

### DIFF
--- a/source_control/subversion.py
+++ b/source_control/subversion.py
@@ -175,7 +175,7 @@ class Subversion(object):
         # Match only revisioned files, i.e. ignore status '?'.
         regex = re.compile(r'^[^?X]')
         # Has local mods if more than 0 modified revisioned files.
-        return len(filter(regex.match, lines)) > 0
+        return len(list(filter(regex.match, lines))) > 0
 
     def needs_update(self):
         curr, url = self.get_revision()


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

subversion
##### SUMMARY

In python 3, filter return a iterator and so result in this traceback:

```
Traceback (most recent call last):
  File \"/tmp/ansible_kzu72kz5/ansible_module_subversion.py\", line 264, in <module>
    main()
  File \"/tmp/ansible_kzu72kz5/ansible_module_subversion.py\", line 243, in main
    local_mods = svn.has_local_mods()
  File \"/tmp/ansible_kzu72kz5/ansible_module_subversion.py\", line 178, in has_local_mods
    return len(filter(regex.match, lines)) > 0
TypeError: object of type 'filter' has no len()
```
