### PR TITLE
adding id: back to documentation fixes #2280

### DIFF
--- a/cloud/amazon/ec2.py
+++ b/cloud/amazon/ec2.py
@@ -29,6 +29,13 @@ options:
     required: false
     default: null
     aliases: ['keypair']
+  id:        
+    version_added: "1.1"
+    description:        
+      - identifier for this instance or set of instances, so that the module will be idempotent with respect to EC2 instances. This identifier is valid for at least 24 hours after the termination of the instance, and should not be reused for another call later on. For details, see the description of client token at U(http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Run_Instance_Idempotency.html).        
+    required: false        
+    default: null        
+    aliases: []        
   group:
     description:
       - security group (or list of groups) to use with the instance


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

ec2 module
##### ANSIBLE VERSION

```
ansible 2.3.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Ansible docs do not explain the idempotent use of the ec2 module.  Adding back the description of the "id" field for the convenience of future users.
