### PR TITLE
Add uplink provider type

### DIFF
--- a/cloud/openstack/os_network.py
+++ b/cloud/openstack/os_network.py
@@ -69,7 +69,7 @@ options:
    provider_network_type:
      description:
         - The type of physical network that maps to this network resource.
-     choices: ['flat', 'vlan', 'vxlan', 'gre']
+     choices: ['flat', 'vlan', 'vxlan', 'gre', 'uplink']
      required: false
      default: None
      version_added: "2.1"
@@ -169,7 +169,7 @@ def main():
         external=dict(default=False, type='bool'),
         provider_physical_network=dict(required=False),
         provider_network_type=dict(required=False, default=None,
-                                   choices=['flat', 'vlan', 'vxlan', 'gre']),
+                                   choices=['flat', 'vlan', 'vxlan', 'gre', 'uplink']),
         provider_segmentation_id=dict(required=False),
         state=dict(default='present', choices=['absent', 'present']),
         project=dict(default=None)


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

openstack network cloud module
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0.0
```
##### SUMMARY

Add 'uplink' option to the neutron type provider list, as it is used and required by the midonet plugin, described here:
https://docs.midonet.org/docs/latest-en/operations-guide/content/edge_router_setup.html
