### PR TITLE
Leave current ElastiCache security groups as-is if parameter is not provided

### DIFF
--- a/cloud/amazon/elasticache.py
+++ b/cloud/amazon/elasticache.py
@@ -393,12 +393,13 @@ class ElastiCacheManager(object):
             return True
 
         # check vpc security groups
-        vpc_security_groups = []
-        security_groups = self.data['SecurityGroups'] or []
-        for sg in security_groups:
-            vpc_security_groups.append(sg['SecurityGroupId'])
-        if set(vpc_security_groups) != set(self.security_group_ids):
-            return True
+        if len(self.security_group_ids) > 0:
+            vpc_security_groups = []
+            security_groups = self.data['SecurityGroups'] or []
+            for sg in security_groups:
+                vpc_security_groups.append(sg['SecurityGroupId'])
+            if set(vpc_security_groups) != set(self.security_group_ids):
+                return True
 
         return False
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
elasticache

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
When no security groups are provided to this module, the default (empty list) is used. This is not allowed by Amazon, and undesired in my opinion.

This PR modifies this behavior, by leaving the existing security groups when the default/empty list is provided. Which makes it easier to modify the elasicache instance whith the need to grabbing the current security groups first (in order to keep them)
