### PR TITLE
cloudformation: add .format indexes for 2.6 compatability

### DIFF
--- a/cloud/amazon/cloudformation.py
+++ b/cloud/amazon/cloudformation.py
@@ -257,11 +257,11 @@ def get_stack_events(cfn, stack_name):
         return ret
 
     for e in events.get('StackEvents', []):
-        eventline = 'StackEvent {} {} {}'.format(e['ResourceType'], e['LogicalResourceId'], e['ResourceStatus'])
+        eventline = 'StackEvent {0} {1} {2}'.format(e['ResourceType'], e['LogicalResourceId'], e['ResourceStatus'])
         ret['events'].append(eventline)
 
         if e['ResourceStatus'].endswith('FAILED'):
-            failline = '{} {} {}: {}'.format(e['ResourceType'], e['LogicalResourceId'], e['ResourceStatus'], e['ResourceStatusReason'])
+            failline = '{0} {1} {2}: {3}'.format(e['ResourceType'], e['LogicalResourceId'], e['ResourceStatus'], e['ResourceStatusReason'])
             ret['log'].append(failline)
 
     return ret

--- a/cloud/amazon/cloudformation.py
+++ b/cloud/amazon/cloudformation.py
@@ -257,11 +257,11 @@ def get_stack_events(cfn, stack_name):
         return ret
 
     for e in events.get('StackEvents', []):
-        eventline = 'StackEvent {0} {1} {2}'.format(e['ResourceType'], e['LogicalResourceId'], e['ResourceStatus'])
+        eventline = 'StackEvent {ResourceType} {LogicalResourceId} {ResourceStatus}'.format(**e)
         ret['events'].append(eventline)
 
         if e['ResourceStatus'].endswith('FAILED'):
-            failline = '{0} {1} {2}: {3}'.format(e['ResourceType'], e['LogicalResourceId'], e['ResourceStatus'], e['ResourceStatusReason'])
+            failline = '{ResourceType} {LogicalResourceId} {ResourceStatus}: {ResourceStatusReason}'.format(**e)
             ret['log'].append(failline)
 
     return ret


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
cloudformation

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3.0
```

##### SUMMARY

Fixes #5551; the "".format() style needs to have `{0}` instead of the implied `{}` version for compatability with 2.6.