### PR TITLE
made ec2_group idempotent to leading / trailing spaces for ports

### DIFF
--- a/cloud/amazon/ec2_group.py
+++ b/cloud/amazon/ec2_group.py
@@ -149,9 +149,12 @@ def make_rule_key(prefix, rule, group_id, cidr_ip):
     else:  # isinstance boto.ec2.securitygroup.IPPermissions
         proto, from_port, to_port = [getattr(rule, x, None) for x in ('ip_protocol', 'from_port', 'to_port')]
 
-    key = "%s-%s-%s-%s-%s-%s" % (prefix, proto, from_port, to_port, group_id, cidr_ip)
+    key = "%s-%s-%s-%s-%s-%s" % (prefix, proto, to_int_safe(from_port), to_int_safe(to_port), group_id, cidr_ip)
     return key.lower().replace('-none', '-None')
 
+
+def to_int_safe(str):
+    return int(str) if str else None
 
 def addRulesToLookup(rules, prefix, dict):
     for rule in rules:

--- a/files/stat.py
+++ b/files/stat.py
@@ -62,7 +62,7 @@ options:
     required: false
     choices: [ Yes, No ]
     default: Yes
-    version_added: "2.1"
+    version_added: "2.3"
     aliases: [ 'mime', 'mime_type', 'mime-type' ]
   get_attributes:
     description:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`cloud/amazon/ec2_group.py`

##### ANSIBLE VERSION
```
ansible 2.3.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Could be related to 
https://github.com/ansible/ansible-modules-core/issues/2576

Enables idempotence with leading / trailing spaces in `from_port` and `to_port`
```
"rules":[{"to_port": " 9090", "from_port": " 9090", "cidr_ip": "0.0.0.0/0", "proto": "tcp"}]
```

Otherwise the first ec2_group creation succeeds, but the following ones won't and will fail with
```
<Code>InvalidPermission.Duplicate</Code><Message>the specified rule "peer: sg-795f0c1f, TCP, from port: 9090, to port: 9090, ALLOW" already exists</Message></Error></Errors>
```