### PR TITLE
[DOC FIX] Route 53 SRV record is example is wrong.

### DIFF
--- a/cloud/amazon/route53.py
+++ b/cloud/amazon/route53.py
@@ -203,7 +203,7 @@ EXAMPLES = '''
       "zone": "foo.com"
       "record": "_example-service._tcp.foo.com"
       "type": "SRV"
-      "value": ["0 0 22222 host1.foo.com", "0 0 22222 host2.foo.com"]
+      "value": 0 0 22222 host1.foo.com, 0 0 22222 host2.foo.com
 
 # Add a TXT record. Note that TXT and SPF records must be surrounded
 # by quotes when sent to Route 53:


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
route53

##### ANSIBLE VERSION
```
ansible 2.2.0 (devel 811fc385ee) last updated 2016/08/31 11:42:18 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 958d894c61) last updated 2016/08/31 11:42:23 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 3867cc71a6) last updated 2016/08/31 11:42:26 (GMT -400)
  config file = /Users/ecarter/work/github-ansible-seatgeek/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Example is wrong. This is how I was able to properly add multiple route 53 SRV records to an Route 53 record