### PR TITLE
Update system/group.py module on Darwin so system=yes works.

### DIFF
--- a/system/group.py
+++ b/system/group.py
@@ -269,6 +269,11 @@ class DarwinGroup(Group):
         cmd += [ '-o', 'create' ]
         if self.gid is not None:
             cmd += [ '-i', self.gid ]
+        elif 'system' in kwargs and kwargs['system'] == True:
+            gid = self.get_lowest_available_system_gid()
+            if gid != False:
+                self.gid = str(gid)
+                cmd += [ '-i', self.gid ]
         cmd += [ '-L', self.name ]
         (rc, out, err) = self.execute_command(cmd)
         return (rc, out, err)
@@ -291,6 +296,26 @@ class DarwinGroup(Group):
             (rc, out, err) = self.execute_command(cmd)
             return (rc, out, err)
         return (None, '', '')
+    
+    def get_lowest_available_system_gid(self):
+        # check for lowest available system gid (< 500)
+        try:
+            cmd = [self.module.get_bin_path('dscl', True)]
+            cmd += [ '/Local/Default', '-list', '/Groups', 'PrimaryGroupID']
+            (rc, out, err) = self.execute_command(cmd)
+            lines = out.splitlines()
+            highest = 0
+            for group_info in lines:
+                parts = group_info.split(' ')
+                if len(parts) > 1:
+                    gid = int(parts[-1])
+                    if gid > highest and gid < 500:
+                        highest = gid
+            if highest == 0 or highest == 499:
+                return False
+            return (highest + 1)
+        except:
+            return False
 
 class OpenBsdGroup(Group):
     """


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
system/group.py module

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel 11465134fa) last updated 2016/11/14 21:27:46 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 8d1fe3b444) last updated 2016/11/14 21:34:36 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 88e58df86b) last updated 2016/11/14 21:34:49 (GMT +200)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
Extend group module for Darwin operating systems such that system options now generates a system
gid (< 500) if possible.

Add `get_lowest_available_system_gid` method to `DarwinGroup` and use it, when user has not
provided a `gid` and has set `system=yes` option. Only call `get_lowest_available_system_gid` in `group_add` method. Like that it stays idempotent.

Commit message: Add ability to add system groups with next free system gid (< 500) on macOS.