### PR TITLE
Fix wait_for Module to handle socket response as string in Python3

### DIFF
--- a/utilities/logic/wait_for.py
+++ b/utilities/logic/wait_for.py
@@ -27,6 +27,8 @@ import socket
 import sys
 import time
 
+from ansible.module_utils._text import to_native
+
 HAS_PSUTIL = False
 try:
     import psutil
@@ -489,7 +491,7 @@ def main():
                             if not response:
                                 # Server shutdown
                                 break
-                            data += response
+                            data += to_native(response, errors='surrogate_or_strict')
                             if re.search(compiled_search_re, data):
                                 matched = True
                                 break


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
module wait_for

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
In Python3 socket module returns responses as bytes type. So it's
necessary to convert it to string for the wait_for module to work correctly.

Ansible Task:
```
- name: Wait for SSH to come up
  local_action:
    module: wait_for
    host: "{{ ec2.tagged_instances[0].public_ip }}"
    connect_timeout: 30
    port: 22
    delay: 1
    timeout: 500
    state: started
```

Execution with before change Python3
```
TASK [XXXXXXXXX : Wait for SSH to come up] ***************************
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: xxxxxx
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /tmp/ansible-tmp-1478798066.181361-222247894729410 `" && echo ansible-tmp-1478798066.181361-222247894729410="` echo /tmp/ansible-tmp-1478798066.181361-222247894729410 `" ) && sleep 0'
<localhost> PUT /var/folders/jp/yldvqbl17593128_plywwv1r0000gn/T/tmp_6pt8xoa TO /tmp/ansible-tmp-1478798066.181361-222247894729410/wait_for.py
<localhost> EXEC /bin/sh -c 'chmod u+x /tmp/ansible-tmp-1478798066.181361-222247894729410/ /tmp/ansible-tmp-1478798066.181361-222247894729410/wait_for.py && sleep 0'
<localhost> EXEC /bin/sh -c '/Users/xxxxx/Envs/ansiblepr/bin/python3.4 /tmp/ansible-tmp-1478798066.181361-222247894729410/wait_for.py; rm -rf "/tmp/ansible-tmp-1478798066.181361-222247894729410/" > /dev/null 2>&1 && sleep 0'
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/var/folders/jp/yldvqbl17593128_plywwv1r0000gn/T/ansible_r1hi63sj/ansible_module_wait_for.py", line 538, in <module>
    main()
  File "/var/folders/jp/yldvqbl17593128_plywwv1r0000gn/T/ansible_r1hi63sj/ansible_module_wait_for.py", line 483, in main
    data += response
TypeError: Can't convert 'bytes' object to str implicitly

fatal: [localhost -> localhost]: FAILED! => {
    "changed": false,
    "failed": true,
    "invocation": {
        "module_name": "wait_for"
    },
    "module_stderr": "Traceback (most recent call last):\n  File \"/var/folders/jp/yldvqbl17593128_plywwv1r0000gn/T/ansible_r1hi63sj/ansible_module_wait_for.py\", line 538, in <module>\n    main()\n  File \"/var/folders/jp/yldvqbl17593128_plywwv1r0000gn/T/ansible_r1hi63sj/ansible_module_wait_for.py\", line 483, in main\n    data += response\nTypeError: Can't convert 'bytes' object to str implicitly\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE"
}
```

Python3 execution after change:
```
TASK [create_op5_instance : Wait for SSH to come up] ***************************
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: xxxxxx
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /tmp/ansible-tmp-1478798053.3-272255374313316 `" && echo ansible-tmp-1478798053.3-272255374313316="` echo /tmp/ansible-tmp-1478798053.3-272255374313316 `" ) && sleep 0'
<localhost> PUT /var/folders/jp/yldvqbl17593128_plywwv1r0000gn/T/tmpbeccpN TO /tmp/ansible-tmp-1478798053.3-272255374313316/wait_for.py
<localhost> EXEC /bin/sh -c 'chmod u+x /tmp/ansible-tmp-1478798053.3-272255374313316/ /tmp/ansible-tmp-1478798053.3-272255374313316/wait_for.py && sleep 0'
<localhost> EXEC /bin/sh -c '/Users/xxxxxxx/Envs/ansiblepr/bin/python3.4 /tmp/ansible-tmp-1478798053.3-272255374313316/wait_for.py; rm -rf "/tmp/ansible-tmp-1478798053.3-272255374313316/" > /dev/null 2>&1 && sleep 0'
ok: [localhost -> localhost] => {
    "changed": false,
    "elapsed": 1,
    "invocation": {
        "module_args": {
            "connect_timeout": 30,
            "delay": 1,
            "exclude_hosts": null,
            "host": "xxx.xxx.xxx.xxx",
            "path": null,
            "port": 22,
            "search_regex": "OpenSSH",
            "state": "started",
            "timeout": 500
        },
        "module_name": "wait_for"
    },
    "path": null,
    "port": 22,
    "search_regex": "OpenSSH",
    "state": "started"
}

```