### PR TITLE
Ensure proper error when fetch_url returns status -1

### DIFF
--- a/network/basics/get_url.py
+++ b/network/basics/get_url.py
@@ -227,10 +227,14 @@ def url_get(module, url, dest, use_proxy, last_mod_time, force, timeout=10, head
     if info['status'] == 304:
         module.exit_json(url=url, dest=dest, changed=False, msg=info.get('msg', ''))
 
-    # create a temporary file and copy content to do checksum-based replacement
+    # Exceptions in fetch_url may result in a status -1, the ensures a proper error to the user in all cases
+    if info['status'] == -1:
+        module.fail_json(msg=info['msg'], url=url, dest=dest)
+
     if info['status'] != 200 and not url.startswith('file:/') and not (url.startswith('ftp:/') and info.get('msg', '').startswith('OK')):
         module.fail_json(msg="Request failed", status_code=info['status'], response=info['msg'], url=url, dest=dest)
 
+    # create a temporary file and copy content to do checksum-based replacement
     if tmp_dest != '':
         # tmp_dest should be an existing dir
         tmp_dest_is_dir = os.path.isdir(tmp_dest)


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
get_url

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.2 and older

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

When using a file:// or ftp:// URL the normal provisions that a non-200 status code means error have been disabled. But the common error status -1 from fetch_url is not properly returning an error message. This fix ensures that if the status code returns -1, we always return a proper error message.

This fixes #3563