### PR TITLE
Fail if specifying an ENI as device but in_vpc is not true

### DIFF
--- a/cloud/amazon/ec2_eip.py
+++ b/cloud/amazon/ec2_eip.py
@@ -376,6 +376,8 @@ def main():
         if device_id and device_id.startswith('i-'):
             is_instance = True
         elif device_id:
+            if device_id.startswith('eni-') and not in_vpc:
+                module.fail_json(msg="If you are specifying an ENI, in_vpc must be true")
             is_instance = False
 
     try:


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ec2_eip

##### ANSIBLE VERSION
```
2.3
```

##### SUMMARY
Fail if user is using ENIs but in_vpc not set to true.
The in_vpc flag defaults to False but ENIs are only available in a VPC so it should always be set to true if we're working with ENIs

See https://github.com/ansible/ansible-modules-core/issues/5767
