### PR TITLE
Unquote urls in YAML - packaging

### DIFF
--- a/packaging/language/pip.py
+++ b/packaging/language/pip.py
@@ -152,17 +152,17 @@ EXAMPLES = '''
 
 # Install (MyApp) using one of the remote protocols (bzr+,hg+,git+,svn+). You do not have to supply '-e' option in extra_args.
 - pip:
-    name: 'svn+http://myrepo/svn/MyApp#'
+    name: svn+http://myrepo/svn/MyApp#
     egg: MyApp'
 
 # Install MyApp using one of the remote protocols (bzr+,hg+,git+) in a non editable way.
 - pip:
-    name: 'git+http://myrepo/app/MyApp'
+    name: git+http://myrepo/app/MyApp
     editable: false
 
 # Install (MyApp) from local tarball
 - pip:
-    name: 'file:///path/to/MyApp.tar.gz'
+    name: file:///path/to/MyApp.tar.gz
 
 # Install (Bottle) into the specified (virtualenv), inheriting none of the globally installed modules
 - pip:
@@ -193,7 +193,7 @@ EXAMPLES = '''
 # Install specified python requirements and custom Index URL.
 - pip:
     requirements: /my_app/requirements.txt
-    extra_args: '-i https://example.com/pypi/simple'
+    extra_args: -i https://example.com/pypi/simple
 
 # Install (Bottle) for Python 3.3 specifically,using the 'pip-3.3' executable.
 - pip:

--- a/packaging/os/apt_repository.py
+++ b/packaging/os/apt_repository.py
@@ -85,23 +85,23 @@ requirements:
 EXAMPLES = '''
 # Add specified repository into sources list.
 - apt_repository:
-    repo: 'deb http://archive.canonical.com/ubuntu hardy partner'
+    repo: deb http://archive.canonical.com/ubuntu hardy partner
     state: present
 
 # Add specified repository into sources list using specified filename.
 - apt_repository:
-    repo: 'deb http://dl.google.com/linux/chrome/deb/ stable main'
+    repo: deb http://dl.google.com/linux/chrome/deb/ stable main
     state: present
     filename: 'google-chrome'
 
 # Add source repository into sources list.
 - apt_repository:
-    repo: 'deb-src http://archive.canonical.com/ubuntu hardy partner'
+    repo: deb-src http://archive.canonical.com/ubuntu hardy partner
     state: present
 
 # Remove specified repository from sources list.
 - apt_repository:
-    repo: 'deb http://archive.canonical.com/ubuntu hardy partner'
+    repo: deb http://archive.canonical.com/ubuntu hardy partner
     state: absent
 
 # Add nginx stable repository from PPA and install its signing key.

--- a/packaging/os/rhn_channel.py
+++ b/packaging/os/rhn_channel.py
@@ -63,7 +63,7 @@ EXAMPLES = '''
 - rhn_channel:
     name: rhel-x86_64-server-v2vwin-6
     sysname: server01
-    url: 'https://rhn.redhat.com/rpc/api'
+    url: https://rhn.redhat.com/rpc/api
     user: rhnuser
     password: guessme
 '''

--- a/packaging/os/rhn_register.py
+++ b/packaging/os/rhn_register.py
@@ -112,7 +112,7 @@ EXAMPLES = '''
     state: present
     username: joe_user
     password: somepass'
-    server_url: 'https://xmlrpc.my.satellite/XMLRPC'
+    server_url: https://xmlrpc.my.satellite/XMLRPC
 
 # Register as user (joe_user) with password (somepass) and enable
 # channels (rhel-x86_64-server-6-foo-1) and (rhel-x86_64-server-6-bar-1).

--- a/packaging/os/rpm_key.py
+++ b/packaging/os/rpm_key.py
@@ -54,7 +54,7 @@ EXAMPLES = '''
 # Example action to import a key from a url
 - rpm_key:
     state: present
-    key: 'http://apt.sw.be/RPM-GPG-KEY.dag.txt'
+    key: http://apt.sw.be/RPM-GPG-KEY.dag.txt
 
 # Example action to import a key from a file
 - rpm_key:

--- a/packaging/os/yum.py
+++ b/packaging/os/yum.py
@@ -183,7 +183,7 @@ EXAMPLES = '''
 
 - name: install the nginx rpm from a remote repo
   yum:
-    name: 'http://nginx.org/packages/centos/6/noarch/RPMS/nginx-release-centos-6-0.el6.ngx.noarch.rpm'
+    name: http://nginx.org/packages/centos/6/noarch/RPMS/nginx-release-centos-6-0.el6.ngx.noarch.rpm
     state: present
 
 - name: install nginx rpm from a local file


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
packaging/*

##### ANSIBLE VERSION
```
2.2
```

##### SUMMARY
The columns in urls are ok for YAML, since the special character for YAML is ': ' (column space), and not just column

@gundalow