### PR TITLE
Add more specific language to apt_key description

### DIFF
--- a/packaging/os/apt_key.py
+++ b/packaging/os/apt_key.py
@@ -47,7 +47,7 @@ options:
         required: false
         default: none
         description:
-            - path to a keyfile to add to the keyring
+            - path to a keyfile on the remote server to add to the keyring
     keyring:
         required: false
         default: none
@@ -102,6 +102,9 @@ EXAMPLES = '''
 
 # Add an Apt signing key to a specific keyring file
 - apt_key: id=473041FA url=https://ftp-master.debian.org/keys/archive-key-6.0.asc keyring=/etc/apt/trusted.gpg.d/debian.gpg state=present
+
+# Add Apt signing key on remote server to keyring
+- apt_key: id=473041FA file=/tmp/apt.gpg state=present
 '''
 
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
`apt_key` module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.1.1.0
  config file = 
  configured module search path = Default w/o overrides

```

##### SUMMARY

It was unclear to me if specifying the`file` parameter would upload a local key file before importing it, or if it referenced a path on the remote server. After checking out [the code](https://github.com/ansible/ansible-modules-core/blob/1182d1f/packaging/os/apt_key.py#L246) it became clear that this only works with remote file paths. I added a few words to the `file` parameter's comment section, and added an example.

##### COMMIT MESSAGE

* Add 'on the remote server' to `file` parameter description
* Add example showing how to use the `file` parameter, with specific
  language about the file's location being on the 'remote server'