### PR TITLE
URLs do not need quotes (also removed some tabs at the end of lines)

### DIFF
--- a/cloud/amazon/s3.py
+++ b/cloud/amazon/s3.py
@@ -168,7 +168,7 @@ EXAMPLES = '''
     src: /usr/local/myfile.txt
     mode: put
     rgw: true
-    s3_url: "http://localhost:8000"
+    s3_url: http://localhost:8000
 
 - name: Simple GET operation
   s3:

--- a/cloud/docker/docker_login.py
+++ b/cloud/docker/docker_login.py
@@ -37,7 +37,7 @@ options:
     required: False
     description:
       - The registry URL.
-    default: "https://index.docker.io/v1/"
+    default: https://index.docker.io/v1/
     aliases:
       - registry
       - url

--- a/cloud/openstack/os_ironic_node.py
+++ b/cloud/openstack/os_ironic_node.py
@@ -121,9 +121,9 @@ os_ironic_node:
   power: present
   deploy: True
   maintenance: False
-  config_drive: "http://192.168.1.1/host-configdrive.iso"
+  config_drive: http://192.168.1.1/host-configdrive.iso
   instance_info:
-    image_source: "http://192.168.1.1/deploy_image.img"
+    image_source: http://192.168.1.1/deploy_image.img
     image_checksum: "356a6b55ecc511a20c33c946c4e678af"
     image_disk_format: "qcow"
   delegate_to: localhost

--- a/files/unarchive.py
+++ b/files/unarchive.py
@@ -126,7 +126,7 @@ EXAMPLES = '''
 
 # Unarchive a file that needs to be downloaded (added in 2.0)
 - unarchive:
-    src: "https://example.com/example.zip"
+    src: https://example.com/example.zip
     dest: /usr/local/bin
     remote_src: yes
 '''

--- a/network/basics/get_url.py
+++ b/network/basics/get_url.py
@@ -169,39 +169,39 @@ author: "Jan-Piet Mens (@jpmens)"
 
 EXAMPLES='''
 - name: download foo.conf
-  get_url: 
-    url: http://example.com/path/file.conf 
-    dest: /etc/foo.conf 
+  get_url:
+    url: http://example.com/path/file.conf
+    dest: /etc/foo.conf
     mode: 0440
 
 - name: download file and force basic auth
-  get_url: 
-    url: http://example.com/path/file.conf 
-    dest: /etc/foo.conf 
+  get_url:
+    url: http://example.com/path/file.conf
+    dest: /etc/foo.conf
     force_basic_auth: yes
 
 - name: download file with custom HTTP headers
-  get_url: 
-    url: http://example.com/path/file.conf 
-    dest: /etc/foo.conf 
+  get_url:
+    url: http://example.com/path/file.conf
+    dest: /etc/foo.conf
     headers: 'key:value,key:value'
 
 - name: download file with check (sha256)
-  get_url: 
-    url: http://example.com/path/file.conf 
-    dest: /etc/foo.conf 
+  get_url:
+    url: http://example.com/path/file.conf
+    dest: /etc/foo.conf
     checksum: sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c
 
 - name: download file with check (md5)
-  get_url: 
-    url: http://example.com/path/file.conf 
+  get_url:
+    url: http://example.com/path/file.conf
     dest: /etc/foo.conf
     checksum: md5:66dffb5228a211e61d6d7ef4a86f5758
 
 - name: download file from a file path
-  get_url: 
-    url: "file:///tmp/afile.txt" 
-    dest: /tmp/afilecopy.txt  
+  get_url:
+    url: file:///tmp/afile.txt
+    dest: /tmp/afilecopy.txt
 '''
 
 from ansible.module_utils.six.moves.urllib.parse import urlsplit

--- a/packaging/os/apt_key.py
+++ b/packaging/os/apt_key.py
@@ -89,18 +89,18 @@ EXAMPLES = '''
 
 # Add an Apt signing key, uses whichever key is at the URL
 - apt_key:
-    url: "https://ftp-master.debian.org/keys/archive-key-6.0.asc"
+    url: https://ftp-master.debian.org/keys/archive-key-6.0.asc
     state: present
 
 # Add an Apt signing key, will not download if present
 - apt_key:
     id: 473041FA
-    url: "https://ftp-master.debian.org/keys/archive-key-6.0.asc"
+    url: https://ftp-master.debian.org/keys/archive-key-6.0.asc
     state: present
 
 # Remove an Apt signing key, uses whichever key is at the URL
 - apt_key:
-    url: "https://ftp-master.debian.org/keys/archive-key-6.0.asc"
+    url: https://ftp-master.debian.org/keys/archive-key-6.0.asc
     state: absent
 
 # Remove a Apt specific signing key, leading 0x is valid
@@ -116,7 +116,7 @@ EXAMPLES = '''
 # Add an Apt signing key to a specific keyring file
 - apt_key:
     id: 473041FA
-    url: "https://ftp-master.debian.org/keys/archive-key-6.0.asc"
+    url: https://ftp-master.debian.org/keys/archive-key-6.0.asc
     keyring: /etc/apt/trusted.gpg.d/debian.gpg
 
 # Add Apt signing key on remote server to keyring


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
*

##### ANSIBLE VERSION
```
2.2
```

##### SUMMARY
The columns in urls are ok for YAML, since the special character for YAML is ': ' (column space), and not just column

@gundalow