### PR TITLE
Unquote urls in YAML - system

### DIFF
--- a/system/authorized_key.py
+++ b/system/authorized_key.py
@@ -99,7 +99,7 @@ EXAMPLES = '''
 # Using github url as key source
 - authorized_key:
     user: charlie
-    key: 'https://github.com/charlie.keys'
+    key: https://github.com/charlie.keys
 
 # Using alternate directory locations:
 - authorized_key:
@@ -126,7 +126,7 @@ EXAMPLES = '''
 # Using validate_certs:
 - authorized_key:
     user: charlie
-    key: 'https://github.com/user.keys'
+    key: https://github.com/user.keys
     validate_certs: no
 
 # Set up authorized_keys exclusively with one key


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
system/*

##### ANSIBLE VERSION
```
2.2
```

##### SUMMARY
The columns in urls are ok for YAML, since the special character for YAML is ': ' (column space), and not just column

@gundalow