### PR TITLE
Avoid TypeError exception on desired_capacity

### DIFF
--- a/cloud/amazon/ec2_asg.py
+++ b/cloud/amazon/ec2_asg.py
@@ -596,6 +596,14 @@ def replace(connection, module):
     instances = props['instances']
     if replace_instances:
         instances = replace_instances
+        
+    #check if min_size/max_size/desired capacity have been specified and if not use ASG values
+    if min_size is None:
+        min_size = as_group.min_size
+    if max_size is None:
+        max_size = as_group.max_size
+    if desired_capacity is None:
+        desired_capacity = as_group.desired_capacity
     # check to see if instances are replaceable if checking launch configs
 
     new_instances, old_instances = get_instances_by_lc(props, lc_check, instances)
@@ -618,14 +626,7 @@ def replace(connection, module):
     if not old_instances:
         changed = False
         return(changed, props)
-
-    #check if min_size/max_size/desired capacity have been specified and if not use ASG values
-    if min_size is None:
-        min_size = as_group.min_size
-    if max_size is None:
-        max_size = as_group.max_size
-    if desired_capacity is None:
-        desired_capacity = as_group.desired_capacity
+      
     # set temporary settings and wait for them to be reached
     # This should get overwritten if the number of instances left is less than the batch size.
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
ec2_asg.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible version 2.0.2.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When executing the following operation it is currently assumed that the desired_capacity variable is defined, but that is not necessarily true. It isn't indicated in the documentation that a replacement operation requires the desired_capacity, min_size and max_size values to be defined. And that is OK, but only as long as those values are READ from the current ASG settings when they're not defined as inputs of the module.  Since the code to read from the ASG settings is already in place, we're simply moving it to be executed above the operation that throws the exception.
Operation:
`num_new_inst_needed = desired_capacity - len(new_instances)`

Validation:
```
 #check if min_size/max_size/desired capacity have been specified and if not use ASG values
    if min_size is None:
        min_size = as_group.min_size
    if max_size is None:
        max_size = as_group.max_size
    if desired_capacity is None:
        desired_capacity = as_group.desired_capacity
```

Validation should be executed BEFORE operation otherwise the following error occurs if desired_capacity becomes a NoneType:

> An exception occurred during task execution. The full traceback is:
> Traceback (most recent call last):
>   File "/var/lib/awx/.ansible/tmp/ansible-tmp-1478229985.74-62334493713074/ec2_asg", line 3044, in <module>
>     main()
>   File "/var/lib/awx/.ansible/tmp/ansible-tmp-1478229985.74-62334493713074/ec2_asg", line 3038, in main
>     replace_changed, asg_properties=replace(connection, module)
>   File "/var/lib/awx/.ansible/tmp/ansible-tmp-1478229985.74-62334493713074/ec2_asg", line 2778, in replace
>     **num_new_inst_needed = desired_capacity - len(new_instances)
> TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'**
> 
> fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "invocation": {"module_name": "ec2_asg"}, "module_stderr": "Traceback (most recent call last):\n  File \"/var/lib/awx/.ansible/tmp/ansible-tmp-1478229985.74-62334493713074/ec2_asg\", line 3044, in <module>\n    main()\n  File \"/var/lib/awx/.ansible/tmp/ansible-tmp-1478229985.74-62334493713074/ec2_asg\", line 3038, in main\n    replace_changed, asg_properties=replace(connection, module)\n  File \"/var/lib/awx/.ansible/tmp/ansible-tmp-1478229985.74-62334493713074/ec2_asg\", line 2778, in replace\n    num_new_inst_needed = desired_capacity - len(new_instances)\nTypeError: unsupported operand type(s) for -: 'NoneType' and 'int'\n", "module_stdout": "", "msg": "MODULE FAILURE", "parsed": false}
> 

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

Moving the "check if min_size/max_size/desired_capacity..." code to execute BEFORE the desired_capacity code is used in the following operation:
num_new_inst_needed = desired_capacity - len(new_instances)

Otherwise the following exception occurs when desired_capacity is not specified and you're replacing instances:
    num_new_inst_needed = desired_capacity - len(new_instances)
TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'

Stack Trace:

An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/var/lib/awx/.ansible/tmp/ansible-tmp-1478229985.74-62334493713074/ec2_asg", line 3044, in <module>
    main()
  File "/var/lib/awx/.ansible/tmp/ansible-tmp-1478229985.74-62334493713074/ec2_asg", line 3038, in main
    replace_changed, asg_properties=replace(connection, module)
  File "/var/lib/awx/.ansible/tmp/ansible-tmp-1478229985.74-62334493713074/ec2_asg", line 2778, in replace
    num_new_inst_needed = desired_capacity - len(new_instances)
TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'

fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "invocation": {"module_name": "ec2_asg"}, "module_stderr": "Traceback (most recent call last):\n  File \"/var/lib/awx/.ansible/tmp/ansible-tmp-1478229985.74-62334493713074/ec2_asg\", line 3044, in <module>\n    main()\n  File \"/var/lib/awx/.ansible/tmp/ansible-tmp-1478229985.74-62334493713074/ec2_asg\", line 3038, in main\n    replace_changed, asg_properties=replace(connection, module)\n  File \"/var/lib/awx/.ansible/tmp/ansible-tmp-1478229985.74-62334493713074/ec2_asg\", line 2778, in replace\n    num_new_inst_needed = desired_capacity - len(new_instances)\nTypeError: unsupported operand type(s) for -: 'NoneType' and 'int'\n", "module_stdout": "", "msg": "MODULE FAILURE", "parsed": false}
	to retry, use: --limit @