### PR TITLE
Unquote urls in YAML - cloud

### DIFF
--- a/cloud/amazon/cloudformation.py
+++ b/cloud/amazon/cloudformation.py
@@ -147,7 +147,7 @@ EXAMPLES = '''
     state: present
     region: us-east-1
     disable_rollback: true
-    template_url: 'https://s3.amazonaws.com/my-bucket/cloudformation.template'
+    template_url: https://s3.amazonaws.com/my-bucket/cloudformation.template
   args:
     template_parameters:
       KeyName: jmartin
@@ -164,7 +164,7 @@ EXAMPLES = '''
     state: present
     region: us-east-1
     disable_rollback: true
-    template_url: 'https://s3.amazonaws.com/my-bucket/cloudformation.template'
+    template_url: https://s3.amazonaws.com/my-bucket/cloudformation.template
     role_arn: 'arn:aws:iam::123456789012:role/cloudformation-iam-role'
   args:
     template_parameters:

--- a/cloud/openstack/_glance_image.py
+++ b/cloud/openstack/_glance_image.py
@@ -44,7 +44,7 @@ options:
      description:
         - The keystone url for authentication
      required: false
-     default: 'http://127.0.0.1:35357/v2.0/'
+     default: http://127.0.0.1:35357/v2.0/
    region_name:
      description:
         - Name of the region
@@ -129,7 +129,7 @@ EXAMPLES = '''
     container_format: bare
     disk_format: qcow2
     state: present
-    copy_from: 'http://launchpad.net/cirros/trunk/0.3.0/+download/cirros-0.3.0-x86_64-disk.img'
+    copy_from: http://launchpad.net/cirros/trunk/0.3.0/+download/cirros-0.3.0-x86_64-disk.img
 '''
 
 import time

--- a/cloud/openstack/_keystone_user.py
+++ b/cloud/openstack/_keystone_user.py
@@ -51,7 +51,7 @@ options:
      description:
         - The keystone url for authentication
      required: false
-     default: 'http://127.0.0.1:35357/v2.0/'
+     default: http://127.0.0.1:35357/v2.0/
    user:
      description:
         - The name of the user that has to added/removed from OpenStack

--- a/cloud/openstack/_nova_compute.py
+++ b/cloud/openstack/_nova_compute.py
@@ -58,7 +58,7 @@ options:
      description:
         - The keystone url for authentication
      required: false
-     default: 'http://127.0.0.1:35357/v2.0/'
+     default: http://127.0.0.1:35357/v2.0/
    region_name:
      description:
         - Name of the region

--- a/cloud/openstack/_nova_keypair.py
+++ b/cloud/openstack/_nova_keypair.py
@@ -56,7 +56,7 @@ options:
      description:
         - The keystone url for authentication
      required: false
-     default: 'http://127.0.0.1:35357/v2.0/'
+     default: http://127.0.0.1:35357/v2.0/
    region_name:
      description:
         - Name of the region

--- a/cloud/openstack/_quantum_floating_ip.py
+++ b/cloud/openstack/_quantum_floating_ip.py
@@ -60,7 +60,7 @@ options:
      description:
         - The keystone url for authentication
      required: false
-     default: 'http://127.0.0.1:35357/v2.0/'
+     default: http://127.0.0.1:35357/v2.0/
    region_name:
      description:
         - Name of the region

--- a/cloud/openstack/_quantum_floating_ip_associate.py
+++ b/cloud/openstack/_quantum_floating_ip_associate.py
@@ -57,7 +57,7 @@ options:
      description:
         - the keystone url for authentication
      required: false
-     default: 'http://127.0.0.1:35357/v2.0/'
+     default: http://127.0.0.1:35357/v2.0/
    region_name:
      description:
         - name of the region

--- a/cloud/openstack/_quantum_network.py
+++ b/cloud/openstack/_quantum_network.py
@@ -59,7 +59,7 @@ options:
      description:
         - The keystone url for authentication
      required: false
-     default: 'http://127.0.0.1:35357/v2.0/'
+     default: http://127.0.0.1:35357/v2.0/
    region_name:
      description:
         - Name of the region

--- a/cloud/openstack/_quantum_router.py
+++ b/cloud/openstack/_quantum_router.py
@@ -55,7 +55,7 @@ options:
      description:
         - The keystone url for authentication
      required: false
-     default: 'http://127.0.0.1:35357/v2.0/'
+     default: http://127.0.0.1:35357/v2.0/
    region_name:
      description:
         - Name of the region

--- a/cloud/openstack/_quantum_router_gateway.py
+++ b/cloud/openstack/_quantum_router_gateway.py
@@ -55,7 +55,7 @@ options:
      description:
         - The keystone URL for authentication
      required: false
-     default: 'http://127.0.0.1:35357/v2.0/'
+     default: http://127.0.0.1:35357/v2.0/
    region_name:
      description:
         - Name of the region

--- a/cloud/openstack/_quantum_subnet.py
+++ b/cloud/openstack/_quantum_subnet.py
@@ -54,7 +54,7 @@ options:
      description:
         - The keystone URL for authentication
      required: false
