### PR TITLE
fix for #4029 apt-get autoremove

### DIFF
--- a/packaging/os/apt.py
+++ b/packaging/os/apt.py
@@ -693,7 +693,7 @@ def remove(m, pkgspec, cache, purge=False, force=False,
         else:
             check_arg = ''
 
-        cmd = "%s -q -y %s %s %s %s %s remove %s" % (APT_GET_CMD, dpkg_options, purge, force_yes , check_arg, packages)
+        cmd = "%s -q -y %s %s %s %s remove %s" % (APT_GET_CMD, dpkg_options, purge, force_yes, check_arg, packages)
 
         rc, out, err = m.run_command(cmd)
         if m._diff:

--- a/packaging/os/apt.py
+++ b/packaging/os/apt.py
@@ -109,7 +109,8 @@ options:
     required: false
     default: no
     choices: [ "yes", "no" ]
-    version_added: "2.3"
+    aliases: [ 'autoclean']
+    version_added: "2.1"
   only_upgrade:
     description:
       - Only install/upgrade a package if it is already installed.
@@ -847,7 +848,7 @@ def main():
             dpkg_options = dict(default=DPKG_OPTIONS),
             only_upgrade = dict(type='bool', default=False),
             allow_unauthenticated = dict(default='no', aliases=['allow-unauthenticated'], type='bool'),
-            autoremove = dict(default='no', type='bool'),
+            autoremove = dict(default='no', type='bool',  aliases=['autoclean']),
         ),
         mutually_exclusive = [['package', 'upgrade', 'deb']],
         required_one_of = [['package', 'upgrade', 'update_cache', 'deb']],

--- a/packaging/os/apt.py
+++ b/packaging/os/apt.py
@@ -104,12 +104,12 @@ options:
      version_added: "1.6"
   autoremove:
     description:
-      - If C(yes), remove unused dependency packages for all module states except I(build-dep).
+      - If C(yes), remove all unused dependency packages for all module states.
+      - If C(yes) and package(s) name are provided, remove all provided package(s) with unused dependency.
     required: false
     default: no
     choices: [ "yes", "no" ]
-    aliases: [ 'autoclean']
-    version_added: "2.1"
+    version_added: "2.3"
   only_upgrade:
     description:
       - Only install/upgrade a package if it is already installed.
