### PR TITLE
Fixing md5 check on nxos_file_copy

### DIFF
--- a/network/nxos/nxos_file_copy.py
+++ b/network/nxos/nxos_file_copy.py
@@ -273,6 +273,8 @@ def execute_show(cmds, module, command_type=None):
 
 def execute_show_command(command, module, command_type='cli_show'):
     if module.params['transport'] == 'cli':
+        if 'md5sum' in command:
+            command += ' | json'
         cmds = [command]
         body = execute_show(cmds, module)
     elif module.params['transport'] == 'nxapi':
@@ -324,11 +326,12 @@ def get_remote_md5(module, dst):
 
 def get_local_md5(module, blocksize=2**20):
     md5 = hashlib.md5()
-    with open(module.params['local_file'], 'rb') as f:
-        buf = f.read(blocksize)
-        while buf:
-            md5.update(buf)
-            buf = f.read(blocksize)
+    local_file = open(module.params['local_file'], 'rb')
+    buf = local_file.read(blocksize)
+    while buf:
+        md5.update(buf)
+        buf = local_file.read(blocksize)
+    local_file.close()
     return md5.hexdigest()
 
 

--- a/network/nxos/nxos_file_copy.py
+++ b/network/nxos/nxos_file_copy.py
@@ -84,6 +84,7 @@ import os
 from scp import SCPClient
 import paramiko
 import time
+import hashlib
 
 # COMMON CODE FOR MIGRATION
 import re
@@ -286,7 +287,8 @@ def remote_file_exists(module, dst, file_system='bootflash:'):
     body = execute_show_command(command, module, command_type='cli_show_ascii')
     if 'No such file' in body[0]:
         return False
-    return True
+    else:
+        return file_already_exists(module, dst)
 
 
 def verify_remote_file_exists(module, dst, file_system='bootflash:'):
@@ -299,6 +301,35 @@ def verify_remote_file_exists(module, dst, file_system='bootflash:'):
 
 def local_file_exists(module):
     return os.path.isfile(module.params['local_file'])
+
+
+def file_already_exists(module, dst):
+    dst_hash = get_remote_md5(module, dst)
+    src_hash = get_local_md5(module)
+    if src_hash == dst_hash:
+        return True
+    return False
+
+
+def already_transfered(self):
+    return self.file_already_exists()
+
+
+def get_remote_md5(module, dst):
+    command = 'show file {0}{1} md5sum'.format(module.params['file_system'], dst)
+    md5_body = execute_show_command(command, module)
+    if md5_body:
+        return md5_body[0]['file_content_md5sum'].strip()
+
+
+def get_local_md5(module, blocksize=2**20):
+    md5 = hashlib.md5()
+    with open(module.params['local_file'], 'rb') as f:
+        buf = f.read(blocksize)
+        while buf:
+            md5.update(buf)
+            buf = f.read(blocksize)
+    return md5.hexdigest()
 
 
 def get_flash_size(module):
@@ -338,7 +369,9 @@ def transfer_file(module, dest):
     ssh.connect(
         hostname=hostname,
         username=username,
-        password=password)
+        password=password,
+        allow_agent=False,
+        look_for_keys=False)
 
     full_remote_path = '{}{}'.format(module.params['file_system'], dest)
     scp = SCPClient(ssh.get_transport())


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_file_copy

##### ANSIBLE VERSION
```
ansible 2.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Fix md5 sums check