### PR TITLE
Added API throttling to RDS module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ venv
 Vagrantfile
 .vagrant
 ansible.egg-info/
+# Visual Studio Code
+.vscode

--- a/cloud/amazon/rds.py
+++ b/cloud/amazon/rds.py
@@ -184,7 +184,7 @@ options:
   aws_throttling:
     description:
       - how long before calling AWS API to check resource, in seconds
-    default: 10
+    default: 5
   apply_immediately:
     description:
       - Used only when command=modify.  If enabled, the modifications will be applied as soon as possible rather than waiting for the next preferred maintenance window.
@@ -1057,7 +1057,7 @@ def main():
             subnet            = dict(required=False),
             wait              = dict(type='bool', default=False),
             wait_timeout      = dict(type='int', default=300),
-            api_throttling    = dict(type='int', default=30),
+            api_throttling    = dict(type='int', default=5),
             snapshot          = dict(required=False),
             apply_immediately = dict(type='bool', default=False),
             new_instance_name = dict(required=False),

--- a/cloud/amazon/rds.py
+++ b/cloud/amazon/rds.py
@@ -185,6 +185,7 @@ options:
     description:
       - how long before calling AWS API to check resource, in seconds
     default: 5
+    version_added: "2.3"
   apply_immediately:
     description:
       - Used only when command=modify.  If enabled, the modifications will be applied as soon as possible rather than waiting for the next preferred maintenance window.


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
AWS RDS module

##### ANSIBLE VERSION
```
$ ansible --version
ansible 2.2.0.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
```
Added a new parameter `api_throttling` to RDS module to allow specifying a time before calling AWS API to avoid throttling issue. 

Fixes my bug report in Issue #143 (see my comment there).
```
