### PR TITLE
Attach an attached/detached volume from OpenStack VM’s should return similar information

### DIFF
--- a/cloud/openstack/os_server_volume.py
+++ b/cloud/openstack/os_server_volume.py
@@ -116,11 +116,10 @@ def main():
             module.exit_json(changed=_system_state_change(state, dev))
 
         if state == 'present':
-            if dev:
-                # Volume is already attached to this server
-                module.exit_json(changed=False)
-
-            cloud.attach_volume(server, volume, module.params['device'],
+            changed = False
+            if not dev:
+                changed = True
+                cloud.attach_volume(server, volume, module.params['device'],
                                 wait=wait, timeout=timeout)
 
             server = cloud.get_server(module.params['server'])  # refresh
@@ -128,7 +127,7 @@ def main():
             hostvars = meta.get_hostvars_from_server(cloud, server)
 
             module.exit_json(
-                changed=True,
+                changed=changed,
                 id=volume['id'],
                 attachments=volume['attachments'],
                 openstack=hostvars


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
os_server_volume

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.1.1.0
  config file = /vagrant/provision/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Currently, attach an attached volume from OpenStack VM’s returns only
argument data. It is better to return full data as attaching a detached
volume.

In my use case, I need the extra data to mount and format the volume.
<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before change:
```
ok: [localhost] => {
    "attach_result": {
        "changed": false, 
        "msg": "All items completed", 
        "results": [
            {
                "_ansible_item_result": true, 
                "_ansible_no_log": false, 
                "changed": false, 
                "invocation": {
                    "module_args": {
                        "api_timeout": null, 
                        "auth": null, 
                        "auth_type": null, 
                        "availability_zone": null, 
                        "cacert": null, 
                        "cert": null, 
                        "cloud": null, 
                        "device": null, 
                        "endpoint_type": "public", 
                        "key": null, 
                        "region_name": null, 
                        "server": "xxx-yyy-zzz", 
                        "state": "present", 
                        "timeout": 180, 
                        "verify": true, 
                        "volume": "xxx-yyy-zzz-backup", 
                        "wait": true
                    }, 
                    "module_name": "os_server_volume"
                }, 
                "volume": {
                    "name": "backup", 
                    "size": 1
                }
            }
        ]
    }
}
```

After change:
```
ok: [localhost] => {
    "attach_result": {
        "changed": false, 
        "msg": "All items completed", 
        "results": [
            {
                "_ansible_item_result": true, 
                "_ansible_no_log": false, 
                "attachments": [
                    {
                        "attached_at": "2016-11-02T14:32:33.000000", 
                        "attachment_id": "771386ba-a28a-446b-b2d5-7748fec07dad", 
                        "device": "/dev/vdb", 
                        "host_name": null, 
                        "id": "1b20cbcc-08ba-4247-a000-2fbcc66ad3c5", 
                        "server_id": "22d67beb-8ad0-40a4-a85a-643c0ae847ca", 
                        "volume_id": "1b20cbcc-08ba-4247-a000-2fbcc66ad3c5"
                    }
                ], 
                "changed": false, 
                "id": "1b20cbcc-08ba-4247-a000-2fbcc66ad3c5", 
                "invocation": {
                    "module_args": {
                        "api_timeout": null, 
                        "auth": null, 
                        "auth_type": null, 
                        "availability_zone": null, 
                        "cacert": null, 
                        "cert": null, 
                        "cloud": null, 
                        "device": null, 
                        "endpoint_type": "public", 
                        "key": null, 
                        "region_name": null, 
                        "server": "xxx-yyy-zzz", 
                        "state": "present", 
                        "timeout": 180, 
                        "verify": true, 
                        "volume": "xxx-yyy-zzz-backup", 
                        "wait": true
                    }, 
                    "module_name": "os_server_volume"
                }, 
                "openstack": {
                    "HUMAN_ID": true, 
                    "NAME_ATTR": "name", 
                    "OS-DCF:diskConfig": "MANUAL", 
                    "OS-EXT-AZ:availability_zone": "cbk1", 
                    "OS-EXT-STS:power_state": 1, 
                    "OS-EXT-STS:task_state": null, 
                    "OS-EXT-STS:vm_state": "active", 
                    "OS-SRV-USG:launched_at": "2016-11-02T14:28:53.000000", 
                    "OS-SRV-USG:terminated_at": null, 
                    "accessIPv4": "", 
                    "accessIPv6": "", 
                    "addresses": {
                        "xxx-yyy-internal": [
                            {
                                "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:76:eb:db", 
                                "OS-EXT-IPS:type": "fixed", 
                                "addr": "192.168.0.95", 
                                "version": 4
                            }
                        ]
                    }, 
                    "az": "cbk1", 
                    "cloud": "int", 
                    "config_drive": "", 
                    "created": "2016-11-02T14:28:47Z", 
                    "flavor": {
                        "id": "368b9719-821c-4d4f-945d-4c2c569ae5d9", 
                        "name": "m1.micro"
                    }, 
                    "hostId": "434791113137d3015ab2c8692c230f8119bb158efac4244954f30254", 
                    "human_id": "xxx-yyy-zzz", 
                    "id": "22d67beb-8ad0-40a4-a85a-643c0ae847ca", 
                    "image": {
                        "id": "f28d7635-c122-4f4b-ae9a-9986b8a8c109", 
                        "name": "Ubuntu 14.04 sys11-cloudimg amd64"
                    }, 
                    "interface_ip": "", 
                    "key_name": "my_key_name", 
                    "metadata": {
                        "inventory_groups": "public, ungrouped", 
                        "inventory_hostname": "zzz"
                    }, 
                    "name": "xxx-yyy-zzz", 
                    "networks": {
                        "xxx-yyy-internal": [
                            "192.168.0.95"
                        ]
                    }, 
                    "os-extended-volumes:volumes_attached": [
                        {
                            "id": "1b20cbcc-08ba-4247-a000-2fbcc66ad3c5"
                        }
                    ], 
                    "private_v4": "192.168.0.95", 
                    "progress": 0, 
                    "public_v4": "", 
                    "public_v6": "", 
                    "region": "cbk", 
                    "request_ids": [], 
                    "security_groups": [
                        {
                            "description": "Default security group", 
                            "id": "3168822c-c8cd-4a46-9d28-82ec7a44f0d2", 
                            "name": "default", 
                            "security_group_rules": [
                                {
                                    "direction": "ingress", 
                                    "ethertype": "IPv4", 
                                    "id": "e69237ab-d9e7-40e4-8459-2ec0d2c7f95c", 
                                    "port_range_max": null, 
                                    "port_range_min": null, 
                                    "protocol": null, 
                                    "remote_ip_prefix": null, 
                                    "security_group_id": "3168822c-c8cd-4a46-9d28-82ec7a44f0d2"
                                }, 
                                {
                                    "direction": "ingress", 
                                    "ethertype": "IPv4", 
                                    "id": "e82a0b2b-2854-4ecb-ab32-c9b415310ed1", 
                                    "port_range_max": null, 
                                    "port_range_min": null, 
                                    "protocol": null, 
                                    "remote_ip_prefix": null, 
                                    "security_group_id": "3168822c-c8cd-4a46-9d28-82ec7a44f0d2"
                                }
                            ]
                        }
                    ], 
                    "status": "ACTIVE", 
                    "tenant_id": "c74b137638bf4eb2b62f3d18bbb88ae4", 
                    "updated": "2016-11-02T14:28:53Z", 
                    "user_id": "c4b89b1622cf4c21bb73865a55a856dd", 
                    "volumes": [
                        {
                            "HUMAN_ID": false, 
                            "NAME_ATTR": "name", 
                            "attachments": [
                                {
                                    "attached_at": "2016-11-02T14:32:33.000000", 
                                    "attachment_id": "771386ba-a28a-446b-b2d5-7748fec07dad", 
                                    "device": "/dev/vdb", 
                                    "host_name": null, 
                                    "id": "1b20cbcc-08ba-4247-a000-2fbcc66ad3c5", 
                                    "server_id": "22d67beb-8ad0-40a4-a85a-643c0ae847ca", 
                                    "volume_id": "1b20cbcc-08ba-4247-a000-2fbcc66ad3c5"
                                }
                            ], 
                            "availability_zone": "nova", 
                            "bootable": false, 
                            "consistencygroup_id": null, 
                            "created_at": "2016-11-02T14:30:05.000000", 
                            "description": null, 
                            "device": "/dev/vdb", 
                            "display_description": null, 
                            "display_name": "xxx-yyy-zzz-backup", 
                            "encrypted": false, 
                            "human_id": null, 
                            "id": "1b20cbcc-08ba-4247-a000-2fbcc66ad3c5", 
                            "links": [
                                {
                                    "href": "https://api.cbk.cloud.syseleven.net:8776/v2/c74b137638bf4eb2b62f3d18bbb88ae4/volumes/1b20cbcc-08ba-4247-a000-2fbcc66ad3c5", 
                                    "rel": "self"
                                }, 
                                {
                                    "href": "https://api.cbk.cloud.syseleven.net:8776/c74b137638bf4eb2b62f3d18bbb88ae4/volumes/1b20cbcc-08ba-4247-a000-2fbcc66ad3c5", 
                                    "rel": "bookmark"
                                }
                            ], 
                            "metadata": {
                                "attached_mode": "rw", 
                                "readonly": "False"
                            }, 
                            "multiattach": false, 
                            "name": "xxx-yyy-zzz-backup", 
                            "os-vol-tenant-attr:tenant_id": "c74b137638bf4eb2b62f3d18bbb88ae4", 
                            "replication_status": "disabled", 
                            "request_ids": [], 
                            "size": 1, 
                            "snapshot_id": null, 
                            "source_volid": null, 
                            "status": "in-use", 
                            "updated_at": "2016-11-02T14:32:33.000000", 
                            "user_id": "c4b89b1622cf4c21bb73865a55a856dd", 
                            "volume_type": "quobyte", 
                            "x_openstack_request_ids": []
                        }
                    ], 
                    "x_openstack_request_ids": []
                }, 
                "volume": {
                    "name": "backup", 
                    "size": 1
                }
            }
        ]
    }
}
```