### PR TITLE
Do not use include on ios_facts

### DIFF
--- a/network/ios/ios_facts.py
+++ b/network/ios/ios_facts.py
@@ -198,11 +198,11 @@ class Default(FactsBase):
 class Hardware(FactsBase):
 
     def populate(self):
-        data = self.run('dir | include Directory')
+        data = self.run('dir')
         if data:
             self.facts['filesystems'] = self.parse_filesystems(data)
 
-        data = self.run('show memory statistics | include Processor')
+        data = self.run('show memory statistics')
         if data:
             match = re.findall(r'\s(\d+)\s', data)
             if match:


### PR DESCRIPTION
Certain IOS versions do not support include, thus breaking the facts
collecting.
Just remove it as we have in devel right now.

Fixes #21565