### PR TITLE
Ini_file: fix regression with the create option

### DIFF
--- a/files/ini_file.py
+++ b/files/ini_file.py
@@ -80,10 +80,10 @@ options:
   create:
      required: false
      choices: [ "yes", "no" ]
-     default: "no"
+     default: "yes"
      description:
-       - If specified, the file will be created if it does not already exist.
-         By default it will fail if the file is missing.
+       - If set to 'no', the module will fail if the file does not already exist.
+         By default it will create the file if it is missing.
      version_added: "2.2"
 notes:
    - While it is possible to add an I(option) without specifying a I(value), this makes
@@ -252,7 +252,7 @@ def main():
             backup = dict(default='no', type='bool'),
             state = dict(default='present', choices=['present', 'absent']),
             no_extra_spaces = dict(required=False, default=False, type='bool'),
-            create=dict(default=False, type='bool')
+            create=dict(default=True, type='bool')
         ),
         add_file_common_args = True,
         supports_check_mode = True


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
ini_file

##### ANSIBLE VERSION
ansible 2.2.0.0

##### SUMMARY
Fix the regression introduced with the new create parameter. Change the default value to 'yes' to
behave the same way as previous Ansible versions.

Fixes: #5488