### PR TITLE
vsphere_guest : fix issue #4755 - Defining more than 7 disks using vm_disk causes an error and fails VM creation.

### DIFF
--- a/cloud/vmware/vsphere_guest.py
+++ b/cloud/vmware/vsphere_guest.py
@@ -1343,6 +1343,8 @@ def create_vm(vsphere_client, module, esxi, resource_pool, cluster_name, guest, 
     if vm_disk:
         disk_num = 0
         disk_key = 0
+        bus_num = 0
+        disk_ctrl = 1
         for disk in sorted(vm_disk):
             try:
                 datastore = vm_disk[disk]['datastore']
@@ -1365,6 +1367,16 @@ def create_vm(vsphere_client, module, esxi, resource_pool, cluster_name, guest, 
                 module.fail_json(
                     msg="Error on %s definition. type needs to be"
                     " specified." % disk)
+            if disk_num == 7:
+                disk_num = disk_num + 1
+                disk_key = disk_key + 1
+            elif disk_num > 15:
+                bus_num = bus_num + 1
+                disk_ctrl = disk_ctrl + 1
+                disk_ctrl_key = add_scsi_controller(
+                    module, vsphere_client, config, devices, type=vm_hardware['scsi'], bus_num=bus_num, disk_ctrl_key=disk_ctrl)
+                disk_num = 0
+                disk_key = 0
             # Add the disk  to the VM spec.
             add_disk(
                 module, vsphere_client, config_target, config,


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

vsphere_guest
##### ANSIBLE VERSION

ansible 2.3.0
##### SUMMARY

Fixes the issue(https://github.com/ansible/ansible-modules-core/issues/4755) - Defining more than 7 disks using vm_disk causes an error and fails VM creation.
- Skips index 7 for disks, as by default the virtual SCSI controller is assigned to virtual device node (z:7)
- For more than 15 disks:
  - Automatically adds a required new SCSI controller & attach disks to it.
### Define vm_disk more than 15:

```
 vm_disk:
  disk1:  {datastore: "Storage1", size_gb: 1, type: "thin"}
  disk2:  {datastore: "Storage1", size_gb: 1, type: "thin"}
  disk3:  {datastore: "Storage1", size_gb: 1, type: "thin"}
  disk4:  {datastore: "Storage1", size_gb: 1, type: "thin"}
  .
  .
  .
  disk29:  {datastore: "Storage1", size_gb: 1, type: "thin"}
  disk30:  {datastore: "Storage1", size_gb: 1, type: "thin"}
  disk31:  {datastore: "Storage1", size_gb: 1, type: "thin"}
  disk32:  {datastore: "Storage1", size_gb: 1, type: "thin"}
```
## BEFORE:

```
_Traceback (most recent call last):
  File "/tmp/ansible_fTxUMO/ansible_module_vsphere_guest.py", line 1909, in <module>
    main()
  File "/tmp/ansible_fTxUMO/ansible_module_vsphere_guest.py", line 1897, in main
    state=state
  File "/tmp/ansible_fTxUMO/ansible_module_vsphere_guest.py", line 1446, in create_vm
    task.get_error_message())
  File "/usr/local/lib/python2.7/site-packages/pysphere/vi_task.py", line 82, in get_error_message
    self.__poll_task_info()
  File "/usr/local/lib/python2.7/site-packages/pysphere/vi_task.py", line 120, in __poll_task_info
    raise e
pysphere.resources.vi_exception.VIException: [Not Connected]: Must call 'connect' before invoking this method_
```
## AFTER:

```
_TASK [vsphere_guest] ***********************************************************
changed: [localhost] => {"ansible_facts": {"hw_guest_full_name": "CentOS 4/5/6/7 (64-bit)", "hw_guest_id": "centos64Guest", "hw_interfaces": [], "hw_memtotal_mb": 512, "hw_name": "newvm001", "hw_power_status": "POWERED OFF", "hw_processor_count": 1, "hw_product_uuid": "564d248f-fea1-2d17-6a6e-58a31ea2998d", "module_hw": true}, "changed": true, "changes": "Created VM newvm001"}_
```
