### PR TITLE
Adding [] around user to resolve issue Fixes #4894

### DIFF
--- a/database/mysql/mysql_user.py
+++ b/database/mysql/mysql_user.py
@@ -352,7 +352,7 @@ def user_delete(cursor, user, host, host_all, check_mode):
     return True
 
 def user_get_hostnames(cursor, user):
-    cursor.execute("SELECT Host FROM mysql.user WHERE user = %s", user)
+    cursor.execute("SELECT Host FROM mysql.user WHERE user = %s", [user])
     hostnames_raw = cursor.fetchall()
     hostnames = []
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

core/database/mysql/mysql_user.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.1.1.0
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Fixes #4894 

This is a minor correction where "[]" were missing around a passed in argument. There is no structural changes to the code beyond that correction to resolve the issue where Ansible does not handle "host_all" using mysql_user module.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
Before:
fatal: [test]: FAILED! => {"changed": false, "failed": true, "module_stderr": "", "module_stdout": "\r\nTraceback (most recent call last):\r\n  File \"/tmp/ansible_VcFFGU/ansible_module_mysql_user.py\", line 582, in <module>\r\n    main()\r\n  File \"/tmp/ansible_VcFFGU/ansible_module_mysql_user.py\", line 554, in main\r\n    if user_exists(cursor, user, host, host_all):\r\n  File \"/tmp/ansible_VcFFGU/ansible_module_mysql_user.py\", line 216, in user_exists\r\n    cursor.execute(\"SELECT count(*) FROM user WHERE user = %s\", user)\r\n  File \"/usr/lib/python2.7/dist-packages/MySQLdb/cursors.py\", line 210, in execute\r\n    query = query % args\r\nTypeError: not all arguments converted during string formatting\r\n", "msg": "MODULE FAILURE", "parsed": false}

After:
ok: [test]
```

Link to issue: https://github.com/ansible/ansible-modules-core/issues/4894
