### PR TITLE
Consistent path attribute for file-related modules

### DIFF
--- a/files/acl.py
+++ b/files/acl.py
@@ -23,12 +23,13 @@ short_description: Sets and retrieves file ACL information.
 description:
     - Sets and retrieves file ACL information.
 options:
-  name:
+  path:
     required: true
     default: null
     description:
       - The full path of the file or object.
-    aliases: ['path']
+    aliases: ['name', 'dest']
+    version_added: "historical"
 
   state:
     required: false
@@ -50,7 +51,7 @@ options:
     default: no
     choices: [ 'yes', 'no' ]
     description:
-      - if the target is a directory, setting this to yes will make it the default acl for entities created inside the directory. It causes an error if name is a file.
+      - if the target is a directory, setting this to yes will make it the default acl for entities created inside the directory. It causes an error if path is a file.
 
   entity:
     version_added: "1.5"
@@ -65,7 +66,6 @@ options:
     choices: [ 'user', 'group', 'mask', 'other' ]
     description:
       - the entity type of the ACL to apply, see setfacl documentation for more info.
-
 
   permissions:
     version_added: "1.5"
@@ -97,19 +97,19 @@ notes:
 
 EXAMPLES = '''
 # Grant user Joe read access to a file
-- acl: name=/etc/foo.conf entity=joe etype=user permissions="r" state=present
+- acl: path=/etc/foo.conf entity=joe etype=user permissions="r" state=present
 
 # Removes the acl for Joe on a specific file
-- acl: name=/etc/foo.conf entity=joe etype=user state=absent
+- acl: path=/etc/foo.conf entity=joe etype=user state=absent
 
 # Sets default acl for joe on foo.d
-- acl: name=/etc/foo.d entity=joe etype=user permissions=rw default=yes state=present
+- acl: path=/etc/foo.d entity=joe etype=user permissions=rw default=yes state=present
 
 # Same as previous but using entry shorthand
-- acl: name=/etc/foo.d entry="default:user:joe:rw-" state=present
+- acl: path=/etc/foo.d entry="default:user:joe:rw-" state=present
 
 # Obtain the acl for a specific file
-- acl: name=/etc/foo.conf
+- acl: path=/etc/foo.conf
   register: acl_info
 '''
 
