### PR TITLE
Remove the neccesity of sizes when replace

### DIFF
--- a/cloud/amazon/ec2_asg.py
+++ b/cloud/amazon/ec2_asg.py
@@ -648,12 +648,9 @@ def replace(connection, module):
     # check to see if instances are replaceable if checking launch configs
 
     #check if min_size/max_size/desired capacity have been specified and if not use ASG values
-    if min_size is None:
-        min_size = as_group.min_size
-    if max_size is None:
-        max_size = as_group.max_size
-    if desired_capacity is None:
-        desired_capacity = as_group.desired_capacity
+    min_size = as_group.min_size
+    max_size = as_group.max_size
+    desired_capacity = as_group.desired_capacity
 
     new_instances, old_instances = get_instances_by_lc(props, lc_check, instances)
     num_new_inst_needed = desired_capacity - len(new_instances)
@@ -758,7 +755,7 @@ def terminate_batch(connection, module, min_size, desired_capacity, replace_inst
     as_group = connection.get_all_groups(names=[group_name])[0]
     props = get_properties(as_group)
     desired_size = as_group.min_size
-    
+
     new_instances, old_instances = get_instances_by_lc(props, lc_check, initial_instances)
     num_new_inst_needed = desired_capacity - len(new_instances)
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

ec2_asg module

##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.2.0
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Remove the neccesity to provide min_size and desired_size when enabling replace_instance using this module.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```

```

Previously, you need to specify sizes when use replace instances.
