### PR TITLE
Fix ios_template docs to refer to ios_config (not eos_..)

### DIFF
--- a/network/ios/_ios_template.py
+++ b/network/ios/_ios_template.py
@@ -28,7 +28,7 @@ description:
     by evaluating the current running-config and only pushing configuration
     commands that are not already configured.  The config source can
     be a set of commands or a template.
-deprecated: Deprecated in 2.2. Use eos_config instead
+deprecated: Deprecated in 2.2. Use ios_config instead
 extends_documentation_fragment: ios
 options:
   src:


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Docs Pull Request
##### COMPONENT NAME

network/ios/ios_template.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.3.0 (devel 38d0f77a0f) last updated 2016/10/18 11:43:44 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 3266efb02f) last updated 2016/10/18 11:43:45 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 3f77bb6857) last updated 2016/10/18 11:43:45 (GMT -400)
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Fixup minor ref to eos_config vs ios_config

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```

```
