### PR TITLE
Make the code run on python 3

### DIFF
--- a/system/authorized_key.py
+++ b/system/authorized_key.py
@@ -250,7 +250,7 @@ def parseoptions(module, options):
         for part in parts:
             if "=" in part:
                 (key, value) = part.split("=", 1)
-                if options_dict.has_key(key):
+                if key in options_dict:
                     if isinstance(options_dict[key], list):
                         options_dict[key].append(value)
                     else:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

authorized_keys
##### SUMMARY

Test suite block on:

```
Traceback (most recent call last):
  File "/tmp/ansible_fhootp1e/ansible_module_authorized_key.py", line 496, in <module>
    main()
  File "/tmp/ansible_fhootp1e/ansible_module_authorized_key.py", line 490, in main
    results = enforce_state(module, module.params)
  File "/tmp/ansible_fhootp1e/ansible_module_authorized_key.py", line 410, in enforce_state
    parsed_new_key = parsekey(module, new_key)
  File "/tmp/ansible_fhootp1e/ansible_module_authorized_key.py", line 308, in parsekey
    options = parseoptions(module, options)
  File "/tmp/ansible_fhootp1e/ansible_module_authorized_key.py", line 253, in parseoptions
    if options_dict.has_key(key):
AttributeError: 'keydict' object has no attribute 'has_key'
```

With keydict being a subclass of dict.

This should enable to merge https://github.com/ansible/ansible/pull/18053 later, if we have no other issues in the code.
