### PR TITLE
Fix fanout issue for OS10 10.2.2 release

### DIFF
--- a/network/dellos10/dellos10_facts.py
+++ b/network/dellos10/dellos10_facts.py
@@ -290,21 +290,23 @@ class Interfaces(FactsBase):
 
         for interface in interfaces.findall('./data/ports/ports-state/port'):
             name = self.parse_item(interface, 'name')
-            fanout = self.parse_item(interface, 'fanout-state')
-            mediatype = self.parse_item(interface, 'media-type')  
+            # media-type name interface name format phy-eth 1/1/1
+            mediatype = self.parse_item(interface, 'media-type')
 
             typ, sname = name.split('-eth')
-
-            if fanout == "BREAKOUT_1x1":
-                name = "ethernet" + sname
+            name = "ethernet" + sname
+            try:
                 intf = int_facts[name]
-                intf['mediatype'] = mediatype  
-            else:
-                #TODO: Loop for the exact subport
+                intf['mediatype'] = mediatype
+            except:
+                # fanout
                 for subport in xrange(1, 5):
                     name = "ethernet" + sname + ":" + str(subport)
-                    intf = int_facts[name]
-                    intf['mediatype'] = mediatype  
+                    try:
+                        intf = int_facts[name]
+                        intf['mediatype'] = mediatype
+                    except:
+                        pass
 
         return int_facts
 


### PR DESCRIPTION
Fix fanout issue for OS10 10.2.2 release

In OS10.2.2 release the fanout attribute was not passed as part of the show interface command.
Updated the code, not use the fanout attribute, instead parse based on subport.