### PR TITLE
Support mariadb engine version 10.1 in param groups

### DIFF
--- a/cloud/amazon/rds_param_group.py
+++ b/cloud/amazon/rds_param_group.py
@@ -85,6 +85,7 @@ EXAMPLES = '''
 VALID_ENGINES = [
     'aurora5.6',
     'mariadb10.0',
+    'mariadb10.1', 
     'mysql5.1',
     'mysql5.5',
     'mysql5.6',


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
rds_param_group

##### ANSIBLE VERSION
```
ansible 2.2.0.0
```

##### SUMMARY
Allow to create param groups for MariaDB 10.1
