### PR TITLE
Performance improvement using in-operator on dicts

### DIFF
--- a/cloud/google/gce.py
+++ b/cloud/google/gce.py
@@ -449,7 +449,7 @@ def create_instances(module, gce, instance_names, number):
     bad_perms = []
     if service_account_permissions:
         for perm in service_account_permissions:
-            if perm not in gce.SA_SCOPES_MAP.keys():
+            if perm not in gce.SA_SCOPES_MAP:
                 bad_perms.append(perm)
         if len(bad_perms) > 0:
             module.fail_json(msg='bad permissions: %s' % str(bad_perms))

--- a/network/nxos/nxos_bgp.py
+++ b/network/nxos/nxos_bgp.py
@@ -757,7 +757,7 @@ def state_present(module, existing, proposed, candidate):
         elif value is False:
             commands.append('no {0}'.format(key))
         elif value == 'default':
-            if key in PARAM_TO_DEFAULT_KEYMAP.keys():
+            if key in PARAM_TO_DEFAULT_KEYMAP:
                 commands.append('{0} {1}'.format(key, PARAM_TO_DEFAULT_KEYMAP[key]))
             elif existing_commands.get(key):
                 existing_value = existing_commands.get(key)

--- a/network/nxos/nxos_bgp_af.py
+++ b/network/nxos/nxos_bgp_af.py
@@ -889,7 +889,7 @@ def state_present(module, existing, proposed, candidate):
             commands.append('no {0}'.format(key))
 
         elif value == 'default':
-            if key in PARAM_TO_DEFAULT_KEYMAP.keys():
+            if key in PARAM_TO_DEFAULT_KEYMAP:
                 commands.append('{0} {1}'.format(key, PARAM_TO_DEFAULT_KEYMAP[key]))
 
             elif existing_commands.get(key):

--- a/network/nxos/nxos_feature.py
+++ b/network/nxos/nxos_feature.py
@@ -355,7 +355,7 @@ def get_available_features(feature, module):
             if 'enabled' in state:
                 state = 'enabled'
 
-            if feature not in available_features.keys():
+            if feature not in available_features:
                 available_features[feature] = state
             else:
                 if (available_features[feature] == 'disabled' and
@@ -443,7 +443,7 @@ def main():
     state = module.params['state'].lower()
 
     available_features = get_available_features(feature, module)
-    if feature not in available_features.keys():
+    if feature not in available_features:
         module.fail_json(
             msg='Invalid feature name.',
             features_currently_supported=available_features,

--- a/network/nxos/nxos_igmp_interface.py
+++ b/network/nxos/nxos_igmp_interface.py
@@ -823,7 +823,7 @@ def main():
 
     if state == 'absent':
         for each in CANNOT_ABSENT:
-            if each in proposed.keys():
+            if each in proposed:
                 module.fail_json(msg='only params: oif_prefix, oif_source, '
                                      'oif_routemap can be used when '
                                      'state=absent')

--- a/network/nxos/nxos_ip_interface.py
+++ b/network/nxos/nxos_ip_interface.py
@@ -560,7 +560,7 @@ def get_config_ip_commands(delta, interface, existing, version):
     # loop used in the situation that just an IP address or just a
     # mask is changing, not both.
     for each in ['addr', 'mask']:
-        if each not in delta.keys():
+        if each not in delta:
             delta[each] = existing[each]
 
     if version == 'v4':

--- a/network/nxos/nxos_static_route.py
+++ b/network/nxos/nxos_static_route.py
@@ -321,7 +321,7 @@ def get_existing(module, prefix, warnings):
             group_route = match_route.groupdict()
 
             for key in key_map:
-                if key not in group_route.keys():
+                if key not in group_route:
                     group_route[key] = ''
             group_route['prefix'] = prefix
             group_route['vrf'] = module.params['vrf']

--- a/network/nxos/nxos_vpc_interface.py
+++ b/network/nxos/nxos_vpc_interface.py
@@ -501,7 +501,7 @@ def main():
     if vpc:
         mapping = get_existing_portchannel_to_vpc_mappings(module)
 
-        if vpc in mapping.keys() and portchannel != mapping[vpc].strip('Po'):
+        if vpc in mapping and portchannel != mapping[vpc].strip('Po'):
             module.fail_json(msg="This vpc is already configured on "
                                  "another portchannel.  Remove it first "
                                  "before trying to assign it here. ",

--- a/packaging/os/yum.py
+++ b/packaging/os/yum.py
@@ -877,7 +877,7 @@ def latest(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
                 # or virtual provides (like "python-*" or "smtp-daemon") while
                 # updates contains name only.
                 this_name_only = '-'.join(this.split('-')[:-2])
-                if spec in pkgs['update'] and this_name_only in updates.keys():
+                if spec in pkgs['update'] and this_name_only in updates:
                     nothing_to_do = False
                     will_update.add(spec)
                     # Massage the updates list


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
Various components

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.2

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

Just a small cleanup for the existing occurrences.

Using the in-operator for hash lookups is faster than using .keys()
http://stackoverflow.com/questions/29314269/why-do-key-in-dict-and-key-in-dict-keys-have-the-same-output