### PR TITLE
bugfix: allow docker containers with no ports

### DIFF
--- a/cloud/docker/docker_container.py
+++ b/cloud/docker/docker_container.py
@@ -1217,7 +1217,7 @@ class Container(DockerBaseClass):
             expected_env=(config.get('Env') or []),
             expected_entrypoint=config.get('Entrypoint'),
             expected_etc_hosts=host_config['ExtraHosts'],
-            expected_exposed=[re.sub(r'/.+$', '', p) for p in config.get('ExposedPorts', dict()).keys()],
+            expected_exposed=[re.sub(r'/.+$', '', p) for p in (config.get('ExposedPorts') or {}).keys()],
             groups=host_config.get('GroupAdd'),
             ipc_mode=host_config.get("IpcMode"),
             labels=config.get('Labels'),


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
devel
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
config.get('ExposedPorts', dict()) is returning None; that is to say
config['ExposedPorts'] exists but is set to None; this should be
converted into a dict so we can continue; currently I get:

"Traceback (most recent call last):\r\n  File
\"/tmp/ansible_ZzP93K/ansible_module_docker_container.py\", line 2007,
in <module>\r\n    main()\r\n  File
\"/tmp/ansible_ZzP93K/ansible_module_docker_container.py\", line 2000,
in main\r\n    cm = ContainerManager(client)\r\n  File
\"/tmp/ansible_ZzP93K/ansible_module_docker_container.py\", line 1652,
in __init__\r\n    self.present(state)\r\n  File
\"/tmp/ansible_ZzP93K/ansible_module_docker_container.py\", line 1677,
in present\r\n    different, differences =
container.has_different_configuration(image)\r\n  File
\"/tmp/ansible_ZzP93K/ansible_module_docker_container.py\", line 1220,
in has_different_configuration\r\n    expected_exposed=[re.sub(r'/.+$',
'', p) for p in config.get('ExposedPorts',
dict()).keys()],\r\nAttributeError: 'NoneType' object has no attribute
'keys'\r\n"
```
