### PR TITLE
update vsphere_guest.py to include snapshot operations

### DIFF
--- a/cloud/vmware/vsphere_guest.py
+++ b/cloud/vmware/vsphere_guest.py
@@ -155,6 +155,12 @@ options:
       - Boolean. Allows you to run commands which may alter the running state of a guest. Also used to reconfigure and destroy.
     default: "no"
     choices: [ "yes", "no" ]
+  snapshot_op:
+    description:
+      - A key, value pair of snapshot operation types and their additional required parameters.
+    required: False
+    default: null
+    version_added: "2.3"
 
 notes:
   - This module should run from a system that can access vSphere directly.
@@ -314,6 +320,61 @@ as seen in the VMPowerState-Class of PySphere: http://git.io/vlwOq
     guest: newvm001
     state: absent
     force: yes
+
+## Snapshot Operations
+# Create a snapshot
+- vsphere_guest:
+    vcenter_hostname: <hostname>
+    username: <username>
+    password: <password>
+    validate_certs: False
+    guest: <vm_name>
+    snapshot_op:
+        op_type: create
+        name: <snapshot_name_to_create>
+        description: <snapshot_description>
+        
+# Remove a snapshot
+- vsphere_guest:
+    vcenter_hostname: <hostname>
+    username: <username>
+    password: <password>
+    validate_certs: False
+    guest: <vm_name>
+    snapshot_op:
+        op_type: remove
+        name: <snapshot_name_to_delete>
+
+# Revert to a snapshot
+- vsphere_guest:
+    vcenter_hostname: <hostname>
+    username: <username>
+    password: <password>
+    validate_certs: False
+    guest: <vm_name>
+    snapshot_op:
+        op_type: revert
+        name: <snapshot_name_to_revert>
+
+# List all snapshots
+- vsphere_guest:
+    vcenter_hostname: <hostname>
+    username: <username>
+    password: <password>
+    validate_certs: False
+    guest: <vm_name>
+    snapshot_op:
+        op_type: list_all
+
+# List current snapshot of a vm
+- vsphere_guest:
+    vcenter_hostname: <hostname>
+    username: <username>
+    password: <password>
+    validate_certs: False
+    guest: <vm_name>
+    snapshot_op:
+        op_type: list_current
 '''
 
 def add_scsi_controller(module, s, config, devices, type="paravirtual", bus_num=0, disk_ctrl_key=1):
@@ -1507,14 +1568,14 @@ def delete_vm(vsphere_client, module, guest, vm, force):
 
 def snapshot_vm(vsphere_client, module, guest, vm, snapshot_op):
     """
-    To perform snapshot operations create/delete/list/revert.
+    To perform snapshot operations create/remove/revert/list_all/list_current.
     """
     
     try:
         snapshot_op_name = snapshot_op['op_type']
     except KeyError:
         vsphere_client.disconnect()
-        module.fail_json(msg="Specify op_type - list_all/remove/create/revert")
+        module.fail_json(msg="Specify op_type - create/remove/revert/list_all/list_current")
     
     if snapshot_op_name == 'list_all':
         snapshot_data = []
@@ -1543,22 +1604,26 @@ def snapshot_vm(vsphere_client, module, guest, vm, snapshot_op):
             vsphere_client.disconnect()
             module.fail_json(msg="specify name to delete snapshot")
         try:
-            vm.delete_named_snapshot(snapname, remove_children=False, sync_run=False)
+            vm.delete_named_snapshot(snapname, remove_children=True, sync_run=True)
             module.exit_json(changed=True, msg="Deleted snapshot %s for guest %s" % (snapname, guest))
         except Exception:
-            e = get_exception()
-            module.fail_json(msg='Failed to delete snapshot %s for guest %s : %s' % (snapname, guest, e))
+            module.fail_json(msg='Failed to delete snapshot %s for guest %s : %s' % (snapname, guest, get_exception()))
             
     elif snapshot_op_name == 'create':
         try:
             snapname = snapshot_op['name']
-            snapdesc = snapshot_op['description']
         except KeyError:
             vsphere_client.disconnect()
-            module.fail_json(msg="specify name & description to create snapshot")
+            module.fail_json(msg="specify name & description(optional) to create snapshot")
+        
+        if 'description' in snapshot_op:
+            snapdesc = snapshot_op['description']
+        else:
+            snapdesc = ''
+            
         try:
-            vm.create_snapshot(snapname, description=snapdesc, sync_run=False)
-            module.exit_json(changed=True, msg="Snapshot create task running asynchronously")
+            vm.create_snapshot(snapname, description=snapdesc, sync_run=True)
+            module.exit_json(changed=True, msg="Snapshot %s created for guest %s" %(snapname, guest))
         except Exception:
             module.fail_json(msg='Failed to create snapshot for guest %s : %s' % (guest, get_exception()))
             
@@ -1568,12 +1633,12 @@ def snapshot_vm(vsphere_client, module, guest, vm, snapshot_op):
         except KeyError:
             module.fail_json(msg="specify name to revert snapshot")
         try:
-            vm.revert_to_named_snapshot(snapname, sync_run=False)
-            module.exit_json(changed=True, msg="Snapshot revert task running asynchronously")
+            vm.revert_to_named_snapshot(snapname, sync_run=True)
+            module.exit_json(changed=True, msg="Guest %s reverted to snapshot %s" %(guest, snapname))
         except Exception:
             module.fail_json(msg='Failed to revert snapshot for guest %s : %s' % (guest, get_exception()))
             
-    elif snapshot_op_name == "list_current_snapshot":
+    elif snapshot_op_name == "list_current":
         try:
             current_snap = vm.get_current_snapshot_name()
             module.exit_json(changed=False, msg="Guest %s current snapshot - %s" %(guest, current_snap))
@@ -1581,7 +1646,7 @@ def snapshot_vm(vsphere_client, module, guest, vm, snapshot_op):
             module.fail_json(msg='Failed to get current snapshot for guest %s : %s' % (guest, get_exception()))
     else:
         vsphere_client.disconnect()
-        module.fail_json(msg="Specify op_type - list_all/remove/create/revert")
+        module.fail_json(msg="Specify op_type - create/remove/revert/list_all/list_current")
         
 def power_state(vm, state, force):
     """

--- a/cloud/vmware/vsphere_guest.py
+++ b/cloud/vmware/vsphere_guest.py
@@ -23,6 +23,7 @@ try:
     import json
 except ImportError:
     import simplejson as json
+    from datetime import datetime
 
 HAS_PYSPHERE = False
 try:
@@ -1502,8 +1503,86 @@ def delete_vm(vsphere_client, module, guest, vm, force):
         e = get_exception()
         module.fail_json(
             msg='Failed to delete vm %s : %s' % (guest, e))
+        
 
-
+def snapshot_vm(vsphere_client, module, guest, vm, snapshot_op):
+    """
+    To perform snapshot operations create/delete/list/revert.
+    """
+    
+    try:
+        snapshot_op_name = snapshot_op['op_type']
+    except KeyError:
+        vsphere_client.disconnect()
+        module.fail_json(msg="Specify op_type - list_all/remove/create/revert")
+    
+    if snapshot_op_name == 'list_all':
+        snapshot_data = []
+        snaptext = ''
+        try:
+            snapshot_list = vm.get_snapshots()
+            if len(snapshot_list) > 0:
+                for snapshot in snapshot_list:
+                    snap_time = snapshot.get_create_time()
+                    snap_time_formatted = datetime.datetime(*snap_time[:6])
+                    snap_time_formatted = snap_time_formatted.strftime('%Y-%m-%d %H:%M:%S')
+                    snaptext = 'Id: %s; Name: %s; Description: %s; Created: %s; State: %s; Path: %s' %(snapshot._mor
+                                            , snapshot.get_name(), snapshot.get_description(), snap_time_formatted
+                                            , snapshot.get_state(), snapshot.get_path() )
+                    snapshot_data.append(snaptext)
+                module.exit_json(changed=False, msg="Snapshot List %s" % snapshot_data)
+            else:
+                module.exit_json(changed=False, msg="No snapshot exists for guest %s" % guest)
+        except Exception:
+            module.fail_json(msg='Failed to list snapshot for guest %s : %s' % (guest, get_exception()))
+    
+    elif snapshot_op_name == 'remove':
+        try:
+            snapname = snapshot_op['name']
+        except KeyError:
+            vsphere_client.disconnect()
+            module.fail_json(msg="specify name to delete snapshot")
+        try:
+            vm.delete_named_snapshot(snapname, remove_children=False, sync_run=False)
+            module.exit_json(changed=True, msg="Deleted snapshot %s for guest %s" % (snapname, guest))
+        except Exception:
+            e = get_exception()
+            module.fail_json(msg='Failed to delete snapshot %s for guest %s : %s' % (snapname, guest, e))
+            
+    elif snapshot_op_name == 'create':
+        try:
+            snapname = snapshot_op['name']
+            snapdesc = snapshot_op['description']
+        except KeyError:
+            vsphere_client.disconnect()
+            module.fail_json(msg="specify name & description to create snapshot")
+        try:
+            vm.create_snapshot(snapname, description=snapdesc, sync_run=False)
+            module.exit_json(changed=True, msg="Snapshot create task running asynchronously")
+        except Exception:
+            module.fail_json(msg='Failed to create snapshot for guest %s : %s' % (guest, get_exception()))
+            
+    elif snapshot_op_name == 'revert':
+        try:
+            snapname = snapshot_op['name']
+        except KeyError:
+            module.fail_json(msg="specify name to revert snapshot")
+        try:
+            vm.revert_to_named_snapshot(snapname, sync_run=False)
+            module.exit_json(changed=True, msg="Snapshot revert task running asynchronously")
+        except Exception:
+            module.fail_json(msg='Failed to revert snapshot for guest %s : %s' % (guest, get_exception()))
+            
+    elif snapshot_op_name == "list_current_snapshot":
+        try:
+            current_snap = vm.get_current_snapshot_name()
+            module.exit_json(changed=False, msg="Guest %s current snapshot - %s" %(guest, current_snap))
+        except Exception:
+            module.fail_json(msg='Failed to get current snapshot for guest %s : %s' % (guest, get_exception()))
+    else:
+        vsphere_client.disconnect()
+        module.fail_json(msg="Specify op_type - list_all/remove/create/revert")
+        
 def power_state(vm, state, force):
     """
     Correctly set the power status for a VM determined by the current and
@@ -1713,6 +1792,7 @@ def main():
             template_src=dict(required=False, type='str'),
             snapshot_to_clone=dict(required=False, default=None, type='str'),
             guest=dict(required=True, type='str'),
+            snapshot_op=dict(required=False, type='dict', default={}),
             vm_disk=dict(required=False, type='dict', default={}),
             vm_nic=dict(required=False, type='dict', default={}),
             vm_hardware=dict(required=False, type='dict', default={}),
@@ -1752,6 +1832,7 @@ def main():
     state = module.params['state']
     guest = module.params['guest']
     force = module.params['force']
+    snapshot_op = module.params['snapshot_op']
     vm_disk = module.params['vm_disk']
     vm_nic = module.params['vm_nic']
     vm_hardware = module.params['vm_hardware']
@@ -1804,6 +1885,16 @@ def main():
                 e = get_exception()
                 module.fail_json(
                     msg="Fact gather failed with exception %s" % e)
+                
+        #Snapshot operations
+        elif snapshot_op:
+            snapshot_result = snapshot_vm(
+                vsphere_client=viserver,
+                module=module,
+                guest=guest,
+                vm=vm,
+                snapshot_op=snapshot_op)
+            
         # Power Changes
         elif state in ['powered_on', 'powered_off', 'restarted']:
             state_result = power_state(vm, state, force)
@@ -1842,6 +1933,7 @@ def main():
                 guest=guest,
                 vm=vm,
                 force=force)
+            
 
     # VM doesn't exist
     else:


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vsphere_guest

##### ANSIBLE VERSION
ansible 2.3.0 (devel)

##### SUMMARY
The vsphere_guest module lacks the ability to handle snapshot operations of vmware guests. This is an initial effort for the feature request(https://github.com/ansible/ansible-modules-core/issues/4942).

EXAMPLES:
### List all snapshots

```
vsphere_guest:
    vcenter_hostname: <hostname>
    username: <username>
    password: <password>
    validate_certs: False
    guest: <vm_name>
    snapshot_op:
        op_type: list_all
```
### Remove a snapshot

```
 snapshot_op:
     op_type: remove
     name: <snapshot_name_to_delete>
```
### Create a snapshot

```
 snapshot_op:
     op_type: create
     name: <snapshot_name_to_create>
     description: <snapshot_description>
```
### Revert snapshot

```
 snapshot_op:
     op_type: revert
     name: <snapshot_name_to_revert>
```
### List current snapshot of a VM

```
 snapshot_op:
     op_type: list_current
```
