### PR TITLE
Git module: UnboundLocalError: local variable 'remote_head'

### DIFF
--- a/source_control/git.py
+++ b/source_control/git.py
@@ -990,7 +990,7 @@ def main():
         result['after'] = get_version(module, git_path, dest)
 
         if result['before'] == result['after']:
-            if local_mods:
+            if local_mods and module.check_mode:
                 result.update(changed=True, after=remote_head, msg='Local modifications exist')
                 # no diff, since the repo didn't change
                 module.exit_json(**result)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
git

##### ANSIBLE VERSION
```
ansible 2.2.0.0
```

##### SUMMARY

Performing a git clone with force when local modifications exist, throws the below error.

```
failed: [pdevop] (item={u'repo': u'git@gitlab.example.com:ansible-inventories/all.git', u'dest': u'/opt/ansible/inventory'}) => {"failed": true, "item": {"dest": "/opt/ansible/inventory", "repo": "git@gitlab.paragon-es.de:ansible-inventories/all.git"}, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_OrL1Nw/ansible_module_git.py\", line 1040, in <module>\n    main()\n  File \"/tmp/ansible_OrL1Nw/ansible_module_git.py\", line 994, in main\n    result.update(changed=True, after=remote_head, msg='Local modifications exist')\nUnboundLocalError: local variable 'remote_head' referenced before assignment\n", "module_stdout": "", "msg": "MODULE FAILURE"}
```
