### PR TITLE
ec2_elb_lb: convert number variables to integer before comparing (to avoid unnecessary updates)

### DIFF
--- a/cloud/amazon/ec2_elb_lb.py
+++ b/cloud/amazon/ec2_elb_lb.py
@@ -894,10 +894,10 @@ class ElbManager(object):
             # health_check; values are desired values of new health_check
             health_check_config = {
                 "target": self._get_health_check_target(),
-                "timeout": self.health_check['response_timeout'],
-                "interval": self.health_check['interval'],
-                "unhealthy_threshold": self.health_check['unhealthy_threshold'],
-                "healthy_threshold": self.health_check['healthy_threshold'],
+                "timeout": int(self.health_check['response_timeout']),
+                "interval": int(self.health_check['interval']),
+                "unhealthy_threshold": int(self.health_check['unhealthy_threshold']),
+                "healthy_threshold": int(self.health_check['healthy_threshold'])
             }
 
             update_health_check = False

--- a/cloud/amazon/ec2_elb_lb.py
+++ b/cloud/amazon/ec2_elb_lb.py
@@ -962,7 +962,7 @@ class ElbManager(object):
         attributes = self.elb.get_attributes()
         if self.connection_draining_timeout is not None:
             if not attributes.connection_draining.enabled or \
-                    attributes.connection_draining.timeout != self.connection_draining_timeout:
+                    int(attributes.connection_draining.timeout) != int(self.connection_draining_timeout):
                 self.changed = True
             attributes.connection_draining.enabled = True
             attributes.connection_draining.timeout = self.connection_draining_timeout
@@ -976,7 +976,7 @@ class ElbManager(object):
     def _set_idle_timeout(self):
         attributes = self.elb.get_attributes()
         if self.idle_timeout is not None:
-            if attributes.connecting_settings.idle_timeout != self.idle_timeout:
+            if int(attributes.connecting_settings.idle_timeout) != int(self.idle_timeout):
                 self.changed = True
             attributes.connecting_settings.idle_timeout = self.idle_timeout
             self.elb_conn.modify_lb_attribute(self.name, 'ConnectingSettings', attributes.connecting_settings)


### PR DESCRIPTION
#### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cloud/amazon/ec2_elb_lb
<!--- Name of the plugin/module/task -->

##### ANSIBLE VERSION
```
devel
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Recently I noticed that my ELB was updating constantly, even when there were no any updates. After some digging I found out that during parameters changes comparison (health check, connection draining and connection settings) the types of variables were different, which was causing ELB to update. Here is an example of debug output:
```
fatal: [localhost]: FAILED! => {"changed": false, "existing": 10, "failed": true, "msg": "_set_health_check", "new": "10"}
```
as you can see, types of existing and new variables are different - str vs. int (`existing` and `new` values are from `getattr(self.elb.health_check, attr)` and `desired_value`, from  https://github.com/ansible/ansible-modules-core/blob/devel/cloud/amazon/ec2_elb_lb.py#L911)

So my idea is to explicitly convert number variables to int before trying to compare and detect changes (and I don't think we need to detect any types here, since those variables should be numbers by design)

PS: for health checks I've also tried to pass integers (via `default('')`, see example below) from Ansible task, but that didn't help.
```
- name: ELB | Configure health check
  set_fact:
    customELBHealth:
      ping_protocol: "{{ health.protocol | default('TCP') }}"
      ping_port: "{{ health.port | default('80') }}"
      response_timeout: "{{ health.response_timeout | default('5') }}"
      interval: "{{ health.interval | default('30') }}"
      unhealthy_threshold: "{{ health.unhealthy_threshold | default('2') }}"
      healthy_threshold: "{{ health.healthy_threshold | default('10') }}"

- name: ELB | Create load balancer
  ec2_elb_lb:
    name: "custom-elb"
    state: present
    connection_draining_timeout: 60
    idle_timeout: 300
    cross_az_load_balancing: "yes"
    region: "{{ region }}"
    health_check: "{{ customELBHealth }}"
    security_group_ids:
      - "{{ sg_group_id }}"
    subnets: "{{ subnets }}"
    listeners: "{{ listeners }}"
```