-     default: 'http://127.0.0.1:35357/v2.0/'
+     default: http://127.0.0.1:35357/v2.0/
    region_name:
      description:
         - Name of the region

--- a/cloud/openstack/os_image_facts.py
+++ b/cloud/openstack/os_image_facts.py
@@ -45,7 +45,7 @@ EXAMPLES = '''
 - name: Gather facts about a previously created image named image1
   os_image_facts:
     auth:
-      auth_url: 'https://your_api_url.com:9000/v2.0'
+      auth_url: https://your_api_url.com:9000/v2.0
       username: user
       password: password
       project_name: someproject

--- a/cloud/openstack/os_networks_facts.py
+++ b/cloud/openstack/os_networks_facts.py
@@ -49,7 +49,7 @@ EXAMPLES = '''
 - name: Gather facts about previously created networks
   os_networks_facts:
     auth:
-      auth_url: 'https://your_api_url.com:9000/v2.0'
+      auth_url: https://your_api_url.com:9000/v2.0
       username: user
       password: password
       project_name: someproject
@@ -61,7 +61,7 @@ EXAMPLES = '''
 - name: Gather facts about a previously created network by name
   os_networks_facts:
     auth:
-      auth_url: 'https://your_api_url.com:9000/v2.0'
+      auth_url: https://your_api_url.com:9000/v2.0
       username: user
       password: password
       project_name: someproject
@@ -75,7 +75,7 @@ EXAMPLES = '''
   # Note: name and filters parameters are Not mutually exclusive
   os_networks_facts:
     auth:
-      auth_url: 'https://your_api_url.com:9000/v2.0'
+      auth_url: https://your_api_url.com:9000/v2.0
       username: user
       password: password
       project_name: someproject

--- a/cloud/openstack/os_server.py
+++ b/cloud/openstack/os_server.py
@@ -207,7 +207,7 @@ EXAMPLES = '''
   os_server:
        state: present
        auth:
-         auth_url: 'https://region-b.geo-1.identity.hpcloudsvc.com:35357/v2.0/'
+         auth_url: https://region-b.geo-1.identity.hpcloudsvc.com:35357/v2.0/
          username: admin
          password: admin
          project_name: admin
@@ -232,7 +232,7 @@ EXAMPLES = '''
       os_server:
         state: present
         auth:
-          auth_url: 'https://region-b.geo-1.identity.hpcloudsvc.com:35357/v2.0/'
+          auth_url: https://region-b.geo-1.identity.hpcloudsvc.com:35357/v2.0/
           username: username
           password: Equality7-2521
           project_name: username-project1
@@ -299,7 +299,7 @@ EXAMPLES = '''
     - name: launch an instance with a string
       os_server:
         auth:
-           auth_url: 'https://region-b.geo-1.identity.hpcloudsvc.com:35357/v2.0/'
+           auth_url: https://region-b.geo-1.identity.hpcloudsvc.com:35357/v2.0/
            username: admin
            password: admin
            project_name: admin
@@ -314,7 +314,7 @@ EXAMPLES = '''
   os_server:
        state: present
        auth:
-         auth_url: 'https://region-b.geo-1.identity.hpcloudsvc.com:35357/v2.0/'
+         auth_url: https://region-b.geo-1.identity.hpcloudsvc.com:35357/v2.0/
          username: admin
          password: admin
          project_name: admin
@@ -332,7 +332,7 @@ EXAMPLES = '''
   os_server:
     state: present
     auth:
-      auth_url: 'https://region-b.geo-1.identity.hpcloudsvc.com:35357/v2.0/'
+      auth_url: https://region-b.geo-1.identity.hpcloudsvc.com:35357/v2.0/
       username: admin
       password: admin
       project_name: admin

--- a/cloud/openstack/os_subnets_facts.py
+++ b/cloud/openstack/os_subnets_facts.py
@@ -49,7 +49,7 @@ EXAMPLES = '''
 - name: Gather facts about previously created subnets
   os_subnets_facts:
     auth:
-      auth_url: 'https://your_api_url.com:9000/v2.0'
+      auth_url: https://your_api_url.com:9000/v2.0
       username: user
       password: password
       project_name: someproject
@@ -61,7 +61,7 @@ EXAMPLES = '''
 - name: Gather facts about a previously created subnet by name
   os_subnets_facts:
     auth:
-      auth_url: 'https://your_api_url.com:9000/v2.0'
+      auth_url: https://your_api_url.com:9000/v2.0
       username: user
       password: password
       project_name: someproject
@@ -75,7 +75,7 @@ EXAMPLES = '''
   # Note: name and filters parameters are not mutually exclusive
   os_subnets_facts:
     auth:
-      auth_url: 'https://your_api_url.com:9000/v2.0'
+      auth_url: https://your_api_url.com:9000/v2.0
       username: user
       password: password
       project_name: someproject


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
cloud/*

##### ANSIBLE VERSION
```
2.2
```

##### SUMMARY
The columns in urls are ok for YAML, since the special character for YAML is ': ' (column space), and not just column

@gundalow