### PR TITLE
Re-order logic around testing for group_in_use so that the test is on…

### DIFF
--- a/cloud/amazon/ec2_group.py
+++ b/cloud/amazon/ec2_group.py
@@ -309,12 +309,12 @@ def main():
             '''existing group found'''
             # check the group parameters are correct
             group_in_use = False
-            rs = ec2.get_all_instances()
-            for r in rs:
-                for i in r.instances:
-                    group_in_use |= reduce(lambda x, y: x | (y.name == 'public-ssh'), i.groups, False)
-
             if group.description != description:
+                rs = ec2.get_all_instances()
+                for r in rs:
+                    for i in r.instances:
+                        group_in_use |= reduce(lambda x, y: x | (y.name == 'public-ssh'), i.groups, False)
+
                 if group_in_use:
                     module.fail_json(msg="Group description does not match, but it is in use so cannot be changed.")
 


### PR DESCRIPTION
…ly run if it is actually required.

This gives a massive speed-up in the event that you have a large number of instances nad groups in the VPC.

Current code iterates over every instance in the vpc and then over every group on each instance, whether or not this is required.  In the 99.9% of cases when it is not required this is wasted effort, and if there are are a large number of instances it takes a very long time.  In our environment where we have 1500 instances, making this change reduced the time to execute from 35 seconds to 7 seconds, which adds iup very quickly if there are multiple ec2_group tasks.

I believe there are further optimisations that could be made as well, but this is good enough for now.

# This repository is locked

Please open all new issues and pull requests in https://github.com/ansible/ansible

For more information please see http://docs.ansible.com/ansible/dev_guide/repomerge.html