@@ -235,7 +235,7 @@ def run_acl(module, cmd, check_rc=True):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            name=dict(required=True, aliases=['path'], type='path'),
+            path=dict(required=True, aliases=['dest', 'name'], type='path'),
             entry=dict(required=False, type='str'),
             entity=dict(required=False, type='str', default=''),
             etype=dict(
@@ -261,7 +261,7 @@ def main():
     if get_platform().lower() not in ['linux', 'freebsd']:
         module.fail_json(msg="The acl module is not available on this system.")
 
-    path = module.params.get('name')
+    path = module.params.get('path')
     entry = module.params.get('entry')
     entity = module.params.get('entity')
     etype = module.params.get('etype')

--- a/files/file.py
+++ b/files/file.py
@@ -41,6 +41,7 @@ options:
     required: true
     default: []
     aliases: ['dest', 'name']
+    version_added: "historical"
   state:
     description:
       - If C(directory), all immediate subdirectories will be created if they

--- a/files/ini_file.py
+++ b/files/ini_file.py
@@ -32,11 +32,13 @@ description:
      - Before version 2.0, comments are discarded when the source file is read, and therefore will not show up in the destination file.
 version_added: "0.9"
 options:
-  dest:
+  path:
     description:
       - Path to the INI-style file; this file is created if required
     required: true
     default: null
+    aliases: ['dest', 'name']
+    version_added: "historical"
   section:
     description:
       - Section name in INI file. This is added if C(state=present) automatically when
@@ -100,9 +102,9 @@ author:
 
 EXAMPLES = '''
 # Ensure "fav=lemonade is in section "[drinks]" in specified file
-- ini_file: dest=/etc/conf section=drinks option=fav value=lemonade mode=0600 backup=yes
+- ini_file: path=/etc/conf section=drinks option=fav value=lemonade mode=0600 backup=yes
 
-- ini_file: dest=/etc/anotherconf
+- ini_file: path=/etc/anotherconf
             section=drinks
             option=temperature
             value=cold
@@ -250,7 +252,7 @@ def main():
 
     module = AnsibleModule(
         argument_spec = dict(
-            dest = dict(required=True),
+            path = dict(required=True, aliases=['dest', 'name'], type='path'),
             section = dict(required=True),
             option = dict(required=False),
             value = dict(required=False),
@@ -263,7 +265,7 @@ def main():
         supports_check_mode = True
     )
 
-    dest = os.path.expanduser(module.params['dest'])
+    path = os.path.expanduser(module.params['path'])
     section = module.params['section']
     option = module.params['option']
     value = module.params['value']
@@ -272,13 +274,13 @@ def main():
     no_extra_spaces = module.params['no_extra_spaces']
     create = module.params['create']
 
-    (changed,backup_file,diff,msg) = do_ini(module, dest, section, option, value, state, backup, no_extra_spaces, create)
+    (changed,backup_file,diff,msg) = do_ini(module, path, section, option, value, state, backup, no_extra_spaces, create)
 
-    if not module.check_mode and os.path.exists(dest):
+    if not module.check_mode and os.path.exists(path):
         file_args = module.load_file_common_arguments(module.params)
         changed = module.set_fs_attributes_if_different(file_args, changed)
 
-    results = { 'changed': changed, 'msg': msg, 'dest': dest, 'diff': diff }
+    results = { 'changed': changed, 'msg': msg, 'path': path, 'diff': diff }
     if backup_file is not None:
         results['backup_file'] = backup_file
 

--- a/files/stat.py
+++ b/files/stat.py
@@ -27,6 +27,8 @@ options:
       - The full path of the file/object to get the facts of
     required: true
     default: null
+    aliases: ['dest', 'name']
+    version_added: "historical"
   follow:
     description:
       - Whether to follow symlinks
@@ -397,7 +399,7 @@ def format_output(module, path, st):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            path=dict(required=True, type='path'),
+            path=dict(required=True, aliases=['dest', 'name'], type='path'),
             follow=dict(default='no', type='bool'),
             get_md5=dict(default='yes', type='bool'),
             get_checksum=dict(default='yes', type='bool'),

--- a/files/xattr.py
+++ b/files/xattr.py
@@ -23,12 +23,13 @@ description:
      - Manages filesystem user defined extended attributes, requires that they are enabled
        on the target filesystem and that the setfattr/getfattr utilities are present.
 options:
-  name:
+  path:
     required: true
     default: None
-    aliases: ['path']
+    aliases: ['dest', 'name']
     description:
       - The full path of the file/object to get the facts of
+    version_added: "historical"
   key:
     required: false
     default: None
@@ -63,13 +64,13 @@ author: "Brian Coca (@bcoca)"
 
 EXAMPLES = '''
 # Obtain the extended attributes  of /etc/foo.conf
-- xattr: name=/etc/foo.conf
+- xattr: path=/etc/foo.conf
 
 # Sets the key 'foo' to value 'bar'
 - xattr: path=/etc/foo.conf key=user.foo value=bar
 
 # Removes the key 'foo'
-- xattr: name=/etc/foo.conf key=user.foo state=absent
+- xattr: path=/etc/foo.conf key=user.foo state=absent
 '''
 
 import operator
@@ -145,7 +146,7 @@ def _run_xattr(module,cmd,check_rc=True):
 def main():
     module = AnsibleModule(
         argument_spec = dict(
-            name = dict(required=True, aliases=['path'], type='path'),
+            path = dict(required=True, aliases=['dest', 'name'], type='path'),
             key = dict(required=False, default=None, type='str'),
             value = dict(required=False, default=None, type='str'),
             state = dict(required=False, default='read', choices=[ 'read', 'present', 'all', 'keys', 'absent' ], type='str'),
@@ -153,7 +154,7 @@ def main():
         ),
         supports_check_mode=True,
     )
-    path = module.params.get('name')
+    path = module.params.get('path')
     key = module.params.get('key')
     value = module.params.get('value')
     state = module.params.get('state')

--- a/windows/win_lineinfile.ps1
+++ b/windows/win_lineinfile.ps1
@@ -25,7 +25,7 @@ $params = Parse-Args $args;
 
 # Initialize defaults for input parameters.
 
-$dest= Get-Attr $params "dest" $FALSE;
+$path = Get-Attr $params "path" $FALSE;
 $regexp = Get-Attr $params "regexp" $FALSE;
 $state = Get-Attr $params "state" "present";
 $line = Get-Attr $params "line" $FALSE;
@@ -39,32 +39,34 @@ $encoding = Get-Attr $params "encoding" "auto";
 $newline = Get-Attr $params "newline" "windows";
 
 
-# Parse dest / name /destfile param aliases for compatibility with lineinfile
+# Parse path / dest / destfile / name param aliases for compatibility with lineinfile
 # and fail if at least one spelling of the parameter is not provided.
 
-$dest = Get-Attr $params "dest" $FALSE;
-If ($dest -eq $FALSE) {
-    $dest = Get-Attr $params "name" $FALSE;
-    If ($dest -eq $FALSE) {
-        $dest = Get-Attr $params "destfile" $FALSE;
-        If ($dest -eq $FALSE) {
-            Fail-Json (New-Object psobject) "missing required argument: dest";
+If ($path -eq $FALSE) {
+    $path = Get-Attr $params "dest" $FALSE;
+    If ($path -eq $FALSE) {
+        $path = Get-Attr $params "destfile" $FALSE;
+        If ($path -eq $FALSE) {
+            $path = Get-Attr $params "name" $FALSE;
+            If ($path -eq $FALSE) {
+                Fail-Json (New-Object psobject) "missing required argument: path";
+            }
         }
     }
 }
 
 
-# Fail if the destination is not a file
+# Fail if the path is not a file
 
-If (Test-Path $dest -pathType container) {
-    Fail-Json (New-Object psobject) "destination is a directory";
+If (Test-Path $path -pathType container) {
+    Fail-Json (New-Object psobject) "path is a directory";
 }
 
 
 # Write lines to a file using the specified line separator and encoding, 
 # performing validation if a validation command was specified.
 
-function WriteLines($outlines, $dest, $linesep, $encodingobj, $validate) {
+function WriteLines($outlines, $path, $linesep, $encodingobj, $validate) {
 	$temppath = [System.IO.Path]::GetTempFileName();
 	$joined = $outlines -join $linesep;
 	[System.IO.File]::WriteAllText($temppath, $joined, $encodingobj);
@@ -95,8 +97,8 @@ function WriteLines($outlines, $dest, $linesep, $encodingobj, $validate) {
 	}
 	
 	# Commit changes to the destination file
-	$cleandest = $dest.Replace("/", "\");
-	Copy-Item $temppath $cleandest -force;	
+	$cleanpath = $path.Replace("/", "\");
+	Copy-Item $temppath $cleanpath -force;	
 	Remove-Item $temppath -force;
 }
 
@@ -113,24 +115,24 @@ function BackupFile($path) {
 
 # Implement the functionality for state == 'present'
 
-function Present($dest, $regexp, $line, $insertafter, $insertbefore, $create, $backup, $backrefs, $validate, $encodingobj, $linesep) {
+function Present($path, $regexp, $line, $insertafter, $insertbefore, $create, $backup, $backrefs, $validate, $encodingobj, $linesep) {
 
-	# Note that we have to clean up the dest path because ansible wants to treat / and \ as 
+	# Note that we have to clean up the path because ansible wants to treat / and \ as 
 	# interchangable in windows pathnames, but .NET framework internals do not support that.
-	$cleandest = $dest.Replace("/", "\");
+	$cleanpath = $path.Replace("/", "\");
 
-	# Check if destination exists. If it does not exist, either create it if create == "yes"
+	# Check if path exists. If it does not exist, either create it if create == "yes"
 	# was specified or fail with a reasonable error message.
-	If (!(Test-Path $dest)) {
+	If (!(Test-Path $path)) {
 		If ($create -eq "no") {
-			Fail-Json (New-Object psobject) "Destination $dest does not exist !";
+			Fail-Json (New-Object psobject) "Path $path does not exist !";
 		}
 		# Create new empty file, using the specified encoding to write correct BOM
-		[System.IO.File]::WriteAllLines($cleandest, "", $encodingobj);
+		[System.IO.File]::WriteAllLines($cleanpath, "", $encodingobj);
 	}
 
 	# Read the dest file lines using the indicated encoding into a mutable ArrayList.
-    $content = [System.IO.File]::ReadAllLines($cleandest, $encodingobj);
+    $content = [System.IO.File]::ReadAllLines($cleanpath, $encodingobj);
     If ($content -eq $null) {
 		$lines = New-Object System.Collections.ArrayList;
 	}
@@ -225,15 +227,15 @@ function Present($dest, $regexp, $line, $insertafter, $insertbefore, $create, $b
 	}
 
 	# Write backup file if backup == "yes"
-    $backupdest = "";
+    $backuppath = "";
 
 	If ($changed -eq $TRUE -and $backup -eq "yes") {
-		$backupdest = BackupFile $dest;
+		$backuppath = BackupFile $path;
 	}
 	
 	# Write changes to the destination file if changes were made
 	If ($changed) {
-		WriteLines $lines $dest $linesep $encodingobj $validate;
+		WriteLines $lines $path $linesep $encodingobj $validate;
 	}
 
 	$encodingstr = $encodingobj.WebName;
@@ -242,7 +244,7 @@ function Present($dest, $regexp, $line, $insertafter, $insertbefore, $create, $b
 	$result = New-Object psobject @{
     	changed = $changed
 		msg = $msg
-		backup = $backupdest
+		backup = $backuppath
 		encoding = $encodingstr
 	}
 	
@@ -252,19 +254,19 @@ function Present($dest, $regexp, $line, $insertafter, $insertbefore, $create, $b
 
 # Implement the functionality for state == 'absent'
 
-function Absent($dest, $regexp, $line, $backup, $validate, $encodingobj, $linesep) {
+function Absent($path, $regexp, $line, $backup, $validate, $encodingobj, $linesep) {
 
-	# Check if destination exists. If it does not exist, fail with a reasonable error message.
-	If (!(Test-Path $dest)) {
-		Fail-Json (New-Object psobject) "Destination $dest does not exist !";
+	# Check if path exists. If it does not exist, fail with a reasonable error message.
+	If (!(Test-Path $path)) {
+		Fail-Json (New-Object psobject) "Path $path does not exist !";
 	}
 
 	# Read the dest file lines using the indicated encoding into a mutable ArrayList. Note
-	# that we have to clean up the dest path because ansible wants to treat / and \ as 
+	# that we have to clean up the path because ansible wants to treat / and \ as 
 	# interchangeable in windows pathnames, but .NET framework internals do not support that.
 	 
-	$cleandest = $dest.Replace("/", "\");
-    $content = [System.IO.File]::ReadAllLines($cleandest, $encodingobj);
+	$cleanpath = $path.Replace("/", "\");
+    $content = [System.IO.File]::ReadAllLines($cleanpath, $encodingobj);
     If ($content -eq $null) {
 		$lines = New-Object System.Collections.ArrayList;
 	}
@@ -303,15 +305,15 @@ function Absent($dest, $regexp, $line, $backup, $validate, $encodingobj, $linese
 	}
 
 	# Write backup file if backup == "yes"
-    $backupdest = "";
+    $backuppath  = "";
 
 	If ($changed -eq $TRUE -and $backup -eq "yes") {
-		$backupdest = BackupFile $dest;
+		$backuppath = BackupFile $path;
 	}
 	
 	# Write changes to the destination file if changes were made
 	If ($changed) {
-		WriteLines $left $dest $linesep $encodingobj $validate;
+		WriteLines $left $path $linesep $encodingobj $validate;
 	}
 
 	# Return result information
@@ -322,7 +324,7 @@ function Absent($dest, $regexp, $line, $backup, $validate, $encodingobj, $linese
 	$result = New-Object psobject @{
     	changed = $changed
 		msg = $msg
-		backup = $backupdest
+		backup = $backuppath
 		found = $fcount
 		encoding = $encodingstr
 	}
@@ -362,7 +364,7 @@ If ($encoding -ne "auto") {
 # Otherwise see if we can determine the current encoding of the target file.
 # If the file doesn't exist yet (create == 'yes') we use the default or 
 # explicitly specified encoding set above.
-Elseif (Test-Path $dest) {
+Elseif (Test-Path $path) {
 
 	# Get a sorted list of encodings with preambles, longest first
 
@@ -426,7 +428,7 @@ If ($state -eq "present") {
 		$insertafter = "EOF";
 	}
 
-	Present $dest $regexp $line $insertafter $insertbefore $create $backup $backrefs $validate $encodingobj $linesep;
+	Present $path $regexp $line $insertafter $insertbefore $create $backup $backrefs $validate $encodingobj $linesep;
 
 }
 Else {
@@ -435,22 +437,5 @@ Else {
 		Fail-Json (New-Object psobject) "one of line= or regexp= is required with state=absent";
 	}
 	
-	Absent $dest $regexp $line $backup $validate $encodingobj $linesep;
+	Absent $path $regexp $line $backup $validate $encodingobj $linesep;
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/windows/win_lineinfile.py
+++ b/windows/win_lineinfile.py
@@ -26,9 +26,9 @@ description:
   - This is primarily useful when you want to change a single line in a file only.
 version_added: "2.0"
 options:
-  dest:
+  path:
     required: true
-    aliases: [ name, destfile ]
+    aliases: [ dest, destfile, name ]
     description:
       - The path of the file to modify.
       - Note that the Windows path delimiter '\' must be escaped as '\\' (see examples below)
@@ -100,20 +100,20 @@ options:
 """
 
 EXAMPLES = """
-- win_lineinfile: dest=C:\\temp\\example.conf regexp=^name= line="name=JohnDoe"
+- win_lineinfile: path=C:\\temp\\example.conf regexp=^name= line="name=JohnDoe"
 
-- win_lineinfile: dest=C:\\temp\\example.conf state=absent regexp="^name="
+- win_lineinfile: path=C:\\temp\\example.conf state=absent regexp="^name="
 
-- win_lineinfile: dest=C:\\temp\\example.conf regexp='^127\.0\.0\.1' line='127.0.0.1 localhost'
+- win_lineinfile: path=C:\\temp\\example.conf regexp='^127\.0\.0\.1' line='127.0.0.1 localhost'
 
-- win_lineinfile: dest=C:\\temp\\httpd.conf regexp="^Listen " insertafter="^#Listen " line="Listen 8080"
+- win_lineinfile: path=C:\\temp\\httpd.conf regexp="^Listen " insertafter="^#Listen " line="Listen 8080"
 
-- win_lineinfile: dest=C:\\temp\\services regexp="^# port for http" insertbefore="^www.*80/tcp" line="# port for http by default"
+- win_lineinfile: path=C:\\temp\\services regexp="^# port for http" insertbefore="^www.*80/tcp" line="# port for http by default"
 
 # Create file if it doesn't exist with a specific encoding
-- win_lineinfile: dest=C:\\temp\\utf16.txt create="yes" encoding="utf-16" line="This is a utf-16 encoded file"
+- win_lineinfile: path=C:\\temp\\utf16.txt create="yes" encoding="utf-16" line="This is a utf-16 encoded file"
 
 # Add a line to a file and ensure the resulting file uses unix line separators
-- win_lineinfile: dest=C:\\temp\\testfile.txt line="Line added to file" newline="unix"
+- win_lineinfile: path=C:\\temp\\testfile.txt line="Line added to file" newline="unix"
 
 """


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
acl, ini_file, lineinfile, replace, stat, xattr

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

Not all file-related modules consistently use "path" as the attribute to
specify a single filename, some use "dest", others use "name". Most do
have aliases for either "name" or "destfile".

This change makes "path" the default attribute for (single) file-related
modules, but also adds "dest" and "name" as aliases, so that people can
use a consistent way of attributing paths, but also to ensure backward
compatibility with existing playbooks.

If this is acceptable, I don't mind doing the same for the extras
repository, and other modules.