### PR TITLE
Fixes 5840 - replace module and python3 type errors

### DIFF
--- a/files/replace.py
+++ b/files/replace.py
@@ -22,6 +22,8 @@ import re
 import os
 import tempfile
 
+from ansible.module_utils._text import to_text, to_bytes
+
 ANSIBLE_METADATA = {'status': ['stableinterface'],
                     'supported_by': 'community',
                     'version': '1.0'}
@@ -105,7 +107,7 @@ def write_changes(module,contents,dest):
 
     tmpfd, tmpfile = tempfile.mkstemp()
     f = os.fdopen(tmpfd,'wb')
-    f.write(contents)
+    f.write(to_bytes(contents))
     f.close()
 
     validate = module.params.get('validate', None)
@@ -157,7 +159,7 @@ def main():
         module.fail_json(rc=257, msg='Destination %s does not exist !' % dest)
     else:
         f = open(dest, 'rb')
-        contents = f.read()
+        contents = to_text(f.read(), errors='surrogate_or_strict')
         f.close()
 
     mre = re.compile(params['regexp'], re.MULTILINE)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`replace` module

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel e3fa0d9026) last updated 2016/12/06 20:29:22 (GMT +000)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Fix typing issues with python 3, when [reading/writing files in binary mode](http://docs.ansible.com/ansible/dev_guide/developing_modules_python3.html#reading-and-writing-to-files).

Using latest `devel`, to reproduce the bug:
```
$ python3 ./bin/ansible localhost -D -m replace -a "dest=/etc/hosts regexp='local(host|domain)' replace='remote\1' backup=no"
 [WARNING]: Host file not found: /etc/ansible/hosts

 [WARNING]: provided hosts list is empty, only localhost is available

An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: cannot use a string pattern on a bytes-like object
localhost | FAILED! => {
    "changed": false,
    "failed": true,
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_yj_l_3sb/ansible_module_replace.py\", line 194, in <module>\n    main()\n  File \"/tmp/ansible_yj_l_3sb/ansible_module_replace.py\", line 164, in main\n    result = re.subn(mre, params['replace'], contents, 0)\n  File \"/usr/lib/python3.5/re.py\", line 193, in subn\n    return _compile(pattern, flags).subn(repl, string, count)\nTypeError: cannot use a string pattern on a bytes-like object\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE"
}
```

Testing the fix patch:
```
$ python3 ./bin/ansible localhost -D -m replace -a "dest=/etc/hosts regexp='local(host|domain)' replace='remote\1' backup=no"
 [WARNING]: Host file not found: /etc/ansible/hosts

 [WARNING]: provided hosts list is empty, only localhost is available

--- before: /etc/hosts
+++ after: /etc/hosts
@@ -1,11 +1,11 @@
-127.0.0.1	localhost
+127.0.0.1	remotehost
 
 # The following lines are desirable for IPv6 capable hosts
-::1	ip6-localhost	ip6-loopback
+::1	ip6-remotehost	ip6-loopback
 fe00::0	ip6-localnet
 ff00::0	ip6-mcastprefix
 ff02::1	ip6-allnodes
 ff02::2	ip6-allrouters
 ff02::3	ip6-allhosts
-127.0.1.1	ubuntu-xenial.localdomain	ubuntu-xenial
+127.0.1.1	ubuntu-xenial.remotedomain	ubuntu-xenial
 

localhost | SUCCESS => {
    "changed": true,
    "msg": "3 replacements made"
}
```

Fixes #5840