### PR TITLE
[git] Fix fetching branch of shallow clone

### DIFF
--- a/source_control/git.py
+++ b/source_control/git.py
@@ -646,9 +646,7 @@ def fetch(git_path, module, repo, dest, version, remote, depth, bare, refspec, g
                 # 1.8.3 is broken, 1.9.x works
                 # ensure that remote branch is available as both local and remote ref
                 refspecs.append('+refs/heads/%s:refs/heads/%s' % (version, version))
-                refspecs.append('+refs/heads/%s:refs/remotes/%s/%s' % (version, remote, version))
-            else:
-                refspecs.append(version)
+            refspecs.append('+refs/heads/%s:refs/remotes/%s/%s' % (version, remote, version))
         elif is_remote_tag(git_path, module, dest, repo, version):
             refspecs.append('+refs/tags/'+version+':refs/tags/'+version)
         if refspecs:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
git

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
After shallow cloning a repository (non-master branch), updates to this branch are not fetched by the git module. Very similarly as #3817 except I am not switching from a tag to a branch, but merely updating the branch, but I suspect that the same code is activated.

As @robinro suggested in  https://github.com/ansible/ansible-modules-core/issues/3817#issuecomment-224223316, I started with removing the `currenthead != version` check, but fetching a remote ref to the active local ref with
```python
refspecs.append('+refs/heads/%s:refs/heads/%s' % (version, version))
```
gives the following error:
> Failed to download remote objects and refs:  fatal: Refusing to fetch into current branch refs/heads/mybranch of non-bare repository.

Seems logical, hence the check is there (although I do not really understand the comments next to it).

The other refspec addition did the trick for my situation, so I replaced the original with this one.