### PR TITLE
replace - documentation update for short form task parsing and escape sequences

### DIFF
--- a/files/replace.py
+++ b/files/replace.py
@@ -50,6 +50,9 @@ options:
         U(http://docs.python.org/2/library/re.html).
         Uses multiline mode, which means C(^) and C($) match the beginning
         and end respectively of I(each line) of the file.
+      - Note that, as of ansible 2, short form tasks should have any escape
+        sequences backslash-escaped in order to prevent them being parsed
+        as string literal escapes. See the examples.
   replace:
     required: false
     description:
@@ -95,6 +98,15 @@ EXAMPLES = r"""
     regexp: '^(NameVirtualHost|Listen)\s+80\s*$'
     replace: '\1 127.0.0.1:8080'
     validate: '/usr/sbin/apache2ctl -f %s -t'
+
+# short form task (in ansible 2+) necessitates backslash-escaped sequences
+- replace: dest=/etc/hosts regexp='\\b(localhost)(\\d*)\\b' replace='\\1\\2.localdomain\\2 \\1\\2'
+
+# long form task does not
+- replace:
+    dest: /etc/hosts
+    regexp: '\b(localhost)(\d*)\b'
+    replace: '\1\2.localdomain\2 \1\2'
 """
 
 def write_changes(module,contents,dest):


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
`replace` module

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = /vagrant/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

Per the discussion in #5626, documented a gotcha with ansible 2 parsing of short form tasks and escape sequences.

Long story short, non-regexp escape sequences are interpreted as string literals (newlines, tabs, etc) and word boundary escape sequences (`\b`) are mistakenly interpreted as literal backspaces. Since this happens outside of the module, all I can do is document the oddity.