@@ -191,6 +191,9 @@ EXAMPLES = '''
 - name: Install a .deb package from the internet.
   apt:
     deb: https://example.com/python-ppq_0.1-1_all.deb
+- name: Autoremove all unused dependency.
+  apt:
+     autoremove: "yes"
 '''
 
 RETURN = '''
@@ -247,7 +250,9 @@ APT_ENV_VARS = dict(
 
 DPKG_OPTIONS = 'force-confdef,force-confold'
 APT_GET_ZERO = "\n0 upgraded, 0 newly installed"
+APT_AUTORM_GET_ZERO = "\n0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded"
 APTITUDE_ZERO = "\n0 packages upgraded, 0 newly installed"
+APTITUDE_AUTORM_GET_ZERO = "\n0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded"
 APT_LISTS_PATH = "/var/lib/apt/lists"
 APT_UPDATE_SUCCESS_STAMP_PATH = "/var/lib/apt/periodic/update-success-stamp"
 
@@ -446,7 +451,7 @@ def parse_diff(output):
 def install(m, pkgspec, cache, upgrade=False, default_release=None,
             install_recommends=None, force=False,
             dpkg_options=expand_dpkg_options(DPKG_OPTIONS),
-            build_dep=False, autoremove=False, only_upgrade=False,
+            build_dep=False, only_upgrade=False,
             allow_unauthenticated=False):
     pkg_list = []
     packages = ""
@@ -482,11 +487,6 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
         else:
             check_arg = ''
 
-        if autoremove:
-            autoremove = '--auto-remove'
-        else:
-            autoremove = ''
-
         if only_upgrade:
             only_upgrade = '--only-upgrade'
         else:
@@ -495,7 +495,7 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
         if build_dep:
             cmd = "%s -y %s %s %s %s build-dep %s" % (APT_GET_CMD, dpkg_options, only_upgrade, force_yes, check_arg, packages)
         else:
-            cmd = "%s -y %s %s %s %s %s install %s" % (APT_GET_CMD, dpkg_options, only_upgrade, force_yes, autoremove, check_arg, packages)
+            cmd = "%s -y %s %s %s %s install %s" % (APT_GET_CMD, dpkg_options, only_upgrade, force_yes, check_arg, packages)
 
         if default_release:
             cmd += " -t '%s'" % (default_release,)
@@ -605,9 +605,67 @@ def install_deb(m, debs, cache, force, install_recommends, allow_unauthenticated
     else:
         m.exit_json(changed=changed, stdout=retvals.get('stdout',''), stderr=retvals.get('stderr',''), diff=retvals.get('diff', ''))
 
+def autoremove(m, pkgspec, cache, purge=False, force=False,
+           dpkg_options=expand_dpkg_options(DPKG_OPTIONS)):
+    # https://github.com/ansible/ansible-modules-core/issues/4029
+    pkg_list = []
+    try:
+        pkgspec = expand_pkgspec_from_fnmatches(m, pkgspec, cache)
+        for package in pkgspec:
+            name, version = package_split(package)
+            installed, upgradable, has_files = package_status(m, name, version, cache, state='remove')
+            if installed or (has_files and purge):
+                pkg_list.append("'%s'" % package)
+        packages = ' '.join(pkg_list)
+    except:
+        packages = ""
+
+    if force:
+        force_yes = '--force-yes'
+    else:
+        force_yes = ''
+
+    if purge:
+        purge = '--purge'
+    else:
+        purge = ''
+
+    if m.check_mode:
+        check_arg = '--simulate'
+    else:
+        check_arg = ''
+
+    if len(packages) == 0:
+        cmd = "%s -q -y %s %s %s %s autoremove" % (APT_GET_CMD, dpkg_options, purge, force_yes , check_arg)
+
+        rc, out, err = m.run_command(cmd)
+        if m._diff:
+            diff = parse_diff(out)
+        else:
+            diff = {}
+        if rc:
+            m.fail_json(msg="'apt-get autoremove' failed: %s" % (err), stdout=out, stderr=err)
+        if (APT_GET_CMD and APT_AUTORM_GET_ZERO in out) or (APTITUDE_CMD and APTITUDE_ZERO in out):
+            m.exit_json(changed=False, stdout=out, stderr=err)
+        m.exit_json(changed=True, stdout=out, stderr=err, diff=diff)
+    elif len(packages) > 0:
+        cmd = "%s -q -y %s %s %s %s autoremove %s" % (APT_GET_CMD, dpkg_options, purge, force_yes, check_arg, packages)
+
+        rc, out, err = m.run_command(cmd)
+        if m._diff:
+            diff = parse_diff(out)
+        else:
+            diff = {}
+        if rc:
+            m.fail_json(msg="'apt-get autoremove %s' failed: %s" % (packages, err), stdout=out, stderr=err)
+        if (APT_GET_CMD and APT_AUTORM_GET_ZERO in out) or (APTITUDE_CMD and APTITUDE_ZERO in out):
+            m.exit_json(changed=False, stdout=out, stderr=err)
+        m.exit_json(changed=True, stdout=out, stderr=err, diff=diff)
+    else:
+        m.exit_json(changed=False)
 
 def remove(m, pkgspec, cache, purge=False, force=False,
-           dpkg_options=expand_dpkg_options(DPKG_OPTIONS), autoremove=False):
+           dpkg_options=expand_dpkg_options(DPKG_OPTIONS)):
     pkg_list = []
     pkgspec = expand_pkgspec_from_fnmatches(m, pkgspec, cache)
     for package in pkgspec:
@@ -630,17 +688,12 @@ def remove(m, pkgspec, cache, purge=False, force=False,
         else:
             purge = ''
 
-        if autoremove:
-            autoremove = '--auto-remove'
-        else:
-            autoremove = ''
-
         if m.check_mode:
             check_arg = '--simulate'
         else:
             check_arg = ''
 
-        cmd = "%s -q -y %s %s %s %s %s remove %s" % (APT_GET_CMD, dpkg_options, purge, force_yes ,autoremove, check_arg, packages)
+        cmd = "%s -q -y %s %s %s %s %s remove %s" % (APT_GET_CMD, dpkg_options, purge, force_yes , check_arg, packages)
 
         rc, out, err = m.run_command(cmd)
         if m._diff:
@@ -754,7 +807,6 @@ def get_updated_cache_time():
     updated_cache_time = int(time.mktime(mtimestamp.timetuple()))
     return mtimestamp, updated_cache_time
 
-
 # https://github.com/ansible/ansible-modules-core/issues/2951
 def get_cache(module):
     '''Attempt to get the cache object and update till it works'''
@@ -772,13 +824,12 @@ def get_cache(module):
                 if rc == 0:
                     break
             if rc != 0:
-                module.fail_json(msg='Updating the cache to correct corrupt package lists failed:\n%s\n%s' % (str(e), str(so) + str(se)))    
+                module.fail_json(msg='Updating the cache to correct corrupt package lists failed:\n%s\n%s' % (str(e), str(so) + str(se)))
             # try again
             cache = apt.Cache()
         else:
             module.fail_json(msg=str(e))
     return cache
- 
 
 def main():
     module = AnsibleModule(
@@ -794,9 +845,9 @@ def main():
             force = dict(default='no', type='bool'),
             upgrade = dict(choices=['no', 'yes', 'safe', 'full', 'dist']),
             dpkg_options = dict(default=DPKG_OPTIONS),
-            autoremove = dict(type='bool', default=False, aliases=['autoclean']),
             only_upgrade = dict(type='bool', default=False),
             allow_unauthenticated = dict(default='no', aliases=['allow-unauthenticated'], type='bool'),
+            autoremove = dict(default='no', type='bool'),
         ),
         mutually_exclusive = [['package', 'upgrade', 'deb']],
         required_one_of = [['package', 'upgrade', 'update_cache', 'deb']],
@@ -838,7 +889,6 @@ def main():
     install_recommends = p['install_recommends']
     allow_unauthenticated = p['allow_unauthenticated']
     dpkg_options = expand_dpkg_options(p['dpkg_options'])
-    autoremove = p['autoremove']
 
     # Deal with deprecated aliases
     if p['state'] == 'installed':
@@ -904,6 +954,13 @@ def main():
                         force=force_yes, dpkg_options=p['dpkg_options'])
 
         packages = p['package']
+
+        if p['autoremove']:
+            if not packages:
+                autoremove(module, cache, p['purge'], force=force_yes, dpkg_options=dpkg_options)
+            else:
+                autoremove(module, packages, cache, p['purge'], force=force_yes, dpkg_options=dpkg_options)
+
         latest = p['state'] == 'latest'
         for package in packages:
             if package.count('=') > 1:
@@ -929,7 +986,6 @@ def main():
                 force=force_yes,
                 dpkg_options=dpkg_options,
                 build_dep=state_builddep,
-                autoremove=autoremove,
                 only_upgrade=p['only_upgrade'],
                 allow_unauthenticated=allow_unauthenticated
             )
@@ -950,7 +1006,7 @@ def main():
             else:
                 module.fail_json(**retvals)
         elif p['state'] == 'absent':
-            remove(module, packages, cache, p['purge'], force=force_yes, dpkg_options=dpkg_options, autoremove=autoremove)
+            remove(module, packages, cache, p['purge'], force=force_yes, dpkg_options=dpkg_options)
 
     except apt.cache.LockFailedException:
         module.fail_json(msg="Failed to lock apt for exclusive operation")


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 ```
packaging/os/apt.py
```

##### ANSIBLE VERSION

```
2.3
```

##### SUMMARY

Fixes #4029 

##### STEP TO REPRODUCE
###### ALL UNUSED PACKAGES
```
- name: Apt-repositories | Autoremove unused packages
  apt:
    autoremove: 'yes'
```

###### RESULT
```
changed: [localhost] => {
    "changed": true,
    "diff": {},
    "invocation": {
        "module_args": {
            "allow_unauthenticated": false,
            "autoremove": true,
            "cache_valid_time": 0,
            "deb": null,
            "default_release": null,
            "dpkg_options": "force-confdef,force-confold",
            "force": false,
            "install_recommends": null,
            "only_upgrade": false,
            "package": null,
            "purge": false,
            "state": "present",
            "update_cache": false,
            "upgrade": null
        },
        "module_name": "apt"
    },
    "stderr": "invoke-rc.d: policy-rc.d denied execution of stop.\n",
    "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nThe following packages will be REMOVED:\n  fakeroot krb5-locales libalgorithm-diff-perl libalgorithm-diff-xs-perl\n  libalgorithm-merge-perl libfakeroot libfile-fcntllock-perl libglib2.0-data\n  libjs-jquery libsasl2-modules libssl-doc libx11-6 libx11-data libxau6\n  libxcb1 libxdmcp6 libxext6 libxml2 libxmuu1 manpages manpages-dev\n  ncurses-term python-requests python-urllib3 rsync sgml-base shared-mime-info\n  ssh-import-id tcpd wget xauth xml-core\n0 upgraded, 0 newly installed, 32 to remove and 0 not upgraded.\nAfter this operation, 22.4 MB disk space will be freed.\n(Reading database ... 28316 files and directories currently installed.)\nRemoving fakeroot (1.20-3ubuntu2) ...\nupdate-alternatives: using /usr/bin/fakeroot-tcp to provide /usr/bin/fakeroot (fakeroot) in auto mode\nRemoving krb5-locales (1.12+dfsg-2ubuntu5.2) ...\nRemoving libalgorithm-merge-perl (0.08-2) ...\nRemoving libalgorithm-diff-xs-perl (0.04-2build4) ...\nRemoving libalgorithm-diff-perl (1.19.02-3) ...\nRemoving libfakeroot:amd64 (1.20-3ubuntu2) ...\nRemoving libfile-fcntllock-perl (0.14-2build1) ...\nRemoving libglib2.0-data (2.40.2-0ubuntu1) ...\nRemoving libjs-jquery (1.7.2+dfsg-2ubuntu1) ...\nRemoving libsasl2-modules:amd64 (2.1.25.dfsg1-17build1) ...\nRemoving libssl-doc (1.0.1f-1ubuntu2.21) ...\nRemoving xauth (1:1.0.7-1ubuntu1) ...\nRemoving libxext6:amd64 (2:1.3.2-1ubuntu0.0.14.04.1) ...\nRemoving shared-mime-info (1.2-0ubuntu3) ...\nRemoving libxml2:amd64 (2.9.1+dfsg1-3ubuntu4.8) ...\nRemoving libxmuu1:amd64 (2:1.1.1-1) ...\nRemoving manpages-dev (3.54-1ubuntu1) ...\nRemoving manpages (3.54-1ubuntu1) ...\nRemoving ncurses-term (5.9+20140118-1ubuntu1) ...\nRemoving ssh-import-id (3.21-0ubuntu1) ...\nRemoving python-requests (2.2.1-1ubuntu0.3) ...\nRemoving python-urllib3 (1.7.1-1ubuntu4) ...\nRemoving rsync (3.1.0-2ubuntu0.2) ...\nRemoving xml-core (0.13+nmu2) ...\nRemoving sgml-base (1.26+nmu4ubuntu1) ...\nRemoving tcpd (7.6.q-25) ...\nRemoving wget (1.15-1ubuntu1.14.04.2) ...\nRemoving libx11-6:amd64 (2:1.6.2-1ubuntu2) ...\nRemoving libx11-data (2:1.6.2-1ubuntu2) ...\nRemoving libxcb1:amd64 (1.10-2ubuntu1) ...\nRemoving libxau6:amd64 (1:1.0.8-1) ...\nRemoving libxdmcp6:amd64 (1:1.1.1-1) ...\nProcessing triggers for libc-bin (2.19-0ubuntu6.9) ...\n",
    "stdout_lines": [
        "Reading package lists...",
        "Building dependency tree...",
        "Reading state information...",
        "The following packages will be REMOVED:",
        "  fakeroot krb5-locales libalgorithm-diff-perl libalgorithm-diff-xs-perl",
        "  libalgorithm-merge-perl libfakeroot libfile-fcntllock-perl libglib2.0-data",
        "  libjs-jquery libsasl2-modules libssl-doc libx11-6 libx11-data libxau6",
        "  libxcb1 libxdmcp6 libxext6 libxml2 libxmuu1 manpages manpages-dev",
        "  ncurses-term python-requests python-urllib3 rsync sgml-base shared-mime-info",
        "  ssh-import-id tcpd wget xauth xml-core",
        "0 upgraded, 0 newly installed, 32 to remove and 0 not upgraded.",
        "After this operation, 22.4 MB disk space will be freed.",
        "(Reading database ... 28316 files and directories currently installed.)",
        "Removing fakeroot (1.20-3ubuntu2) ...",
        "update-alternatives: using /usr/bin/fakeroot-tcp to provide /usr/bin/fakeroot (fakeroot) in auto mode",
        "Removing krb5-locales (1.12+dfsg-2ubuntu5.2) ...",
        "Removing libalgorithm-merge-perl (0.08-2) ...",
        "Removing libalgorithm-diff-xs-perl (0.04-2build4) ...",
        "Removing libalgorithm-diff-perl (1.19.02-3) ...",
        "Removing libfakeroot:amd64 (1.20-3ubuntu2) ...",
        "Removing libfile-fcntllock-perl (0.14-2build1) ...",
        "Removing libglib2.0-data (2.40.2-0ubuntu1) ...",
        "Removing libjs-jquery (1.7.2+dfsg-2ubuntu1) ...",
        "Removing libsasl2-modules:amd64 (2.1.25.dfsg1-17build1) ...",
        "Removing libssl-doc (1.0.1f-1ubuntu2.21) ...",
        "Removing xauth (1:1.0.7-1ubuntu1) ...",
        "Removing libxext6:amd64 (2:1.3.2-1ubuntu0.0.14.04.1) ...",
        "Removing shared-mime-info (1.2-0ubuntu3) ...",
        "Removing libxml2:amd64 (2.9.1+dfsg1-3ubuntu4.8) ...",
        "Removing libxmuu1:amd64 (2:1.1.1-1) ...",
        "Removing manpages-dev (3.54-1ubuntu1) ...",
        "Removing manpages (3.54-1ubuntu1) ...",
        "Removing ncurses-term (5.9+20140118-1ubuntu1) ...",
        "Removing ssh-import-id (3.21-0ubuntu1) ...",
        "Removing python-requests (2.2.1-1ubuntu0.3) ...",
        "Removing python-urllib3 (1.7.1-1ubuntu4) ...",
        "Removing rsync (3.1.0-2ubuntu0.2) ...",
        "Removing xml-core (0.13+nmu2) ...",
        "Removing sgml-base (1.26+nmu4ubuntu1) ...",
        "Removing tcpd (7.6.q-25) ...",
        "Removing wget (1.15-1ubuntu1.14.04.2) ...",
        "Removing libx11-6:amd64 (2:1.6.2-1ubuntu2) ...",
        "Removing libx11-data (2:1.6.2-1ubuntu2) ...",
        "Removing libxcb1:amd64 (1.10-2ubuntu1) ...",
        "Removing libxau6:amd64 (1:1.0.8-1) ...",
        "Removing libxdmcp6:amd64 (1:1.1.1-1) ...",
        "Processing triggers for libc-bin (2.19-0ubuntu6.9) ..."
    ]
}
```

or if nothing to remove
```
ok: [localhost] => {
    "changed": false,
    "invocation": {
        "module_args": {
            "allow_unauthenticated": false,
            "autoremove": true,
            "cache_valid_time": 0,
            "deb": null,
            "default_release": null,
            "dpkg_options": "force-confdef,force-confold",
            "force": false,
            "install_recommends": null,
            "only_upgrade": false,
            "package": null,
            "purge": false,
            "state": "present",
            "update_cache": false,
            "upgrade": null
        },
        "module_name": "apt"
    },
    "stderr": "",
    "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\n0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.\n",
    "stdout_lines": [
        "Reading package lists...",
        "Building dependency tree...",
        "Reading state information...",
        "0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded."
    ]
}
```

###### SPECIFIC UNUSED PACKAGE
```
- name: Apt-repositories | Autoremove unused packages
  apt:
    name: 'man-db'
    autoremove: 'yes'
```

###### RESULT
```
changed: [localhost] => {
    "changed": true,
    "diff": {},
    "invocation": {
        "module_args": {
            "allow_unauthenticated": false,
            "autoremove": true,
            "cache_valid_time": 0,
            "deb": null,
            "default_release": null,
            "dpkg_options": "force-confdef,force-confold",
            "force": false,
            "install_recommends": null,
            "name": "man-db",
            "only_upgrade": false,
            "package": [
                "man-db"
            ],
            "purge": false,
            "state": "present",
            "update_cache": false,
            "upgrade": null
        },
        "module_name": "apt"
    },
    "stderr": "",
    "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nThe following packages will be REMOVED:\n  bsdmainutils groff-base libpipeline1 man-db\n0 upgraded, 0 newly installed, 4 to remove and 0 not upgraded.\nAfter this operation, 5635 kB disk space will be freed.\n(Reading database ... 22252 files and directories currently installed.)\nRemoving man-db (2.6.7.1-1ubuntu1) ...\nRemoving bsdmainutils (9.0.5ubuntu1) ...\nRemoving groff-base (1.22.2-5) ...\nRemoving libpipeline1:amd64 (1.3.0-1) ...\nProcessing triggers for mime-support (3.54ubuntu1.1) ...\nProcessing triggers for libc-bin (2.19-0ubuntu6.9) ...\n",
    "stdout_lines": [
        "Reading package lists...",
        "Building dependency tree...",
        "Reading state information...",
        "The following packages will be REMOVED:",
        "  bsdmainutils groff-base libpipeline1 man-db",
        "0 upgraded, 0 newly installed, 4 to remove and 0 not upgraded.",
        "After this operation, 5635 kB disk space will be freed.",
        "(Reading database ... 22252 files and directories currently installed.)",
        "Removing man-db (2.6.7.1-1ubuntu1) ...",
        "Removing bsdmainutils (9.0.5ubuntu1) ...",
        "Removing groff-base (1.22.2-5) ...",
        "Removing libpipeline1:amd64 (1.3.0-1) ...",
        "Processing triggers for mime-support (3.54ubuntu1.1) ...",
        "Processing triggers for libc-bin (2.19-0ubuntu6.9) ..."
    ]
}
```