### PR TITLE
docker_container - make json-file default logging driver PR #5269

### DIFF
--- a/cloud/docker/docker_container.py
+++ b/cloud/docker/docker_container.py
@@ -1089,8 +1089,6 @@ class TaskParameters(DockerBaseClass):
         '''
         Create a LogConfig object
         '''
-        if self.log_driver is None:
-            return None
 
         options = dict(
             Type=self.log_driver,
@@ -1949,7 +1947,7 @@ def main():
         kill_signal=dict(type='str'),
         labels=dict(type='dict'),
         links=dict(type='list'),
-        log_driver=dict(type='str', choices=['json-file', 'syslog', 'journald', 'gelf', 'fluentd', 'awslogs', 'splunk'], default=None),
+        log_driver=dict(type='str', choices=['json-file', 'syslog', 'journald', 'gelf', 'fluentd', 'awslogs', 'splunk'], default='json-file'),
         log_options=dict(type='dict', aliases=['log_opt']),
         mac_address=dict(type='str'),
         memory=dict(type='str', default='0'),


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
docker_container

##### ANSIBLE VERSION
ansible 2.3.0

##### SUMMARY
According to docker documentation(https://docs.docker.com/engine/admin/logging/overview/), If the --log-driver option is not set, docker uses the default (json-file) logging driver.

Ansible should also handle this in a similar way as reported on  #PR #5269 

### Playbook

docker_container:
  name: test_container
  image: bash
  log_options:
    max-size: "512m"
    max-file: "5"

### Before - docker inspect

        "LogConfig": {
            "Type": "json-file",
            "Config": {}
        },

### After - docker inspect

        "LogConfig": {
            "Type": "json-file",
            "Config": {
                "max-file": "5",
                "max-size": "512m"
            }
        },
