### PR TITLE
cleanup import for htpassword module

### DIFF
--- a/web_infrastructure/htpasswd.py
+++ b/web_infrastructure/htpasswd.py
@@ -257,7 +257,8 @@ def main():
 
 
 # import module snippets
-from ansible.module_utils.basic import *
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.pycompat24 import get_exception
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

htpasswd
##### SUMMARY

In order to ease future refactoring, we should avoid importing
'*' from ansible.module_utils.basic.
