### PR TITLE
replace - Expose backup file path

### DIFF
--- a/files/replace.py
+++ b/files/replace.py
@@ -131,7 +131,7 @@ def main():
 
     params = module.params
     dest = os.path.expanduser(params['dest'])
-    diff = dict()
+    res_args = dict()
 
     if os.path.isdir(dest):
         module.fail_json(rc=256, msg='Destination %s is a directory !' % dest)
@@ -143,12 +143,6 @@ def main():
         contents = f.read()
         f.close()
 
-    if module._diff:
-        diff = {
-            'before_header': dest,
-            'before': contents,
-        }
-
     mre = re.compile(params['regexp'], re.MULTILINE)
     result = re.subn(mre, params['replace'], contents, 0)
 
@@ -156,22 +150,25 @@ def main():
         msg = '%s replacements made' % result[1]
         changed = True
         if module._diff:
-            diff['after_header'] = dest
-            diff['after'] = result[0]
+            res_args['diff'] = {
+                'before_header': dest,
+                'before': contents,
+                'after_header': dest,
+                'after': result[0],
+            }
     else:
         msg = ''
         changed = False
-        diff = dict()
 
     if changed and not module.check_mode:
         if params['backup'] and os.path.exists(dest):
-            module.backup_local(dest)
+            res_args['backup_file'] = module.backup_local(dest)
         if params['follow'] and os.path.islink(dest):
             dest = os.path.realpath(dest)
         write_changes(module, result[0], dest)
 
-    msg, changed = check_file_attrs(module, changed, msg)
-    module.exit_json(changed=changed, msg=msg, diff=diff)
+    res_args['msg'], res_args['changed'] = check_file_attrs(module, changed, msg)
+    module.exit_json(**res_args)
 
 # this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

`replace` module
##### ANSIBLE VERSION

```
ansible 2.1.2.0
```
##### SUMMARY

Exposes file path, when creating a backup.

```
$ sudo ansible localhost -D -m replace -a "dest=/etc/hosts regexp='local(host|domain)' replace='remote\1' backup=no"
localhost | SUCCESS => {
    "changed": true, 
    "msg": "12 replacements made"
}
--- before: /etc/hosts
+++ after: /etc/hosts
@@ -1,6 +1,6 @@
 127.0.0.1  testbed-webserver-1   testbed-webserver-1
-127.0.0.1  localhost.localdomain localhost localhost4.localdomain4 localhost4
-::1    localhost.localdomain localhost localhost6.localdomain6 localhost6
+127.0.0.1  remotehost.remotedomain remotehost remotehost4.remotedomain4 remotehost4
+::1    remotehost.remotedomain remotehost remotehost6.remotedomain6 remotehost6
 fe00::0 ip6-localnet
 ff00::0 ip6-mcastprefix
 ff02::1 ip6-allnodes

$ sudo ansible localhost -D -m replace -a "dest=/etc/hosts regexp='remote(host|domain)' replace='local\1' backup=yes"
localhost | SUCCESS => {
    "backup_file": "/etc/hosts.2016-10-24@01:40:08~", 
    "changed": true, 
    "msg": "12 replacements made"
}
--- before: /etc/hosts
+++ after: /etc/hosts
@@ -1,6 +1,6 @@
 127.0.0.1  testbed-webserver-1   testbed-webserver-1
-127.0.0.1  remotehost.remotedomain remotehost remotehost4.remotedomain4 remotehost4
-::1    remotehost.remotedomain remotehost remotehost6.remotedomain6 remotehost6
+127.0.0.1  localhost.localdomain localhost localhost4.localdomain4 localhost4
+::1    localhost.localdomain localhost localhost6.localdomain6 localhost6
 fe00::0 ip6-localnet
 ff00::0 ip6-mcastprefix
 ff02::1 ip6-allnodes
```

Fixes #245
