### PR TITLE
Call main in conditional way - utilities

### DIFF
--- a/utilities/helper/_accelerate.py
+++ b/utilities/helper/_accelerate.py
@@ -738,4 +738,5 @@ def main():
         # try to start up the daemon
         daemonize(module, password, port, timeout, minutes, ipv6, pid_file)
 
-main()
+if __name__ == '__main__':
+    main()

--- a/utilities/logic/async_status.py
+++ b/utilities/logic/async_status.py
@@ -102,4 +102,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
utilities/*

##### ANSIBLE VERSION
```
2.2
```

##### SUMMARY
Use conditional main as for the 16th point of the module checklist at http://docs.ansible.com/ansible/dev_guide/developing_modules.html#module-checklist that reads:

Call your main() from a conditional so that it would be possible to import them into unittests in the future example:

    if __name__ == '__main__':
        main()