### PR TITLE
AWS Elasticache module check mode, replication group, and security group names

### DIFF
--- a/cloud/amazon/elasticache.py
+++ b/cloud/amazon/elasticache.py
@@ -154,7 +154,7 @@ class ElastiCacheManager(object):
     def __init__(self, module, name, engine, cache_engine_version, node_type,
                  num_nodes, cache_port, cache_parameter_group, cache_subnet_group,
                  cache_security_groups, security_group_ids, zone, wait,
-                 hard_modify, region, **aws_connect_kwargs):
+                 hard_modify, region, replication_group, **aws_connect_kwargs):
         self.module = module
         self.name = name
         self.engine = engine
@@ -169,6 +169,7 @@ class ElastiCacheManager(object):
         self.zone = zone
         self.wait = wait
         self.hard_modify = hard_modify
+        self.replication_group = replication_group
 
         self.region = region
         self.aws_connect_kwargs = aws_connect_kwargs
@@ -380,6 +381,8 @@ class ElastiCacheManager(object):
 
     def _requires_modification(self):
         """Check if cluster requires (nondestructive) modification"""
+        if self.replication_group:
+            return False
         # Check modifiable data attributes
         modifiable_data = {
             'NumCacheNodes': self.num_nodes,
@@ -497,7 +500,8 @@ def main():
             security_group_names  ={'required': False, 'default': [], 'type': 'list'},
             zone                  ={'required': False, 'default': None},
             wait                  ={'required': False, 'type' : 'bool', 'default': True},
-            hard_modify           ={'required': False, 'type': 'bool', 'default': False}
+            hard_modify           ={'required': False, 'type': 'bool', 'default': False},
+            replication_group     ={'required': False, 'type': 'str', 'default': None},
         )
     )
 
@@ -526,11 +530,16 @@ def main():
     wait = module.params['wait']
     hard_modify = module.params['hard_modify']
     cache_parameter_group = module.params['cache_parameter_group']
+    replication_group = module.params['replication_group']
 
     if cache_subnet_group and cache_security_groups:
         module.fail_json(msg="Can't specify both cache_subnet_group and cache_security_groups")
 
-    if state == 'present' and not num_nodes:
+    if replication_group:
+        engine = None
+        node_type = None
+
+    if state == 'present' and not num_nodes and not replication_group:
         module.fail_json(msg="'num_nodes' is a required parameter. Please specify num_nodes > 0")
 
     if not region:
@@ -556,7 +565,8 @@ def main():
                                              cache_subnet_group,
                                              cache_security_groups,
                                              security_group_ids, zone, wait,
-                                             hard_modify, region, **aws_connect_kwargs)
+                                             hard_modify, region,
+                                             replication_group, **aws_connect_kwargs)
 
     if state == 'present':
         elasticache_manager.ensure_present()


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
AWS elasticache module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 1.9.1
  configured module search path = None
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The module previously had not supported check mode, so this pull request was partly made to address that by only making API calls when check mode is not activated. Also, there was no support for managing replication groups for elasticache clusters, so this pull request also attempts to address that. Also, it may be useful to pass in security group names instead of ids, since you might not want to hardcode security group ids in your configuration management, so the module can query for the ids using these names.

