### PR TITLE
vsphere_guest - Display relevant error message when user tries to perform state operation on a vm which doesn't exists

### DIFF
--- a/cloud/vmware/vsphere_guest.py
+++ b/cloud/vmware/vsphere_guest.py
@@ -1874,6 +1874,12 @@ def main():
         elif state == 'absent':
             module.exit_json(changed=False, msg="vm %s not present" % guest)
 
+        # check if user is trying to perform state operation on a vm which doesn't exists
+        elif state in ['present', 'powered_off', 'powered_on'] and not all((vm_extra_config,
+                                                       vm_hardware, vm_disk, vm_nic, esxi)):
+            module.exit_json(changed=False, msg="vm %s not present" % guest)
+
+
         # Create the VM
         elif state in ['present', 'powered_off', 'powered_on']:
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
vsphere_guest

##### ANSIBLE VERSION
devel

##### SUMMARY
Display relevant error message when user tries to perform state operation on a vm which doesn't exists.
Fixes issue #5633 

### Playbook:

```
  - vsphere_guest:
     vcenter_hostname: hostname
     username: username
     password: password
     validate_certs: False
     guest: doesnt_exists
     state: powered_on
```

### Before:

`"msg": "Missing required key/pair [disk1]. vm_disk must contain {'disk1': {'datastore': <type 'basestring'>, 'type': <type 'basestring'>, 'size_gb': <type 'int'>}}"`

### After:

`"msg": "vm doesnt_exists not present"`
