### PR TITLE
If fetch_url failed to download the URL fail early with a proper error

### DIFF
--- a/packaging/os/yum.py
+++ b/packaging/os/yum.py
@@ -225,6 +225,8 @@ def fetch_rpm_from_url(spec, module=None):
     package = os.path.join(tempdir, str(spec.rsplit('/', 1)[1]))
     try:
         rsp, info = fetch_url(module, spec)
+        if not rsp:
+            module.fail_json(msg="Failure downloading %s, %s" % (spec, info['msg']))
         f = open(package, 'w')
         data = rsp.read(BUFSIZE)
         while data:


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request


##### COMPONENT NAME
yum

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (devel 32a7b4ce71) last updated 2016/11/03 11:26:37 (GMT -500)
```

##### SUMMARY
See and fixes #5474 