### PR TITLE
fix nxos_facts to support multiple neighbors

### DIFF
--- a/network/nxos/nxos_facts.py
+++ b/network/nxos/nxos_facts.py
@@ -328,18 +328,18 @@ class Interfaces(FactsBase):
         return interfaces
 
     def populate_neighbors(self, data):
-        data = data['TABLE_nbor']
+        data = data['TABLE_nbor']['ROW_nbor']
         if isinstance(data, dict):
             data = [data]
 
         objects = dict()
         for item in data:
-            local_intf = item['ROW_nbor']['l_port_id']
+            local_intf = item['l_port_id']
             if local_intf not in objects:
                 objects[local_intf] = list()
             nbor = dict()
-            nbor['port'] = item['ROW_nbor']['port_id']
-            nbor['host'] = item['ROW_nbor']['chassis_id']
+            nbor['port'] = item['port_id']
+            nbor['host'] = item['chassis_id']
             objects[local_intf].append(nbor)
         return objects
 
@@ -428,8 +428,6 @@ class Legacy(FactsBase):
 
     def parse_module(self, data):
         data = data['TABLE_modinfo']['ROW_modinfo']
-        if isinstance(data, dict):
-            data = [data]
         objects = list(self.transform_iterable(data, self.MODULE_MAP))
         return objects
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
nxos_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0

```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->


Testing may have originally be done with nexus with one neighbor.  When there are multiple, it returns a list (as typical with nx-api).  This fixes that.


