### PR TITLE
Support forced SSL-verified connection with given CA certificate

### DIFF
--- a/database/postgresql/postgresql_db.py
+++ b/database/postgresql/postgresql_db.py
@@ -85,6 +85,18 @@ options:
     required: false
     default: present
     choices: [ "present", "absent" ]
+  ssl_mode:
+    description:
+      - Determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server
+    required: false
+    default: null
+    version_added: '2.3'
+  ssl_rootcert:
+    description:
+      - Specifies the name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities
+    required: false
+    default: null
+    version_added: '2.3'
 notes:
    - The default authentication assumes that you are either logging in as or sudo'ing to the C(postgres) account on the host.
    - This module uses I(psycopg2), a Python PostgreSQL database adapter. You must ensure that psycopg2 is installed on
@@ -238,6 +250,8 @@ def main():
             lc_collate=dict(default=""),
             lc_ctype=dict(default=""),
             state=dict(default="present", choices=["absent", "present"]),
+            ssl_mode=dict(default=""),
+            ssl_rootcert=dict(default=""),
         ),
         supports_check_mode = True
     )
@@ -262,7 +276,9 @@ def main():
         "login_host":"host",
         "login_user":"user",
         "login_password":"password",
-        "port":"port"
+        "port":"port",
+        "ssl_mode":"sslmode",
+        "ssl_rootcert":"sslrootcert"
     }
     kw = dict( (params_map[k], v) for (k, v) in iteritems(module.params)
               if k in params_map and v != '' )

--- a/database/postgresql/postgresql_privs.py
+++ b/database/postgresql/postgresql_privs.py
@@ -116,6 +116,18 @@ options:
       - 'Alias: I(login_password))'
     default: null
     required: no
+  ssl_mode:
+    description:
+      - Determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server
+    required: false
+    default: null
+    version_added: '2.3'
+  ssl_rootcert:
+    description:
+      - Specifies the name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities
+    required: false
+    default: null
+    version_added: '2.3'
 notes:
   - Default authentication assumes that postgresql_privs is run by the
     C(postgres) user on the remote host. (Ansible's C(user) or C(sudo-user)).
@@ -270,6 +282,8 @@ class Connection(object):
             "password":"password",
             "port":"port",
             "database": "database",
+            "ssl_mode":"sslmode",
+            "ssl_rootcert":"sslrootcert"
         }
         kw = dict( (params_map[k], getattr(params, k)) for k in params_map
                    if getattr(params, k) != '' )
@@ -537,7 +551,9 @@ def main():
             port=dict(type='int', default=5432),
             unix_socket=dict(default='', aliases=['login_unix_socket']),
             login=dict(default='postgres', aliases=['login_user']),
-            password=dict(default='', aliases=['login_password'], no_log=True)
+            password=dict(default='', aliases=['login_password'], no_log=True),
+            ssl_mode=dict(default=''),
+            ssl_rootcert=dict(default='')
         ),
         supports_check_mode = True
     )

--- a/database/postgresql/postgresql_user.py
+++ b/database/postgresql/postgresql_user.py
@@ -120,6 +120,18 @@ options:
     default: 'no'
     choices: [ "yes", "no" ]
     version_added: '2.0'
+  ssl_mode:
+    description:
+      - Determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server
+    required: false
+    default: null
+    version_added: '2.3'
+  ssl_rootcert:
+    description:
+      - Specifies the name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities
+    required: false
+    default: null
+    version_added: '2.3'
 notes:
    - The default authentication assumes that you are either logging in as or
      sudo'ing to the postgres account on the host.
@@ -576,7 +588,9 @@ def main():
             role_attr_flags=dict(default=''),
             encrypted=dict(type='bool', default='no'),
             no_password_changes=dict(type='bool', default='no'),
-            expires=dict(default=None)
+            expires=dict(default=None),
+            ssl_mode=dict(default=None),
+            ssl_rootcert=dict(default=None)
         ),
         supports_check_mode = True
     )
@@ -613,7 +627,9 @@ def main():
         "login_user":"user",
         "login_password":"password",
         "port":"port",
-        "db":"database"
+        "db":"database",
+        "ssl_mode":"sslmode",
+        "ssl_rootcert":"sslrootcert"
     }
     kw = dict( (params_map[k], v) for (k, v) in iteritems(module.params)
               if k in params_map and v != "" )


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
postgresql modules

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Add support for a forced SSL connection to a PostgreSQL databases using a given certificate.
When the certificate does not match (or is incorrect at any way), the connection is refused.
