### PR TITLE
Add new volume types. Fixes #4041

### DIFF
--- a/cloud/amazon/ec2_vol.py
+++ b/cloud/amazon/ec2_vol.py
@@ -46,8 +46,9 @@ options:
     default: null
   volume_type:
     description:
-      - Type of EBS volume; standard (magnetic), gp2 (SSD), io1 (Provisioned IOPS). "Standard" is the old EBS default
-        and continues to remain the Ansible default for backwards compatibility.
+      - Type of EBS volume; standard (magnetic), gp2 (SSD), io1 (Provisioned IOPS), st1 (Throughput Optimized HDD),
+        sc1 (Cold HDD). "Standard" is the old EBS default and continues to remain the Ansible default for backwards 
+        compatibility.
     required: false
     default: standard
     version_added: "1.9"
@@ -480,7 +481,7 @@ def main():
             id = dict(),
             name = dict(),
             volume_size = dict(),
-            volume_type = dict(choices=['standard', 'gp2', 'io1'], default='standard'),
+            volume_type = dict(choices=['standard', 'gp2', 'io1', 'st1', 'sc1'], default='standard'),
             iops = dict(),
             encrypted = dict(type='bool', default=False),
             device_name = dict(),


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_vol

##### ANSIBLE VERSION
```
2.0.0-0.5.beta3
```

##### SUMMARY
Fixes #4041
I just added the two new options for volume types: st1 and sc1. I have successfully tested the option st1 and have no reason to think that the option sc1 will not work as well. 


