### PR TITLE
Unquote urls in YAML - windows

### DIFF
--- a/windows/win_get_url.py
+++ b/windows/win_get_url.py
@@ -117,7 +117,7 @@ url:
     description: requested url
     returned: always
     type: string
-    sample: 'http://www.example.com/earthrise.jpg'
+    sample: http://www.example.com/earthrise.jpg
 dest:
     description: destination file/path
     returned: always


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
windows/*

##### ANSIBLE VERSION
```
2.2
```

##### SUMMARY
The columns in urls are ok for YAML, since the special character for YAML is ': ' (column space), and not just column

@gundalow