### PR TITLE
Fix code for python 3

### DIFF
--- a/system/authorized_key.py
+++ b/system/authorized_key.py
@@ -159,7 +159,7 @@ class keydict(dict):
 
     def __init__(self, *args, **kw):
         super(keydict,self).__init__(*args, **kw)
-        self.itemlist = super(keydict,self).keys()
+        self.itemlist = list(super(keydict,self).keys())
     def __setitem__(self, key, value):
         self.itemlist.append(key)
         super(keydict,self).__setitem__(key, value)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

authorized_keys
##### SUMMARY

Since dict.keys return a dictkeys under python 3, we hav to cast it
to a list to avoid traceback:

```
Traceback (most recent call last):
  File "/tmp/ansible_sh16ejbd/ansible_module_authorized_key.py", line 496, in <module>
    main()
  File "/tmp/ansible_sh16ejbd/ansible_module_authorized_key.py", line 490, in main
    results = enforce_state(module, module.params)
  File "/tmp/ansible_sh16ejbd/ansible_module_authorized_key.py", line 410, in enforce_state
    parsed_new_key = parsekey(module, new_key)
  File "/tmp/ansible_sh16ejbd/ansible_module_authorized_key.py", line 308, in parsekey
    options = parseoptions(module, options)
  File "/tmp/ansible_sh16ejbd/ansible_module_authorized_key.py", line 259, in parseoptions
    options_dict[key] = value
  File "/tmp/ansible_sh16ejbd/ansible_module_authorized_key.py", line 164, in __setitem__
    self.itemlist.append(key)
AttributeError: 'dict_keys' object has no attribute 'append'
```

Yet another fix for https://github.com/ansible/ansible/pull/18053
