### PR TITLE
Cleanup imports of xattr

### DIFF
--- a/files/xattr.py
+++ b/files/xattr.py
@@ -73,6 +73,8 @@ EXAMPLES = '''
 '''
 
 import operator
+import re
+import os
 
 def get_xattr_keys(module,path,follow):
     cmd = [ module.get_bin_path('getfattr', True) ]
@@ -202,7 +204,7 @@ def main():
     module.exit_json(changed=changed, msg=msg, xattr=res)
 
 # import module snippets
-from ansible.module_utils.basic import *
-
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.pycompat24 import get_exception
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

xattr
##### SUMMARY

Since the module use re and os, we need to import them.
And rather than importing '*', we should limit to the
only object/function needed, so we can more easily refactor
later.
