### PR TITLE
Add support for suspending scaling processes

### DIFF
--- a/cloud/amazon/ec2_asg.py
+++ b/cloud/amazon/ec2_asg.py
@@ -148,7 +148,7 @@ options:
     required: False
     default: []
     choices: ['Launch', 'Terminate', 'HealthCheck', 'ReplaceUnhealthy', 'AZRebalance', 'AlarmNotification', 'ScheduledActions', 'AddToLoadBalancer']
-    version_added: "2.2"
+    version_added: "2.3"
 extends_documentation_fragment:
     - aws
     - ec2

--- a/cloud/amazon/ec2_asg.py
+++ b/cloud/amazon/ec2_asg.py
@@ -142,6 +142,13 @@ options:
     default: ['autoscaling:EC2_INSTANCE_LAUNCH', 'autoscaling:EC2_INSTANCE_LAUNCH_ERROR', 'autoscaling:EC2_INSTANCE_TERMINATE', 'autoscaling:EC2_INSTANCE_TERMINATE_ERROR']
     required: false
     version_added: "2.2"
+  suspend_processes:
+    description:
+      - A list of scaling processes to suspend.
+    required: False
+    default: []
+    choices: ['Launch', 'Terminate', 'HealthCheck', 'ReplaceUnhealthy', 'AZRebalance', 'AlarmNotification', 'ScheduledActions', 'AddToLoadBalancer']
+    version_added: "2.2"
 extends_documentation_fragment:
     - aws
     - ec2
@@ -387,6 +394,28 @@ def wait_for_elb(asg_connection, module, group_name):
             module.fail_json(msg = "Waited too long for ELB instances to be healthy. %s" % time.asctime())
         log.debug("Waiting complete.  ELB thinks {0} instances are healthy.".format(healthy_instances))
 
+
+def suspend_processes(as_group, module):
+    suspend_processes = set(module.params.get('suspend_processes'))
+
+    try:
+        suspended_processes = set([p.process_name for p in as_group.suspended_processes])
+    except AttributeError:
+        # New ASG being created, no suspended_processes defined yet
+        suspended_processes = set()
+
+    if suspend_processes == suspended_processes:
+        return False
+
+    resume_processes = list(suspended_processes - suspend_processes)
+    if resume_processes:
+        as_group.resume_processes(resume_processes)
+
+    if suspend_processes:
+        as_group.suspend_processes(list(suspend_processes))
+
+    return True
+
 def create_autoscaling_group(connection, module):
     group_name = module.params.get('name')
     load_balancers = module.params['load_balancers']
@@ -450,6 +479,7 @@ def create_autoscaling_group(connection, module):
 
         try:
             connection.create_auto_scaling_group(ag)
+            suspend_processes(ag, module)
             if wait_for_instances:
                 wait_for_new_inst(module, connection, group_name, wait_timeout, desired_capacity, 'viable_instances')
                 wait_for_elb(connection, module, group_name)
@@ -466,6 +496,10 @@ def create_autoscaling_group(connection, module):
     else:
         as_group = as_groups[0]
         changed = False
+
+        if suspend_processes(as_group, module):
+            changed = True
+
         for attr in ASG_ATTRIBUTES:
             if module.params.get(attr, None) is not None:
                 module_attr = module.params.get(attr)
@@ -838,7 +872,8 @@ def main():
                 'autoscaling:EC2_INSTANCE_LAUNCH_ERROR',
                 'autoscaling:EC2_INSTANCE_TERMINATE',
                 'autoscaling:EC2_INSTANCE_TERMINATE_ERROR'
-            ])
+            ]),
+            suspend_processes=dict(type='list', default=[])
         ),
     )
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME

```
cloud/amazon/ec2_asg.py
```

##### ANSIBLE VERSION

```
ansible 2.1.1.0 (mycompany 780c363482) last updated 2016/09/15 16:27:51 (GMT -500)
  lib/ansible/modules/core: (feature_asg_suspend_processes f4bd008184) last updated 2016/11/10 17:05:09 (GMT -500)
  lib/ansible/modules/extras: (detached HEAD 14887a9ea8) last updated 2016/09/15 16:28:00 (GMT -500)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
When conducting deployments within my existing instances, my health checks intentionally begin to fail. To combat this, I pause scaling operations before the deployment, execute the deployment, then resume scaling operations.

Reference: http://docs.aws.amazon.com/autoscaling/latest/userguide/as-suspend-resume-processes.html