### PR TITLE
Fixing nxos_vxlan_vtep_vni issue when multiple vni exist

### DIFF
--- a/network/nxos/nxos_vxlan_vtep_vni.py
+++ b/network/nxos/nxos_vxlan_vtep_vni.py
@@ -372,11 +372,11 @@ def get_existing(module, args):
         parents = ['interface {0}'.format(interface_exist)]
         temp_config = netcfg.get_section(parents)
 
-        if 'associate-vrf' in temp_config:
+        if 'member vni {0} associate-vrf'.format(module.params['vni']) in temp_config:
             parents.append('member vni {0} associate-vrf'.format(
                                                     module.params['vni']))
             config = netcfg.get_section(parents)
-        elif 'member vni' in temp_config:
+        elif "member vni {0}".format(module.params['vni']) in temp_config:
             parents.append('member vni {0}'.format(module.params['vni']))
             config = netcfg.get_section(parents)
         else:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_vxlan_vtep_vni

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
This affects 2.2. Fixing issue when multiple vni exist.
