### PR TITLE
Update ec2_tag.py

### DIFF
--- a/cloud/amazon/ec2_tag.py
+++ b/cloud/amazon/ec2_tag.py
@@ -89,19 +89,19 @@ tasks:
     instance: "{{ item.id }}"
     region: eu-west-1
     state: list
-  with_items: "{{ ec2.tagged_instances }}"
+  with_items: "{{ ec2.instances }}"
   register: ec2_vol
 
 - name: tag the volumes
   ec2_tag:
     region:  eu-west-1
-    resource: "{{ item.id }}"
+    resource: "{{ item.1.id }}"
     state: present
     tags: 
       Name: dbserver
       Env: production
   with_subelements: 
-    - ec2_vol.results
+    - "{{ec2_vol.results}}"
     - volumes
 
 # Playbook example of listing tags on an instance


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->

##### ANSIBLE VERSION
<!---
ansible 2.2.0.0
-->
```

```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
Regarding using ec2.instances instead of ec2.tagged_instances, ec2.tagged_instances when printed out contains no values so will error out.
Registered variables need to be quoted in ansible 2.2 or will throw errors.
Regarding using item.1.id instead of just item.id for the tag volume. I'm not exactly a 100% sure why it works yet especially since I found no attribute by the name of 1 in the print out of registered ec2_vol object attributes.
-->

<!---
-->
```

```

