### PR TITLE
vsphere_guest - Fixes issue #4743 and #4249

### DIFF
--- a/cloud/vmware/vsphere_guest.py
+++ b/cloud/vmware/vsphere_guest.py
@@ -779,6 +779,7 @@ def update_disks(vsphere_client, vm, module, vm_disk, changes):
 
     for cnf_disk in vm_disk:
         disk_id = re.sub("disk", "", cnf_disk)
+        disk_type = vm_disk[cnf_disk]['type']
         found = False
         for dev_key in vm._devices:
             if vm._devices[dev_key]['type'] == 'VirtualDisk':
@@ -810,7 +811,10 @@ def update_disks(vsphere_client, vm, module, vm_disk, changes):
             backing.DiskMode = "persistent"
             backing.Split = False
             backing.WriteThrough = False
-            backing.ThinProvisioned = False
+            if disk_type == 'thin':
+                backing.ThinProvisioned = True
+            else:
+                backing.ThinProvisioned = False
             backing.EagerlyScrub = False
             hd.Backing = backing
 
@@ -852,6 +856,7 @@ def reconfigure_vm(vsphere_client, vm, module, esxi, resource_pool, cluster_name
 
     changed, changes = update_disks(vsphere_client, vm,
                                     module, vm_disk, changes)
+    vm.properties._flush_cache()
     request = VI.ReconfigVM_TaskRequestMsg()
 
     # Change extra config


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
vsphere_guest

##### ANSIBLE VERSION
ansible 2.3.0

##### SUMMARY
Fixes issue #4743 and #4249

### Issue #4743 
During VM reconfiguration, if additional disk is added, the newly provisioned disk is created as hard-coded thick lazy zeroed disk.
    - Read the vm[disk]['type'] & create the new disk accordingly.

### Issue #4249
During VM reconfiguration, if additional disk is added, ansible returns error "Error in vm_disk definition. Too many disks defined in comparison to the VM's disk profile." But, the VM is reconfigured & disk is added silently in the background.
    - For performance reason, pysphere maintains a cached copy of the vm object. 
    - vsphere_guest module was acting up on a older copy of vm object pulled at the beginning & thus the failure.
   - Flushing vm properties cache after update_disks did the trick & dev_list had newly created disks. 
 
