### PR TITLE
Add local network type to openstack/os_network

### DIFF
--- a/cloud/openstack/os_network.py
+++ b/cloud/openstack/os_network.py
@@ -69,7 +69,7 @@ options:
    provider_network_type:
      description:
         - The type of physical network that maps to this network resource.
-     choices: ['flat', 'vlan', 'vxlan', 'gre', 'uplink']
+     choices: ['flat', 'vlan', 'vxlan', 'gre', 'uplink', 'local', 'geneve']
      required: false
      default: None
      version_added: "2.1"
@@ -169,7 +169,8 @@ def main():
         external=dict(default=False, type='bool'),
         provider_physical_network=dict(required=False),
         provider_network_type=dict(required=False, default=None,
-                                   choices=['flat', 'vlan', 'vxlan', 'gre', 'uplink']),
+                                   choices=['flat', 'vlan', 'vxlan', 'gre', 
+                                            'uplink', 'local', 'geneve']),
         provider_segmentation_id=dict(required=False),
         state=dict(default='present', choices=['absent', 'present']),
         project=dict(default=None)


### PR DESCRIPTION
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

<!--- Name of the plugin/module/task -->
openstack/os_network

<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

This type is used by some plugins, such as networking_calico.

Fixes #5589