### PR TITLE
Fix `postgresql_user` module to treat quoted identifier well

### DIFF
--- a/database/postgresql/postgresql_user.py
+++ b/database/postgresql/postgresql_user.py
@@ -377,7 +377,7 @@ def get_database_privileges(cursor, user, db):
     datacl = cursor.fetchone()[0]
     if datacl is None:
         return set()
-    r = re.search('%s=(C?T?c?)/[a-z]+\,?' % user, datacl)
+    r = re.search('%s\\\\?\"?=(C?T?c?)/[^,]+\,?' % user, datacl)
     if r is None:
         return set()
     o = set()


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`postgresql_user` module

##### ANSIBLE VERSION
```
ansible 2.1.2.0
  config file = /Users/aleksandr.vinokurov/.ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Failed regex updated to respect escaped quotes for the quoted identifiers. Also pattern for granter of the permissions made more open. Fixes #5441 

##### CHECK RUN
```
echo "First run"
ansible POSTGRES_BOX -i inventory -m postgresql_user -a "name=foo-bar db=foo-bar port=5432 priv='ALL' state=present" --one-line

echo "Second run"
ansible POSTGRES_BOX -i inventory -m postgresql_user -a "name=foo-bar db=foo-bar port=5432 priv='ALL' state=present" --one-line
```

##### ACTUAL RESULTS
```
First run
POSTGRES_BOX | SUCCESS => {"changed": true, "user": "foo-bar"}
Second run
POSTGRES_BOX | SUCCESS => {"changed": true, "user": "foo-bar"}
```

##### AFTER THE FIX
```
First run
POSTGRES_BOX | SUCCESS => {"changed": true, "user": "foo-bar"}
Second run
POSTGRES_BOX | SUCCESS => {"changed": false, "user": "foo-bar"}
```

