### PR TITLE
fix the behavior of copy module using "force" args

### DIFF
--- a/files/copy.py
+++ b/files/copy.py
@@ -284,18 +284,19 @@ def main():
                 directory_args['mode'] = None
             adjust_recursive_directory_permissions(pre_existing_dir, new_directory_list, module, directory_args, changed)
 
+    if os.path.isdir(b_dest):
+        basename = os.path.basename(src)
+        if original_basename:
+            basename = original_basename
+        dest = os.path.join(dest, basename)
+        b_dest = to_bytes(dest, errors='surrogate_or_strict')
+
     if os.path.exists(b_dest):
         if os.path.islink(b_dest) and follow:
             b_dest = os.path.realpath(b_dest)
             dest = to_native(b_dest, errors='surrogate_or_strict')
         if not force:
             module.exit_json(msg="file already exists", src=src, dest=dest, changed=False)
-        if os.path.isdir(b_dest):
-            basename = os.path.basename(src)
-            if original_basename:
-                basename = original_basename
-            dest = os.path.join(dest, basename)
-            b_dest = to_bytes(dest, errors='surrogate_or_strict')
         if os.access(b_dest, os.R_OK):
             checksum_dest = module.sha1(dest)
     else:


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
copy

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

This fixes the behavior that the dest is directory,
when we set the "force: no" argument.
To be join the dest and the src's basename,
before checking the "force" argument.