### PR TITLE
fix apt_key imports

### DIFF
--- a/packaging/os/apt_key.py
+++ b/packaging/os/apt_key.py
@@ -108,8 +108,8 @@ EXAMPLES = '''
 # FIXME: standardize into module_common
 from traceback import format_exc
 
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.urls import fetch_url
+from ansible.module_utils.basic import *
+from ansible.module_utils.urls import *
 
 
 apt_key_bin = None


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
apt_key module

##### ANSIBLE VERSION
```
ansible 2.1.3.0 (stable-2.1 ff0b525608) last updated 2016/11/23 10:09:48 (GMT +000)
  lib/ansible/modules/core: (detached HEAD 36121c5404) last updated 2016/11/23 10:10:31 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD 91a142d625) last updated 2016/11/23 10:10:31 (GMT +000)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
The apt_key.py modules fails with the following error:

```
fatal: [wistla-berk-dev]: FAILED! => {"failed": true, "msg": "error importing module in /home/ubuntu/wistla-devops/third-party/ansible-modules-core/packaging/os/apt_key.py, expecting format like 'from ansible.module_utils.<lib name> import *'"}
```

It looks like ansible is manually processing these imports, and this module doesn't use the correct `import *` format. This change fixes that.

```
ok: [wistla-berk-dev] => (item={u'file': u'security/apt-keys/postgresql-apt-key'})
```
