### PR TITLE
Remove line when 'state: absent' with 'option:' instead of commenting

### DIFF
--- a/files/ini_file.py
+++ b/files/ini_file.py
@@ -186,10 +186,10 @@ def do_ini(module, filename, section=None, option=None, value=None, state='prese
                                 else:
                                     index = index + 1
                         break
-                else:
-                    # comment out the existing option line
+                elif state == 'absent':
+                    # delete the existing line
                     if match_active_opt(option, line):
-                        ini_lines[index] = '#%s' % ini_lines[index]
+                        del ini_lines[index]
                         changed = True
                         break
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

ini_file
##### ANSIBLE VERSION

```
ansible 2.1.2.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

`ini_file` does not remove an option with `state: absent`, instead commenting it out.  This pull request changes that behavior to delete the line instead of commenting it.

An example of where using `#` as a comment in a problematic way is newer versions of php-fpm will throw errors when using `#` to comment out lines instead of `;`, having the line actually removed resolves the issue for anything similar to this, and matches the documentation.
##### TESTING

Playbook:

```

---
- hosts: localhost
  connection: local
  gather_facts: false
  vars:
    file: "inifile"
  tasks:
  - name: Ensure the file exists
    file:
      path: "{{ file }}"
      state: touch

  - name: Create a line in an ini file
    ini_file:
      dest: "{{ file }}"
      section: testing
      option: uncommented
      value: "yes"

  - name: Create a line in an ini file
    ini_file:
      dest: "{{ file }}"
      section: testing
      option: commented
      value: "yes"

  - name: Delete a line in an ini file
    ini_file:
      dest: "{{ file }}"
      section: testing
      option: commented
      state: absent
```

inifile before:

```
[testing]
uncommented = yes
#commented = yes
```

inifile after:

```
[testing]
uncommented = yes
```
