### PR TITLE
system/service.py: Add ability to provide a regex to pattern

### DIFF
--- a/system/service.py
+++ b/system/service.py
@@ -54,10 +54,10 @@ options:
         required: false
         version_added: "0.7"
         description:
-        - If the service does not respond to the status command, name a
-          substring to look for as would be found in the output of the I(ps)
-          command as a stand-in for a status result.  If the string is found,
-          the service will be assumed to be running.
+        - If the service does not respond to the status command, name a substring
+          (or regex) pattern to look for as would be found in the output of the I(ps)
+          command as a stand-in for a status result.  If the string is found, the
+          service will be assumed to be running. Which type is controlled by C(use_regex) option.
     enabled:
         required: false
         choices: [ "yes", "no" ]
@@ -80,6 +80,13 @@ options:
             - Normally it uses the value of the 'ansible_service_mgr' fact and falls back to the old 'service' module when none matching is found.
         default: 'auto'
         version_added: 2.2
+    use_regex:
+        required: false
+        version_added: "2.3"
+        default: "False"
+        choices: [ True, False ]
+        description:
+            - If false the pattern is a substring. if true it is a python regex
 '''
 
 EXAMPLES = '''
@@ -113,6 +120,13 @@ EXAMPLES = '''
     name: foo
     pattern: /usr/bin/foo
     state: started
+
+# Example action to start service foo, based on running process /usr/bin/foo (with no arguments)
+- service:
+    name: foo
+    pattern: "/usr/bin/foo$"
+    state: started
+    use_regex: True
 
 # Example action to restart network service for interface eth0
 - service:
@@ -166,6 +180,7 @@ class Service(object):
         self.state          = module.params['state']
         self.sleep          = module.params['sleep']
         self.pattern        = module.params['pattern']
+        self.use_regex      = module.params['use_regex']
         self.enable         = module.params['enabled']
         self.runlevel       = module.params['runlevel']
         self.changed        = False
@@ -278,6 +293,22 @@ class Service(object):
                     data += dat
             return json.loads(data)
 
+    def pfilter(self, line, pattern=None, use_regex=False):
+        '''filter using pattern'''
+
+        if pattern is None:
+            return True
+
+        if use_regex:
+            r = re.compile(pattern)
+            if r.match(line):
+                return True
+        else:
+            if pattern in line:
+                return True
+
+        return False
+
     def check_ps(self):
         # Set ps flags
         if platform.system() == 'SunOS':
@@ -294,7 +325,7 @@ class Service(object):
             self.running = False
             lines = psout.split("\n")
             for line in lines:
-                if self.pattern in line and not "pattern=" in line:
+                if self.pfilter(line, self.pattern, self.use_regex) and not "pattern=" in line:
                     # so as to not confuse ./hacking/test-module
                     self.running = True
                     break
@@ -1486,6 +1517,7 @@ def main():
             enabled = dict(type='bool'),
             runlevel = dict(required=False, default='default'),
             arguments = dict(aliases=['args'], default=''),
+            use_regex = dict(default="False", type='bool'),
         ),
         supports_check_mode=True,
         required_one_of=[['state', 'enabled']],


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
system/service.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
I ended up in a situation where a service I use (freeradius) does not support the status command via init.d, and using the basic pattern matching fails, because I'm managing freeradius using monit/runit with the -f option (and i'd like that up and running).

We wanted to have the service disabled and stopped (via init.d) while still allowing another instance of it to run via runit. In its current state, the task would always report as "changed", because:
- Without the pattern, it always detects it as running, runs the stop command, and change will be reported.
- With the pattern, it detects the runit managed free radius, runs the stop command, and change will be reported.

I have mirrored the implementation started in ##2249 for adding regex to the find module. It has been implemented in service.py

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
N/A. I am just introducing a backend change to the service module for pattern detection to determine state.
```

