### PR TITLE
fixes corner case for enabled=yes with systemd services

### DIFF
--- a/system/systemd.py
+++ b/system/systemd.py
@@ -322,6 +322,8 @@ def main():
         # check systemctl result or if it is a init script
         if rc == 0:
             enabled = True
+        elif out.startswith('disabled'):
+            enabled = False
         elif rc == 1:
             # Deals with init scripts
             # if both init script and unit file exist stdout should have enabled/disabled, otherwise use rc entries


### PR DESCRIPTION
fixes corner case for enabled=yes with systemd services
when both unit file and sysv init script exist
same fix as in system/service.py for system/systemd.py

fixes #3764
also see https://github.com/ansible/ansible-modules-core/commit/92b4ae4768dce0b159456c44bd1c61321d16ae80