### PR TITLE
Fixes #5692 - cron failure on existing for python 2.4

### DIFF
--- a/system/cron.py
+++ b/system/cron.py
@@ -717,8 +717,9 @@ def main():
                 changed = True
 
     # no changes to env/job, but existing crontab needs a terminating newline
-    if not changed and not crontab.existing.endswith(('\r', '\n')):
-        changed = True
+    if not changed:
+        if not (crontab.existing.endswith('\r') or crontab.existing.endswith('\n')):
+            changed = True
 
     res_args = dict(
         jobs = crontab.get_jobnames(),


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`cron` module

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
Was using `endswith` and a tuple of suffixes, instead should use two calls to `endswith`, for python 2.4 backward compat

Fixes #5692