### PR TITLE
junos_config: Fix the zeroize function

### DIFF
--- a/network/junos/junos_config.py
+++ b/network/junos/junos_config.py
@@ -274,7 +274,7 @@ def rollback_config(module, result):
 
 def zeroize_config(module, result):
     if not module.check_mode:
-        module.cli.run_commands('request system zeroize')
+        module.connection.cli('request system zeroize')
     result['changed'] = True
 
 def confirm_config(module, result):


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
junos_config

##### ANSIBLE VERSION
<!---
Paste verbatim output from “ansible --version” between quotes below,
this is to help the Ansible team determine if this is a version specific
issue which is being fixed.
-->
```
ansible 2.2.0.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Currently this function directs to the standard NetworkModule,
whose run_commands function takes no arguments (other than self) and
so throws an exception that it's given two arguments when it only takes one.

This directs the call to the connection's cli method to run the command
directly on the device.
<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!---
Please paste verbatim command output below, e.g. before and after your change.
Even in the event of a Docs Pull Request, this allows the Ansible team to quickly
verify that there were no accidental syntax mistakes.
-->