### PR TITLE
Remove nat_destination check from openstack FIP

### DIFF
--- a/cloud/openstack/os_floating_ip.py
+++ b/cloud/openstack/os_floating_ip.py
@@ -206,8 +206,7 @@ def main():
                     network_id = cloud.get_network(name_or_id=network)["id"]
                 else:
                     network_id = None
-                if all([(fixed_address and f_ip.fixed_ip_address == fixed_address) or
-                        (nat_destination and f_ip.internal_network == fixed_address),
+                if all([(fixed_address and f_ip.fixed_ip_address != fixed_address),
                         network, f_ip.network != network_id]):
                     # Current state definitely conflicts with requirements
                     module.fail_json(msg="server {server} already has a "


### PR DESCRIPTION
There is no internal_network attribute on a floating ip and adding one
would be very expensive. Also, nat_destination is a way to find the
right address on a server, it's super helpful in and of itself as an
attribute to use for up-to-date checks.

Finally, the equality checking on the internal network is backwards.