### PR TITLE
use 'six' for urlparse compatability

### DIFF
--- a/cloud/amazon/s3.py
+++ b/cloud/amazon/s3.py
@@ -248,7 +248,7 @@ EXAMPLES = '''
 '''
 
 import os
-from six.moves.urllib.parse import urlparse
+from ansible.module_utils.six.moves.urllib.parse import urlparse
 from ssl import SSLError
 
 try:

--- a/cloud/amazon/s3.py
+++ b/cloud/amazon/s3.py
@@ -248,7 +248,7 @@ EXAMPLES = '''
 '''
 
 import os
-import urlparse
+from six.moves.urllib.parse import urlparse
 from ssl import SSLError
 
 try:


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
`s3`

##### ANSIBLE VERSION
<!---
Paste verbatim output from “ansible --version” between quotes below,
this is to help the Ansible team determine if this is a version specific
issue which is being fixed.
-->
```
ansible 2.3.0
  config file = /opt/app/ansible.cfg
  configured module search path = ['./library']
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
`urlparse` lives in different places between py2 and py3. It's an easy fix.



