### PR TITLE
Unquote urls in YAML - source_control

### DIFF
--- a/source_control/git.py
+++ b/source_control/git.py
@@ -195,32 +195,32 @@ notes:
 EXAMPLES = '''
 # Example git checkout from Ansible Playbooks
 - git:
-    repo: 'git://foosball.example.org/path/to/repo.git'
+    repo: git://foosball.example.org/path/to/repo.git
     dest: /srv/checkout
     version: release-0.22
 
 # Example read-write git checkout from github
 - git:
-    repo: 'ssh://git@github.com/mylogin/hello.git'
+    repo: ssh://git@github.com/mylogin/hello.git
     dest: /home/mylogin/hello
 
 # Example just ensuring the repo checkout exists
 - git:
-    repo: 'git://foosball.example.org/path/to/repo.git'
+    repo: git://foosball.example.org/path/to/repo.git
     dest: /srv/checkout
     update: no
 
 # Example just get information about the repository whether or not it has
 # already been cloned locally.
 - git:
-    repo: 'git://foosball.example.org/path/to/repo.git'
+    repo: git://foosball.example.org/path/to/repo.git
     dest: /srv/checkout
     clone: no
     update: no
 
 # Example checkout a github repo and use refspec to fetch all pull requests
 - git:
-    repo: 'https://github.com/ansible/ansible-examples.git'
+    repo: https://github.com/ansible/ansible-examples.git
     dest: /src/ansible-examples
     refspec: '+refs/pull/*:refs/heads/*'
 '''

--- a/source_control/hg.py
+++ b/source_control/hg.py
@@ -96,7 +96,7 @@ requirements: [ ]
 EXAMPLES = '''
 # Ensure the current working copy is inside the stable branch and deletes untracked files if any.
 - hg:
-    repo: 'https://bitbucket.org/user/repo1'
+    repo: https://bitbucket.org/user/repo1
     dest: /home/user/repo1
     revision: stable
     purge: yes
@@ -104,7 +104,7 @@ EXAMPLES = '''
 # Example just get information about the repository whether or not it has
 # already been cloned locally.
 - hg:
-    repo: 'git://bitbucket.org/user/repo'
+    repo: git://bitbucket.org/user/repo
     dest: /srv/checkout
     clone: no
     update: no

--- a/source_control/subversion.py
+++ b/source_control/subversion.py
@@ -105,18 +105,18 @@ options:
 EXAMPLES = '''
 # Checkout subversion repository to specified folder.
 - subversion:
-    repo: 'svn+ssh://an.example.org/path/to/repo'
+    repo: svn+ssh://an.example.org/path/to/repo
     dest: /src/checkout
 
 # Export subversion directory to folder
 - subversion:
-    repo: 'svn+ssh://an.example.org/path/to/repo'
+    repo: svn+ssh://an.example.org/path/to/repo
     dest: /src/export
 
 # Example just get information about the repository whether or not it has
 # already been cloned locally.
 - subversion:
-    repo: 'svn+ssh://an.example.org/path/to/repo'
+    repo: svn+ssh://an.example.org/path/to/repo
     dest: /srv/checkout
     checkout: no
     update: no


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
source_control/*

##### ANSIBLE VERSION
```
2.2
```

##### SUMMARY
The columns in urls are ok for YAML, since the special character for YAML is ': ' (column space), and not just column

@gundalow