### PR TITLE
Do not require password when deleting os_user

### DIFF
--- a/cloud/openstack/os_user.py
+++ b/cloud/openstack/os_user.py
@@ -191,10 +191,6 @@ def main():
     module_kwargs = openstack_module_kwargs()
     module = AnsibleModule(
         argument_spec,
-        required_if=[
-            ('update_password', 'always', ['password']),
-            ('update_password', 'on_create', ['password']),
-        ],
         **module_kwargs)
 
     if not HAS_SHADE:
@@ -219,6 +215,11 @@ def main():
             domain_id = _get_domain_id(opcloud, domain)
 
         if state == 'present':
+            if update_password in ('always', 'on_create'):
+                if not password:
+                    msg = ("update_password is %s but a password value is "
+                          "missing") % update_password
+                    self.fail_json(msg=msg)
             default_project_id = None
             if default_project:
                 default_project_id = _get_default_project_id(cloud, default_project)


### PR DESCRIPTION
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

<!--- Name of the plugin/module/task -->
os_user

<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

I broke backwards compat with the addition to define when a password
should be updated. It was requiring that a password value be passed when
deleting a user, which seems silly.

This moves the argument logic out of the argument spec and into when it
would be needed, when state is present.