### PR TITLE
ios_mods - added stdout to exception output. Removed to_lines()

### DIFF
--- a/network/ios/ios_command.py
+++ b/network/ios/ios_command.py
@@ -148,12 +148,6 @@ from ansible.module_utils.six import string_types
 
 VALID_KEYS = ['command', 'prompt', 'response']
 
-def to_lines(stdout):
-    for item in stdout:
-        if isinstance(item, string_types):
-            item = str(item).split('\n')
-        yield item
-
 def parse_commands(module):
     for cmd in module.params['commands']:
         if isinstance(cmd, string_types):
@@ -216,7 +210,9 @@ def main():
         module.fail_json(msg=str(exc), failed_conditions=exc.failed_conditions)
     except NetworkError:
         exc = get_exception()
-        module.fail_json(msg=str(exc))
+        module.disconnect()
+        module.fail_json(msg=str(exc), stdout=exc.kwargs.get('stdout'))
+
 
     result = dict(changed=False, stdout=list())
 
@@ -228,7 +224,6 @@ def main():
         result['stdout'].append(output)
 
     result['warnings'] = warnings
-    result['stdout_lines'] = list(to_lines(result['stdout']))
 
     module.exit_json(**result)
 

--- a/network/ios/ios_config.py
+++ b/network/ios/ios_config.py
@@ -323,7 +323,7 @@ def main():
     except NetworkError:
         exc = get_exception()
         module.disconnect()
-        module.fail_json(msg=str(exc))
+        module.fail_json(msg=str(exc), stdout=exc.kwargs.get('stdout'))
 
     module.disconnect()
     module.exit_json(**result)


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

ios_config, ios_command
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.3.0 (fix_command_timeout 886f146de9) last updated 2016/10/28 15:10:13 (GMT -400)
  lib/ansible/modules/core: (fix_command_timeout 44015020d4) last updated 2016/10/28 15:41:52 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 8ffe314ea5) last updated 2016/10/25 15:34:40 (GMT -400)
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

stdout lines are now available when certain exceptions occur (Depends on ansible/ansible#18241)

Also noticed that to_lines was essentially handled in lib/ansible/plugins/action/**init**.py -- only difference was it didn't handle a list.  to_lines() could be removed across network modules now, but this commit is only for ios_command.

Also adds disconnect() to ios_command that was added to ios_config in #5247 

Note: the to_lines() function could likely be removed from all network modules.  This PR only handled the ios_command copy.

NB: This is my first time dealing with submitting two PRs across the sub-modules, so please be kind if I was remiss in how I did this.
