### PR TITLE
Fix ignore_image option not work correctly.

### DIFF
--- a/cloud/docker/docker_container.py
+++ b/cloud/docker/docker_container.py
@@ -1167,7 +1167,7 @@ class Container(DockerBaseClass):
                 return True
         return False
 
-    def has_different_configuration(self, image):
+    def has_different_configuration(self, image, **kwargs):
         '''
         Diff parameters vs existing container config. Returns tuple: (True | False, List of differences)
         '''
@@ -1247,6 +1247,9 @@ class Container(DockerBaseClass):
             volumes_from=host_config.get('VolumesFrom'),
             volume_driver=host_config.get('VolumeDriver')
         )
+
+        if kwargs.get('ignore_image', False):
+            del config_mapping['image']
 
         differences = []
         for key, value in config_mapping.iteritems():
@@ -1674,9 +1677,10 @@ class ContainerManager(DockerBaseClass):
                 container = new_container
         else:
             # Existing container
-            different, differences = container.has_different_configuration(image)
+            ignore_image = self.parameters.ignore_image
+            different, differences = container.has_different_configuration(image, ignore_image=ignore_image)
             image_different = False
-            if not self.parameters.ignore_image:
+            if not ignore_image:
                 image_different = self._image_is_different(image, container)
             if image_different or different or self.parameters.recreate:
                 self.diff['differences'] = differences


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

cloud/docker/docker_container.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.3.0 (devel 680cade77a) last updated 2016/10/27 14:55:40 (GMT +800)
  lib/ansible/modules/core: (detached HEAD c51ced56cc) last updated 2016/10/27 14:58:15 (GMT +800)
  lib/ansible/modules/extras: (detached HEAD 8ffe314ea5) last updated 2016/10/27 14:58:15 (GMT +800)
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

I have two docker images with same image ID but different image tag:

```
➜  ~ docker images | grep nginx 
nginx                                  1.10.2              54d9f6a22b41        7 days ago          180.7 MB
nginx                                  1.10.3              54d9f6a22b41        7 days ago          180.7 MB
```

And I have a running docker container belongs to nginx:1.10.2

```
➜  ~ docker ps
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS               NAMES
136914b076a7        nginx:1.10.2        "nginx -g 'daemon off"   5 hours ago         Up 5 hours          80/tcp, 443/tcp     nginx
```

Playbook:

```

---
- hosts: localhost
  tasks:
  - name: Test ignore_image
    docker_container: 
      name: nginx
      image: nginx:1.10.3
      ignore_image: true
      state: started
```

After execute the playbook, the running docker container becomes to nginx:1.10.3

```
➜  ~ ansible-playbook test.yml

PLAY [localhost] ***************************************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [Test ignore_image] *******************************************************
changed: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0

➜  ~ docker ps
CONTAINER ID        IMAGE               COMMAND                  CREATED              STATUS              PORTS               NAMES
696327d6e4d2        nginx:1.10.3        "nginx -g 'daemon off"   About a minute ago   Up About a minute   80/tcp, 443/tcp     nginx
```

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Currently the ignore_image option can be set, but can not work as it is descripted in document. 
The reason is the code will check the difference of configurations between current container and target image, and it will mark the `different` to `True` when the image is different even we set `ignore_image=true`, that will cause the container being re-create.

So my solutions is ignore the difference of image when comparing the configurations of current docker container and target docker image.
