### PR TITLE
Removes outdated "requirement" and outdated "note"

### DIFF
--- a/files/ini_file.py
+++ b/files/ini_file.py
@@ -80,11 +80,6 @@ options:
 notes:
    - While it is possible to add an I(option) without specifying a I(value), this makes
      no sense.
-   - A section named C(default) cannot be added by the module, but if it exists, individual
-     options within the section can be updated. (This is a limitation of Python's I(ConfigParser).)
-     Either use M(template) to create a base INI file with a C([default]) section, or use
-     M(lineinfile) to add the missing line.
-requirements: [ ConfigParser ]
 author:
     - "Jan-Piet Mens (@jpmens)"
     - "Ales Nosek (@noseka1)"


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

ini_file
##### SUMMARY

Removes references to `ConfigParser` in docs
- 7f59773460d79b3dae34c375ba68caea1bfc09a8 no longer uses `ConfigParser`
  - This also lifts the limitation mentioned in the _notes_
- 1d4c0abe2902d91b2895452feedcf72bf3dd9e20 removed the `import` statement
  - `ConfigParser` no longer required
