### PR TITLE
Unquote urls in YAML - web_infrastructure

### DIFF
--- a/web_infrastructure/supervisorctl.py
+++ b/web_infrastructure/supervisorctl.py
@@ -104,7 +104,7 @@ EXAMPLES = '''
     state: restarted
     username: test
     password: testpass
-    server_url: 'http://localhost:9001'
+    server_url: http://localhost:9001
 '''
 
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
web_infrastructure/*

##### ANSIBLE VERSION
```
2.2
```

##### SUMMARY
The columns in urls are ok for YAML, since the special character for YAML is ': ' (column space), and not just column

@gundalow