### PR TITLE
systemd: Start inactive units for reload/restart

### DIFF
--- a/system/systemd.py
+++ b/system/systemd.py
@@ -384,7 +384,10 @@ def main():
                 if result['status']['ActiveState'] == 'active':
                     action = 'stop'
             else:
-                action = module.params['state'][:-2] # remove 'ed' from restarted/reloaded
+                if result['status']['ActiveState'] != 'active':
+                    action = 'start'
+                else:
+                    action = module.params['state'][:-2] # remove 'ed' from restarted/reloaded
                 result['state'] = 'started'
 
             if action:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
systemd

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
The `service` module starts services that are not running when
`action=restarted` or `action=reloaded`, which is especially convenient
for initial deployments because it eliminates an extraneous operation
for when the service starts for the first time. This commit adjusts the
behavior of the `systemd` module to match.