### PR TITLE
Allowing community removal without specifying access or group on nxos_snmp_community

### DIFF
--- a/network/nxos/nxos_snmp_community.py
+++ b/network/nxos/nxos_snmp_community.py
@@ -61,12 +61,14 @@ options:
         required: false
         default: false
         choices: ['true','false']
+        version_added: 2.2
     config:
         description:
             - Configuration string to be used for module operations. If not
               specified, the module will use the current running configuration.
         required: false
         default: null
+        version_added: 2.2
     save:
         description:
             - Specify to save the running configuration after
@@ -74,6 +76,7 @@ options:
         required: false
         default: false
         choices: ['true','false']
+        version_added: 2.2
 '''
 
 EXAMPLES = '''

--- a/network/nxos/nxos_snmp_community.py
+++ b/network/nxos/nxos_snmp_community.py
@@ -56,7 +56,7 @@ options:
         choices: ['present','absent']
     include_defaults:
         description:
-            - Specify to use or not the complete running configuration
+            - Specify to use or not the complete runnning configuration
               for module operations.
         required: false
         default: false
@@ -126,7 +126,7 @@ from ansible.module_utils.shell import ShellError
 try:
     from ansible.module_utils.nxos import get_module
 except ImportError:
-    from ansible.module_utils.nxos import NetworkModule, NetworkError
+    from ansible.module_utils.nxos import NetworkModule
 
 
 def to_list(val):
@@ -348,13 +348,17 @@ def main():
             save=dict(type='bool', default=False)
     )
     module = get_network_module(argument_spec=argument_spec,
-                                required_one_of=[['access', 'group']],
                                 mutually_exclusive=[['access', 'group']],
                                 supports_check_mode=True)
 
     access = module.params['access']
     group = module.params['group']
     state = module.params['state']
+
+    if state == 'present':
+        if not group and not access:
+            module.fail_json(msg='group or access param must be '
+                                 'used when state=present')
 
     if access:
         if access == 'ro':

--- a/network/nxos/nxos_snmp_community.py
+++ b/network/nxos/nxos_snmp_community.py
@@ -56,7 +56,7 @@ options:
         choices: ['present','absent']
     include_defaults:
         description:
-            - Specify to use or not the complete runnning configuration
+            - Specify to use or not the complete running configuration
               for module operations.
         required: false
         default: false

--- a/network/nxos/nxos_snmp_community.py
+++ b/network/nxos/nxos_snmp_community.py
@@ -126,7 +126,7 @@ from ansible.module_utils.shell import ShellError
 try:
     from ansible.module_utils.nxos import get_module
 except ImportError:
-    from ansible.module_utils.nxos import NetworkModule
+    from ansible.module_utils.nxos import NetworkModule, NetworkError
 
 
 def to_list(val):


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
nxos_snmp_community

##### ANSIBLE VERSION
```
ansible 2.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Allowing community removal without specifying access or group