### PR TITLE
Revert "stat: doc: add version for new returns"

### DIFF
--- a/files/stat.py
+++ b/files/stat.py
@@ -311,19 +311,19 @@ stat:
             type: string
             sample: us-ascii
         readable:
-            description: Tells you if the invoking user has the right to read the path, added in version 2.2
+            description: Tells you if the invoking user has the right to read the path
             returned: success, path exists and user can read the path
             type: boolean
             sample: False
             version_added: 2.2
         writeable:
-            description: Tells you if the invoking user has the right to write the path, added in version 2.2
+            description: Tells you if the invoking user has the right to write the path
             returned: success, path exists and user can write the path
             type: boolean
             sample: False
             version_added: 2.2
         executable:
-            description: Tells you if the invoking user has the execute the path, added in version 2.2
+            description: Tells you if the invoking user has the execute the path
             returned: success, path exists and user can execute the path
             type: boolean
             sample: False


### PR DESCRIPTION
Reverts ansible/ansible-modules-core#5594

using version_added field instead of adding to description