### PR TITLE
Timeout: Fix #4281 Add timeout param to junos_config module

### DIFF
--- a/network/junos/_junos_template.py
+++ b/network/junos/_junos_template.py
@@ -81,6 +81,14 @@ options:
     required: false
     default: null
     choices: ['text', 'xml', 'set']
+  netconf_timeout:
+    description:
+      - Extend the NETCONF RPC timeout beyond the default value of
+        30 seconds. Set this value to accommodate changes that might
+        take longer than the default timeout interval.
+    required: false
+    default: 0
+    version_added: "2.3"
 requirements:
   - junos-eznc
 notes:
@@ -91,6 +99,7 @@ notes:
 EXAMPLES = """
 - junos_template:
     src: config.j2
+    netconf_timeout: 60
     comment: update system config
 
 - name: replace config hierarchy
@@ -117,6 +126,7 @@ def main():
         action=dict(default='merge', choices=['merge', 'overwrite', 'replace']),
         config_format=dict(choices=['text', 'set', 'xml']),
         backup=dict(default=False, type='bool'),
+        netconf_timeout=dict(default=0, type='int'),
         transport=dict(default='netconf', choices=['netconf'])
     )
 

--- a/network/junos/junos_command.py
+++ b/network/junos/junos_command.py
@@ -95,6 +95,14 @@ options:
     required: false
     default: 'xml'
     choices: ['xml', 'text']
+  netconf_timeout:
+    description:
+      - Extend the NETCONF RPC timeout beyond the default value of
+        30 seconds. Set this value to accommodate commands
+        that might take longer than the default timeout interval.
+    required: false
+    default: 0
+    version_added: "2.3"
 requirements:
   - junos-eznc
 notes:
@@ -114,6 +122,7 @@ vars:
 - name: run a set of commands
   junos_command:
     commands: ['show version', 'show ip route']
+    netconf_timeout: 60
     provider: "{{ netconf }}"
 
 - name: run a command with a conditional applied to the second command
@@ -224,6 +233,7 @@ def main():
         retries=dict(default=10, type='int'),
         interval=dict(default=1, type='int'),
 
+        netconf_timeout=dict(default=0, type='int'),
         transport=dict(default='netconf', choices=['netconf'])
     )
 

--- a/network/junos/junos_config.py
+++ b/network/junos/junos_config.py
@@ -121,6 +121,7 @@ options:
         timeout interval.
     required: false
     default: 0
+    version_added: "2.3"
 requirements:
   - junos-eznc
 notes:

--- a/network/junos/junos_config.py
+++ b/network/junos/junos_config.py
@@ -113,7 +113,7 @@ options:
     default: no
     choices: ['yes', 'no']
     version_added: "2.2"
-  timeout:
+  netconf_timeout:
     description:
       - Extend the NETCONF RPC timeout beyond the default value of
         30 seconds. Set this value to accommodate configuration
@@ -199,7 +199,6 @@ def guess_format(config):
 
     return 'text'
 
-
 def config_to_commands(config):
     set_format = config.startswith('set') or config.startswith('delete')
     candidate = NetworkConfig(indent=4, contents=config, device_os='junos')
@@ -218,7 +217,6 @@ def config_to_commands(config):
         commands = str(candidate).split('\n')
 
     return commands
-
 
 def diff_commands(commands, config):
     config = [unicode(c).replace("'", '') for c in config]
@@ -241,7 +239,6 @@ def diff_commands(commands, config):
                         visited.add(item)
 
     return updates
-
 
 def load_config(module, result):
     candidate = module.params['lines'] or module.params['src']
@@ -273,7 +270,6 @@ def load_config(module, result):
         result['changed'] = True
         result['diff'] = dict(prepared=diff)
 
-
 def rollback_config(module, result):
     rollback = module.params['rollback']
 
@@ -286,23 +282,16 @@ def rollback_config(module, result):
         result['changed'] = True
         result['diff'] = dict(prepared=diff)
 
-
 def zeroize_config(module, result):
     if not module.check_mode:
         module.cli.run_commands('request system zeroize')
     result['changed'] = True
 
-
 def confirm_config(module, result):
     checkonly = module.check_mode
     result['changed'] = module.connection.confirm_commit(checkonly)
 
-
 def run(module, result):
-    timeout = module.params['timeout']
-    if timeout > 0 and module.params['transport'] == 'netconf':
-        module.connection.device.timeout = timeout
-
     if module.params['rollback']:
         return rollback_config(module, result)
     elif module.params['zeroize']:
@@ -332,9 +321,7 @@ def main():
         rollback=dict(type='int'),
         zeroize=dict(default=False, type='bool'),
 
-        # timeout
-        timeout=dict(default=0, type='int'),
-
+        netconf_timeout=dict(default=0, type='int'),
         transport=dict(default='netconf', choices=['netconf'])
     )
 

--- a/network/junos/junos_facts.py
+++ b/network/junos/junos_facts.py
@@ -50,6 +50,14 @@ options:
     required: false
     default: text
     choices: ['xml', 'text']
+  netconf_timeout:
+    description:
+      - Extend the NETCONF RPC timeout beyond the default value of
+        30 seconds. Set this value to accommodate get fatcs
+        that might take longer than the default timeout interval.
+    required: false
+    default: 0
+    version_added: "2.3"
 requirements:
   - junos-eznc
 notes:
@@ -67,6 +75,7 @@ EXAMPLES = """
 - name: collect default set of facts and configuration
   junos_facts:
     config: yes
+    netconf_timeout: 60
 
 - name: collect default set of facts and configuration in text format
   junos_facts:
@@ -96,6 +105,7 @@ def main():
     spec = dict(
         config=dict(type='bool'),
         config_format=dict(default='text', choices=['xml', 'text']),
+        netconf_timeout=dict(default=0, type='int'),
         transport=dict(default='netconf', choices=['netconf'])
     )
 

--- a/network/junos/junos_package.py
+++ b/network/junos/junos_package.py
@@ -72,6 +72,14 @@ options:
     required: true
     default: false
     choices: ['true', 'false']
+  netconf_timeout:
+    description:
+      - Extend the NETCONF RPC timeout beyond the default value of
+        30 seconds. Set this value to accommodate netconf operations
+        that might take longer than the default timeout interval.
+    required: false
+    default: 0
+    version_added: "2.3"
 requirements:
   - junos-eznc
 notes:
@@ -86,6 +94,7 @@ EXAMPLES = """
 - name: install local package on remote device
   junos_package:
     src: junos-vsrx-12.1X46-D10.2-domestic.tgz
+    netconf_timeout: 60
 
 - name: install local package on remote device without rebooting
   junos_package:
@@ -127,6 +136,7 @@ def main():
         reboot=dict(type='bool', default=True),
         no_copy=dict(default=False, type='bool'),
         force=dict(type='bool', default=False),
+        netconf_timeout=dict(default=0, type='int'),
         transport=dict(default='netconf', choices=['netconf'])
     )
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
junos_config

##### ANSIBLE VERSION
<!---
Paste verbatim output from “ansible --version” between quotes below,
this is to help the Ansible team determine if this is a version specific
issue which is being fixed.
-->
```
ansible 2.3.0 (devel 461286f914)
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!---
Please paste verbatim command output below, e.g. before and after your change.
Even in the event of a Docs Pull Request, this allows the Ansible team to quickly
verify that there were no accidental syntax mistakes.
-->
```
Add NETCONF RPC timeout beyond the default value of
30 seconds. Set this value to accommodate configuration
changes (commits) that might take longer than the default
timeout interval.
```