### PR TITLE
Make find return sample a YAML dict

### DIFF
--- a/files/find.py
+++ b/files/find.py
@@ -34,7 +34,7 @@ version_added: "2.0"
 short_description: return a list of files based on specific criteria
 requirements: []
 description:
-    - Return a list files based on specific criteria. Multiple criteria are AND'd together.
+    - Return a list of files based on specific criteria. Multiple criteria are AND'd together.
 options:
     age:
         required: false
@@ -139,13 +139,13 @@ files:
     returned: success
     type: list of dictionaries
     sample: [
-        { path="/var/tmp/test1",
-          mode=0644,
-          ...,
-          checksum=16fac7be61a6e4591a33ef4b729c5c3302307523
+        { path: "/var/tmp/test1",
+          mode: "0644",
+          "...": "...",
+          checksum: 16fac7be61a6e4591a33ef4b729c5c3302307523
         },
-        { path="/var/tmp/test2",
-          ...
+        { path: "/var/tmp/test2",
+          "...": "..."
         },
         ]
 matched:


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

Find module
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.2.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

In the description of the `find` module return value, the sample dict
has its `key=value` strings converted to `key=value: None` in the
web documentation. This commit updates the sample output to a 'real'
dict.

Before:

```
[{'mode=0644': None, 'path="/var/tmp/test1"': None, '...': None, 'checksum=16fac7be61a6e4591a33ef4b729c5c3302307523': None}, {'...': None, 'path="/var/tmp/test2"': None}]
```

After (generated locally):

```
[{'path': '/var/tmp/test1', 'mode': '0644', '...': '...', 'checksum': '16fac7be61a6e4591a33ef4b729c5c3302307523'}, {'path': '/var/tmp/test2', '...': '...'}]
```

Minor additional edit in the description: "return list _of_ files".
