### PR TITLE
Unquote urls in YAML - network

### DIFF
--- a/network/basics/uri.py
+++ b/network/basics/uri.py
@@ -155,7 +155,7 @@ author: "Romeo Theriault (@romeotheriault)"
 EXAMPLES = '''
 - name: Check that you can connect (GET) to a page and it returns a status 200
   uri:
-    url: 'http://www.example.com'
+    url: http://www.example.com
 
 # Check that a page returns a status 200 and fail if the word AWESOME is not
 # in the page contents.

--- a/network/cumulus/cl_img_install.py
+++ b/network/cumulus/cl_img_install.py
@@ -62,7 +62,7 @@ Example playbook entries using the cl_img_install module
 - name: Install image using using http url. Switch slots so the subsequent will load the new version
   cl_img_install:
     version: 2.0.1
-    src: 'http://10.1.1.1/CumulusLinux-2.0.1.bin'
+    src: http://10.1.1.1/CumulusLinux-2.0.1.bin
     switch_slot: yes
 
 ## Copy the software from the ansible server to the switch.
@@ -72,7 +72,7 @@ Example playbook entries using the cl_img_install module
 
 - name: Download cumulus linux to local system
   get_url:
-    src: 'ftp://cumuluslinux.bin'
+    src: ftp://cumuluslinux.bin
     dest: /root/CumulusLinux-2.0.1.bin
 
 - name: Install image from local filesystem. Get version from the filename.
@@ -85,7 +85,7 @@ Example playbook entries using the cl_img_install module
 
 - name: Download cumulus linux to local system
   get_url:
-    src: 'ftp://CumulusLinux-2.0.1.bin'
+    src: ftp://CumulusLinux-2.0.1.bin
     dest: /root/image.bin
 
 - name: install image and switch slots. only reboot needed

--- a/network/cumulus/cl_license.py
+++ b/network/cumulus/cl_license.py
@@ -61,7 +61,7 @@ EXAMPLES = '''
   tasks:
     - name: install license using http url
       cl_license:
-        src: 'http://10.1.1.1/license.txt'
+        src: http://10.1.1.1/license.txt
       notify: restart switchd
 
     - name: Triggers switchd to be restarted right away, before play, or role


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
network/*

##### ANSIBLE VERSION
```
2.2
```

##### SUMMARY
The columns in urls are ok for YAML, since the special character for YAML is ': ' (column space), and not just column

@gundalow