### PR TITLE
Removed superfluous '*' in check_interface regexp

### DIFF
--- a/network/nxos/nxos_portchannel.py
+++ b/network/nxos/nxos_portchannel.py
@@ -299,7 +299,7 @@ def get_value(arg, config, module):
 
 def check_interface(module, netcfg):
     config = str(netcfg)
-    REGEX = re.compile(r'\s+interface port-channel{0}*$'.format(module.params['group']), re.M)
+    REGEX = re.compile(r'\s+interface port-channel{0}$'.format(module.params['group']), re.M)
     value = False
     try:
         if REGEX.search(config):


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
./network/nxos/nxos_portchannel.py

##### ANSIBLE VERSION
<!---
Paste verbatim output from “ansible --version” between quotes below,
this is to help the Ansible team determine if this is a version specific
issue which is being fixed.
-->
```
ansible 2.2.0.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Removed superfluous '*' in check_interface regexp that was causing it to match too widely.  For example, I could not add 'interface port-channel33' because check_interface would match 'interface port-channel3' and think that it already existed.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!---
Please paste verbatim command output below, e.g. before and after your change.
Even in the event of a Docs Pull Request, this allows the Ansible team to quickly
verify that there were no accidental syntax mistakes.
-->
```
Before:
[stevenca@cil-mgmt cil-infra]$ ansible-playbook --check -i cil-hosts -e "project_definition=port-channel-test.yml" build-project.yml

PLAY [localhost] ***************************************************************

TASK [Building list of devices on which to create vlan_data.] ******************
ok: [localhost]

TASK [set_fact] ****************************************************************
skipping: [localhost]

TASK [set_fact] ****************************************************************
ok: [localhost]

TASK [Creating vlans] **********************************************************

TASK [Create the SVI interfaces] ***********************************************

TASK [Create the VRF] **********************************************************

TASK [Put SVIs in VRFs] ********************************************************

TASK [Address the VRF interfaces] **********************************************

TASK [Configure indiviual interfaces] ******************************************
changed: [localhost] => (item=({u'interface': u'Port-channel333', u'switch': u'csn-sjc18-n9k3.ciscolabs.net', u'desc': u'test'}, u'Eth1/39'))

TASK [Create port-channels on the ToR(s)] **************************************
ok: [localhost] => (item={u'interface': u'Port-channel333', u'switch': u'csn-sjc18-n9k3.ciscolabs.net', u'port_list': [u'Eth1/39'], u'desc': u'test'})

TASK [Configure the VPCs on the ToR(s)] ****************************************
skipping: [localhost] => (item={u'interface': u'Port-channel333', u'switch': u'csn-sjc18-n9k3.ciscolabs.net', u'port_list': [u'Eth1/39'], u'desc': u'test'})

TASK [Configure the port-channel interface] ************************************
changed: [localhost] => (item={u'interface': u'Port-channel333', u'switch': u'csn-sjc18-n9k3.ciscolabs.net', u'port_list': [u'Eth1/39'], u'desc': u'test'})

TASK [Configure the switchport(s)] *********************************************
fatal: [localhost]: FAILED! => {"failed": true, "msg": "the field 'args' has an invalid value, which appears to include a variable that is undefined. The error was: 'port_profiles' is undefined\n\nThe error appears to have been in '/home/stevenca/projects/cil-infra/build-project.yml': line 113, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n    - name: Configure the switchport(s)\n      ^ here\n"}
	to retry, use: --limit @/home/stevenca/projects/cil-infra/build-project.retry

PLAY RECAP *********************************************************************
localhost                  : ok=5    changed=2    unreachable=0    failed=1

After:

[stevenca@cil-mgmt cil-infra]$ ansible-playbook --check -i cil-hosts -e "project_definition=port-channel-test.yml" build-project.yml

PLAY [localhost] ***************************************************************

TASK [Building list of devices on which to create vlan_data.] ******************
ok: [localhost]

TASK [set_fact] ****************************************************************
skipping: [localhost]

TASK [set_fact] ****************************************************************
ok: [localhost]

TASK [Creating vlans] **********************************************************

TASK [Create the SVI interfaces] ***********************************************

TASK [Create the VRF] **********************************************************

TASK [Put SVIs in VRFs] ********************************************************

TASK [Address the VRF interfaces] **********************************************

TASK [Configure indiviual interfaces] ******************************************
changed: [localhost] => (item=({u'interface': u'Port-channel333', u'switch': u'csn-sjc18-n9k3.ciscolabs.net', u'desc': u'test'}, u'Eth1/39'))

TASK [Create port-channels on the ToR(s)] **************************************
changed: [localhost] => (item={u'interface': u'Port-channel333', u'switch': u'csn-sjc18-n9k3.ciscolabs.net', u'port_list': [u'Eth1/39'], u'desc': u'test'})

TASK [Configure the VPCs on the ToR(s)] ****************************************
skipping: [localhost] => (item={u'interface': u'Port-channel333', u'switch': u'csn-sjc18-n9k3.ciscolabs.net', u'port_list': [u'Eth1/39'], u'desc': u'test'})

TASK [Configure the port-channel interface] ************************************
changed: [localhost] => (item={u'interface': u'Port-channel333', u'switch': u'csn-sjc18-n9k3.ciscolabs.net', u'port_list': [u'Eth1/39'], u'desc': u'test'})

TASK [Configure the switchport(s)] *********************************************
fatal: [localhost]: FAILED! => {"failed": true, "msg": "the field 'args' has an invalid value, which appears to include a variable that is undefined. The error was: 'port_profiles' is undefined\n\nThe error appears to have been in '/home/stevenca/projects/cil-infra/build-project.yml': line 113, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n    - name: Configure the switchport(s)\n      ^ here\n"}
	to retry, use: --limit @/home/stevenca/projects/cil-infra/build-project.retry

PLAY RECAP *********************************************************************
localhost                  : ok=5    changed=3    unreachable=0    failed=1

Notice that Ansible thought that port-channel333 already existed because port-channel3 was there.  It sees that it needs to create it in the second run after the change.  The last error was because I ran with '--check' and it depends on things actually being done in preceeding plays.

```

