### PR TITLE
Fix yum update first package on the list

### DIFF
--- a/packaging/os/yum.py
+++ b/packaging/os/yum.py
@@ -820,7 +820,7 @@ def latest(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos):
         update_all = True
 
     # run check-update to see if we have packages pending
-    rc, out, err = module.run_command(yum_basecmd + ['check-update'])
+    rc, out, err = module.run_command(yum_basecmd + ['-q'] + ['check-update'])
     if rc == 0 and update_all:
         res['results'].append('Nothing to do here, all packages are up to date')
         return res


### PR DESCRIPTION
Yum was not able to upgrade the first package on the list of check-update. Adding -q to the check update command fix this issue

# This repository is locked

Please open all new issues and pull requests in https://github.com/ansible/ansible

For more information please see http://docs.ansible.com/ansible/dev_guide/repomerge.html
