### PR TITLE
Adding missing param on nxos_portchannel

### DIFF
--- a/network/nxos/nxos_portchannel.py
+++ b/network/nxos/nxos_portchannel.py
@@ -331,7 +331,7 @@ def execute_config_command(commands, module):
                          error=str(clie), commands=commands)
     except AttributeError:
         try:
-            module.config.load_config(commands)
+            output = module.config.load_config(commands)
         except NetworkError:
             clie = get_exception()
             module.fail_json(msg='Error sending CLI commands',


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_portchannel

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Adding missing param