### PR TITLE
Backport Docker log_driver fix to Ansible 2.1 branch

### DIFF
--- a/cloud/docker/docker_container.py
+++ b/cloud/docker/docker_container.py
@@ -193,7 +193,7 @@ options:
     required: false
   log_driver:
     description:
-      - Specify the logging driver.
+      - Specify the logging driver. Docker uses json-file by default.
     choices:
       - json-file
       - syslog
@@ -202,7 +202,7 @@ options:
       - fluentd
       - awslogs
       - splunk
-    defult: json-file
+    default: null
     required: false
   log_options:
     description:
@@ -1871,7 +1871,7 @@ def main():
         kill_signal=dict(type='str'),
         labels=dict(type='dict'),
         links=dict(type='list'),
-        log_driver=dict(type='str', choices=['json-file', 'syslog', 'journald', 'gelf', 'fluentd', 'awslogs', 'splunk'], default='json-file'),
+        log_driver=dict(type='str', choices=['json-file', 'syslog', 'journald', 'gelf', 'fluentd', 'awslogs', 'splunk'], default=None),
         log_options=dict(type='dict', aliases=['log_opt']),
         mac_address=dict(type='str'),
         memory=dict(type='str', default='0'),


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`cloud/docker/docker_container.py`

##### ANSIBLE VERSION
<!---
Paste verbatim output from “ansible --version” between quotes below,
this is to help the Ansible team determine if this is a version specific
issue which is being fixed.
-->
```
ansible 2.1.3.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
There is confusion in Docker documentation (which I try to fix as well https://github.com/docker/docker.github.io/pull/722), that states when `--log-driver` option for `docker run` is absent, docker uses `json-file` driver by default.

Actually, it uses daemon's default logging driver, which is `json-file` by default, but can be easily overwritten. Here is the proof.
<details>
I have docker daemon with syslog log_driver:

    $ ps aux | grep dockerd
    root     12509  0.0  1.9 776004 39412 ?        Ssl  Nov25   0:21 /usr/bin/dockerd --log-driver=syslog --log-opt tag={{.Name}} --raw-logs

And I run new container without explicit `log_driver` option

    docker run --name test debian:jessie true

It shows `syslog` log_driver for that container:

    $ docker inspect test | grep -A 2 'LogConfig'
                "LogConfig": {
                    "Type": "syslog",
                    "Config": {
</details>


Latest Ansible 2.1 version set's `json-file` logging driver explicitly for container, if there is no `log_driver` option, which prevents container from using daemon's default logging driver.

In Ansible 2.2 and greater there was merged PR https://github.com/ansible/ansible-modules-core/pull/4774, that resolved this issue, however the intention of that PR was different. 

It seems, this problem isn't clear, because there is open PR https://github.com/ansible/ansible-modules-core/pull/5482 to introduce the same misbehaviour again in 2.3 version, as it behaves nowadays in 2.1.

I still use 2.1 in my environment, and, considering this as misbehaviour/bug, want this fix to be backported to 2.1 branch.

P.S. My first PR, sorry for missed guidelines, I do my best to make this helpful.