### PR TITLE
Added ability to specify datastore during clone

### DIFF
--- a/cloud/vmware/vsphere_guest.py
+++ b/cloud/vmware/vsphere_guest.py
@@ -261,6 +261,7 @@ EXAMPLES = '''
     resource_pool: "/Resources"
     vm_extra_config:
       folder: MyFolder
+      datastore: targetDatastoreName
 
 # Task to gather facts from a vSphere cluster only if the system is a VMware guest
 
@@ -746,6 +747,11 @@ def deploy_template(vsphere_client, guest, resource_pool, template_src, esxi, mo
             if vm_extra_config.get("folder") is not None:
                 # if a folder is specified, clone the VM into it
                 cloneArgs["folder"] = vm_extra_config.get("folder")
+
+            if vm_extra_config.get("datastore") is not None:
+                # if a datastore is specified, clone the VM to it instead of to the same place as template
+                datastore, ds = find_datastore(module, vsphere_client, vm_extra_config.get("datastore"), None)
+                cloneArgs["datastore"] = ds
 
             vmTemplate.clone(guest, **cloneArgs)
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
vsphere_guest.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/pcorneli/projects/vsphere/library']

```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
As an vsphere admin I need to be able to clone vms to a different datastore to where my templates live because my operational storage usually needs to be more robust and performant than my template storage.

In this change I have used the existing find_datastore function to look up the datastore MOR in the same way as for reconfiguring a vm.

I have tested by cloning from a template source on NFS to a vsanDatastore.

I determined what was required in the cloneSpec from the pysphere clone function call.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```