### PR TITLE
[WIP] Add docs for new client cert authentication

### DIFF
--- a/network/basics/get_url.py
+++ b/network/basics/get_url.py
@@ -156,6 +156,22 @@ options:
     required: false
     choices: [ "yes", "no" ]
     default: "no"
+  client_cert:
+    required: false
+    default: null
+    description:
+      - PEM formatted certificate chain file to be used for SSL client
+        authentication. This file can also include the key as well, and if
+        the key is included, I(client_cert_key) is not required
+    version_added: 2.3
+  client_cert_key:
+    required: false
+    default: null
+    description:
+      - PEM formatted file that contains your private key to be used for SSL
+        client authentication. If I(client_cert) contains both the certificate
+        and key, this option is not required.
+    version_added: 2.3
   others:
     description:
       - all arguments accepted by the M(file) module also work here

--- a/network/basics/uri.py
+++ b/network/basics/uri.py
@@ -160,6 +160,22 @@ options:
     default: 'yes'
     choices: ['yes', 'no']
     version_added: '1.9.2'
+  client_cert:
+    required: false
+    default: null
+    description:
+      - PEM formatted certificate chain file to be used for SSL client
+        authentication. This file can also include the key as well, and if
+        the key is included, I(client_cert_key) is not required
+    version_added: 2.3
+  client_cert_key:
+    required: false
+    default: null
+    description:
+      - PEM formatted file that contains your private key to be used for SSL
+        client authentication. If I(client_cert) contains both the certificate
+        and key, this option is not required.
+    version_added: 2.3
 notes:
   - The dependency on httplib2 was removed in Ansible 2.1
 author: "Romeo Theriault (@romeotheriault)"


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### COMPONENT NAME

uri
get_url
##### ANSIBLE VERSION

```
v2.3
```
##### SUMMARY

Adds documentation for `client_cert` and `client_cert_key`.  Depends on https://github.com/ansible/ansible/pull/18141
