### PR TITLE
Fixes #4974 - Set Volumes field only for anonymous volumes

### DIFF
--- a/cloud/docker/docker_container.py
+++ b/cloud/docker/docker_container.py
@@ -876,17 +876,9 @@ class TaskParameters(DockerBaseClass):
         result = []
         if self.volumes:
             for vol in self.volumes:
-                if ':' in vol:
-                    if len(vol.split(':')) == 3:
-                        host, container, _ = vol.split(':')
-                        result.append(container)
-                        continue
-                    if len(vol.split(':')) == 2:
-                        parts = vol.split(':')
-                        if parts[1] not in VOLUME_PERMISSIONS:
-                            result.append(parts[1])
-                            continue
-                result.append(vol)
+                parts = vol.split(':')
+                if len(parts) == 1:
+                    result.append(parts[0])
         self.log("mounts:")
         self.log(result, pretty_print=True)
         return result


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
docker_container

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (devel 7e84bcec30) last updated 2016/12/06 19:10:54 (GMT +000)
  config file = 
  configured module search path = ['/opt/ansible/ansible/library']
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Currently docker_container module sets `Volumes` field for all volumes passed.  This behavior is inconsistent with `docker run` command.  This commit fixes `docker_container.py` to set `Volumes` field only when anonymous volumes are passed.

This behavior is also clarified in the following comment:
https://github.com/docker/docker/issues/2949#issuecomment-230883544


<!-- Paste verbatim command output below, e.g. before and after your change -->
Playbook:
```
- name: assert state of my container
  docker_container:
    name: mc
    image: "my_container:1.0"
    command: "execute"
    state: started
    restart_policy: always
    exposed_ports:
    - 12345
    network_mode: host
    detach: True
    volumes:
    - "/a/b:/a/b"
    log_driver: "json-file"
    log_options:
      max-size: "10m"
      max-file: "10"
```
Before:
```
DEBU[0111] form data: {"AttachStderr":false,"AttachStdin":false,"AttachStdout":false,"Cmd":["execute"],"Env":[],"ExposedPorts":{"12345/tcp":{}},"HostConfig":{"Binds":["/a/b:/a/b:rw"],"LogConfig":{"Config":{"max-file":"10","max-size":"10m"},"Type":"json-file"},"Memory":0,"NetworkMode":"host","ReadonlyRootfs":false,"RestartPolicy":{"MaximumRetryCount":null,"Name":"always"}},"Image":"my_container:1.0","NetworkDisabled":false,"OpenStdin":false,"StdinOnce":false,"Tty":false,"Volumes":{"/a/b":{}}} 
```

After:
```
DEBU[0111] form data: {"AttachStderr":false,"AttachStdin":false,"AttachStdout":false,"Cmd":["execute"],"Env":[],"ExposedPorts":{"12345/tcp":{}},"HostConfig":{"Binds":["/a/b:/a/b:rw"],"LogConfig":{"Config":{"max-file":"10","max-size":"10m"},"Type":"json-file"},"Memory":0,"NetworkMode":"host","ReadonlyRootfs":false,"RestartPolicy":{"MaximumRetryCount":null,"Name":"always"}},"Image":"my_container:1.0","NetworkDisabled":false,"OpenStdin":false,"StdinOnce":false,"Tty":false,"Volumes":{}} 
```

Fixes #4974