### PR TITLE
fix JSON junk in win_file state=directory case

### DIFF
--- a/windows/win_file.ps1
+++ b/windows/win_file.ps1
@@ -102,7 +102,7 @@ Else
 
     If ( $state -eq "directory" )
     {
-        New-Item -ItemType directory -Path $path
+        New-Item -ItemType directory -Path $path | Out-Null
         $result.changed = $TRUE
     }
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

win_file
##### SUMMARY

Fixes spurious warning `[WARNING]: Module invocation had junk after the JSON data:` when state=directory and directory was created. 
