### PR TITLE
Backporting fixes#5534 to support 2.2

### DIFF
--- a/network/dellos10/dellos10_command.py
+++ b/network/dellos10/dellos10_command.py
@@ -139,7 +139,11 @@ warnings:
 from ansible.module_utils.basic import get_exception
 from ansible.module_utils.netcli import CommandRunner, FailedConditionsError
 from ansible.module_utils.network import NetworkModule, NetworkError
+from ansible.module_utils.six import string_types
 import ansible.module_utils.dellos10
+
+VALID_KEYS = ['command', 'prompt', 'response']
+
 
 def to_lines(stdout):
     for item in stdout:
@@ -147,8 +151,21 @@ def to_lines(stdout):
             item = str(item).split('\n')
         yield item
 
+
+def parse_commands(module):
+    for cmd in module.params['commands']:
+        if isinstance(cmd, string_types):
+            cmd = dict(command=cmd, output=None)
+        elif 'command' not in cmd:
+            module.fail_json(msg='command keyword argument is required')
+        elif not set(cmd.keys()).issubset(VALID_KEYS):
+            module.fail_json(msg='unknown keyword specified')
+        yield cmd
+
+
 def main():
     spec = dict(
+        # { command: <str>, prompt: <str>, response: <str> }
         commands=dict(type='list', required=True),
         wait_for=dict(type='list'),
         retries=dict(default=10, type='int'),
@@ -159,7 +176,7 @@ def main():
                            connect_on_load=False,
                            supports_check_mode=True)
 
-    commands = module.params['commands']
+    commands = list(parse_commands(module))
     conditionals = module.params['wait_for'] or list()
 
     warnings = list()
@@ -167,15 +184,15 @@ def main():
     runner = CommandRunner(module)
 
     for cmd in commands:
-        if module.check_mode and not cmd.startswith('show'):
+        if module.check_mode and not cmd['command'].startswith('show'):
             warnings.append('only show commands are supported when using '
                             'check mode, not executing `%s`' % cmd)
         else:
-            if cmd.startswith('conf'):
+            if cmd['command'].startswith('conf'):
                 module.fail_json(msg='dellos10_command does not support running '
                                      'config mode commands.  Please use '
                                      'dellos10_config instead')
-            runner.add_command(cmd)
+            runner.add_command(**cmd)
 
     for item in conditionals:
         runner.add_conditional(item)
@@ -197,11 +214,10 @@ def main():
     result['stdout'] = list()
     for cmd in commands:
         try:
-            output = runner.get_command(cmd)
+            output = runner.get_command(cmd['command'])
         except ValueError:
             output = 'command not executed due to check_mode, see warnings'
         result['stdout'].append(output)
-
 
     result['warnings'] = warnings
     result['stdout_lines'] = list(to_lines(result['stdout']))

--- a/network/dellos6/dellos6_command.py
+++ b/network/dellos6/dellos6_command.py
@@ -138,7 +138,11 @@ warnings:
 from ansible.module_utils.basic import get_exception
 from ansible.module_utils.netcli import CommandRunner, FailedConditionsError
 from ansible.module_utils.network import NetworkModule, NetworkError
+from ansible.module_utils.six import string_types
 import ansible.module_utils.dellos6
+
+VALID_KEYS = ['command', 'prompt', 'response']
+
 
 def to_lines(stdout):
     for item in stdout:
@@ -147,8 +151,20 @@ def to_lines(stdout):
         yield item
 
 
+def parse_commands(module):
+    for cmd in module.params['commands']:
+        if isinstance(cmd, string_types):
+            cmd = dict(command=cmd, output=None)
+        elif 'command' not in cmd:
+            module.fail_json(msg='command keyword argument is required')
+        elif not set(cmd.keys()).issubset(VALID_KEYS):
+            module.fail_json(msg='unknown keyword specified')
+        yield cmd
+
+
 def main():
     spec = dict(
+        # { command: <str>, prompt: <str>, response: <str> }
         commands=dict(type='list', required=True),
         wait_for=dict(type='list'),
         retries=dict(default=10, type='int'),
@@ -159,7 +175,7 @@ def main():
                            connect_on_load=False,
                            supports_check_mode=True)
 
-    commands = module.params['commands']
+    commands = list(parse_commands(module))
     conditionals = module.params['wait_for'] or list()
 
     warnings = list()
@@ -167,15 +183,15 @@ def main():
     runner = CommandRunner(module)
 
     for cmd in commands:
-        if module.check_mode and not cmd.startswith('show'):
+        if module.check_mode and not cmd['command'].startswith('show'):
             warnings.append('only show commands are supported when using '
                             'check mode, not executing `%s`' % cmd)
         else:
-            if cmd.startswith('conf'):
+            if cmd['command'].startswith('conf'):
                 module.fail_json(msg='dellos6_command does not support running '
                                      'config mode commands.  Please use '
                                      'dellos6_config instead')
-            runner.add_command(cmd)
+            runner.add_command(**cmd)
 
     for item in conditionals:
         runner.add_conditional(item)
@@ -197,7 +213,7 @@ def main():
     result['stdout'] = list()
     for cmd in commands:
         try:
-            output = runner.get_command(cmd)
+            output = runner.get_command(cmd['command'])
         except ValueError:
             output = 'command not executed due to check_mode, see warnings'
         result['stdout'].append(output)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - network/dellos9/dellos9_command
 - network/dellos10/dellos10_command
 - network/dellos6/dellos6_command

##### ANSIBLE VERSION
```
ansible 2.2.3.0 (stable-2.2 7cc351a237) last updated 2017/04/17 12:29:25 (GMT +550)
  lib/ansible/modules/core: (detached HEAD cfe3c844f4) last updated 2017/04/17 12:29:55 (GMT +550)
  lib/ansible/modules/extras: (detached HEAD 8b78d56a08) last updated 2017/04/17 12:29:58 (GMT +550)
  config file =
  configured module search path = Default w/o overrides

```

##### SUMMARY


Handled command prompt in dellos command modules.
User can specify "yes" or "no". Based on that action will be taken.

Backporting the fix for issue #5534 to Ansible 2.2.

[Fixes#5534](https://github.com/ansible/ansible-modules-core/issues/5534)