### PR TITLE
remove extraneous parameter passed to set_fs_attributes_if_different …

### DIFF
--- a/files/file.py
+++ b/files/file.py
@@ -274,7 +274,7 @@ def main():
             # file is not absent and any other state is a conflict
             module.fail_json(path=path, msg='file (%s) is %s, cannot continue' % (path, prev_state))
 
-        changed = module.set_fs_attributes_if_different(file_args, changed, diff)
+        changed = module.set_fs_attributes_if_different(file_args, changed)
         module.exit_json(path=path, changed=changed, diff=diff)
 
     elif state == 'directory':
@@ -308,7 +308,7 @@ def main():
                                 raise
                         tmp_file_args = file_args.copy()
                         tmp_file_args['path']=curpath
-                        changed = module.set_fs_attributes_if_different(tmp_file_args, changed, diff)
+                        changed = module.set_fs_attributes_if_different(tmp_file_args, changed)
             except Exception, e:
                 module.fail_json(path=path, msg='There was an issue creating %s as requested: %s' % (curpath, str(e)))
 
@@ -316,7 +316,7 @@ def main():
         elif prev_state != 'directory':
             module.fail_json(path=path, msg='%s already exists as a %s' % (path, prev_state))
 
-        changed = module.set_fs_attributes_if_different(file_args, changed, diff)
+        changed = module.set_fs_attributes_if_different(file_args, changed)
 
         if recurse:
             changed |= recursive_set_attributes(module, file_args['path'], follow, file_args)
@@ -392,7 +392,7 @@ def main():
         if module.check_mode and not os.path.exists(path):
             module.exit_json(dest=path, src=src, changed=changed, diff=diff)
 
-        changed = module.set_fs_attributes_if_different(file_args, changed, diff)
+        changed = module.set_fs_attributes_if_different(file_args, changed)
         module.exit_json(dest=path, src=src, changed=changed, diff=diff)
 
     elif state == 'touch':
@@ -411,7 +411,7 @@ def main():
             else:
                 module.fail_json(msg='Cannot touch other than files, directories, and hardlinks (%s is %s)' % (path, prev_state))
             try:
-                module.set_fs_attributes_if_different(file_args, True, diff)
+                module.set_fs_attributes_if_different(file_args, True)
             except SystemExit, e:
                 if e.code:
                     # We take this to mean that fail_json() was called from


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
file module

##### ANSIBLE VERSION
```
ansible 2.1.3.0 (stable-2.1 ff0b525608) last updated 2016/11/23 10:09:48 (GMT +000)
  lib/ansible/modules/core: (detached HEAD 36121c5404) last updated 2016/11/23 10:10:31 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD 91a142d625) last updated 2016/11/23 10:10:31 (GMT +000)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
The files module is passing a third `diff` parameter to `set_fs_attributes_if_different`, which doesn't exist in 2.1. I think this has probably been backported by accident. This change removes this third parameter. 

Before
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: set_fs_attributes_if_different() takes exactly 3 arguments (4 given)
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Traceback (most recent call last):\n  File \"<stdin>\", line 2413, in <module>\n  File \"<stdin>\", line 277, in main\nTypeError: set_fs_attributes_if_different() takes exactly 3 arguments (4 given)\n", "module_stdout": "", "msg": "MODULE FAILURE", "parsed": false}
```

After
```
changed: [localhost]
```