### PR TITLE
Also check for protocol when verifying for already exposed/published …

### DIFF
--- a/cloud/docker/docker_container.py
+++ b/cloud/docker/docker_container.py
@@ -1038,7 +1038,7 @@ class TaskParameters(DockerBaseClass):
                         start_port, end_port = exposed_port[0].split('-')
                         if int(start_port) <= port <= int(end_port):
                             match = True
-                    elif exposed_port[0] == port:
+                    elif exposed_port[0] == port and exposed_port[1] == protocol:
                         match = True
                 if not match:
                     exposed.append((port, protocol))


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible/modules/core/cloud/docker/docker_container.py

##### ANSIBLE VERSION
ansible 2.2
ansible 2.1

##### SUMMARY
When trying to publish/expose the same port under tcp and udp, the port wasn't added to the expose list, as it only verified the port number.

