### PR TITLE
Removing overriding params

### DIFF
--- a/network/nxos/nxos_acl.py
+++ b/network/nxos/nxos_acl.py
@@ -677,10 +677,6 @@ def main():
                                                'ef']),
             state=dict(choices=['absent', 'present', 'delete_acl'],
                        default='present'),
-            protocol=dict(choices=['http', 'https'], default='http'),
-            host=dict(required=True),
-            username=dict(type='str'),
-            password=dict(no_log=True, type='str'),
             include_defaults=dict(default=False),
             config=dict(),
             save=dict(type='bool', default=False)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_acl

##### ANSIBLE VERSION
```
ansible 2.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/usr/share/ansible/']
```

##### SUMMARY
Removing overriding params from arg_spec 

