### PR TITLE
Backporting fixes#21557 to 2.2 support

### DIFF
--- a/network/dellos9/dellos9_facts.py
+++ b/network/dellos9/dellos9_facts.py
@@ -304,13 +304,14 @@ class Interfaces(FactsBase):
 
     def populate_ipv6_interfaces(self, data):
         for key, value in data.items():
-            self.facts['interfaces'][key]['ipv6'] = list()
-            addresses = re.findall(r'\s+(.+), subnet', value, re.M)
-            subnets = re.findall(r', subnet is (\S+)', value, re.M)
-            for addr, subnet in itertools.izip(addresses, subnets):
-                ipv6 = dict(address=addr.strip(), subnet=subnet.strip())
-                self.add_ip_address(addr.strip(), 'ipv6')
-                self.facts['interfaces'][key]['ipv6'].append(ipv6)
+            if key in self.facts['interfaces']:
+                self.facts['interfaces'][key]['ipv6'] = list()
+                addresses = re.findall(r'\s+(.+), subnet', value, re.M)
+                subnets = re.findall(r', subnet is (\S+)', value, re.M)
+                for addr, subnet in itertools.izip(addresses, subnets):
+                    ipv6 = dict(address=addr.strip(), subnet=subnet.strip())
+                    self.add_ip_address(addr.strip(), 'ipv6')
+                    self.facts['interfaces'][key]['ipv6'].append(ipv6)
 
     def add_ip_address(self, address, family):
         if family == 'ipv4':


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - network/dellos9/dellos9_facts

##### ANSIBLE VERSION
```
ansible 2.2.3.0 (stable-2.2 3f8c56a7e3) last updated 2017/04/12 23:48:46 (GMT +550)
  lib/ansible/modules/core: (detached HEAD cfe3c844f4) last updated 2017/04/12 23:50:37 (GMT +550)
  lib/ansible/modules/extras: (detached HEAD 8b78d56a08) last updated 2017/04/12 23:50:39 (GMT +550)
  config file =
  configured module search path = Default w/o overrides


```

##### SUMMARY


Handled dellos9_facts module crash with IPV6 configuration to run in Ansible 2.2.
Backporting the fix for issue #21557 to Ansible 2.2.

[Fixes#21557](https://github.com/ansible/ansible/issues/21557)