### PR TITLE
VMWare disks dont get resized - Update vsphere_guest.py

### DIFF
--- a/cloud/vmware/vsphere_guest.py
+++ b/cloud/vmware/vsphere_guest.py
@@ -787,7 +787,7 @@ def update_disks(vsphere_client, vm, module, vm_disk, changes):
         found = False
         for dev_key in vm._devices:
             if vm._devices[dev_key]['type'] == 'VirtualDisk':
-                hdd_id = vm._devices[dev_key]['label'].split()[2]
+                hdd_id = vm._devices[dev_key]['label'].split()[1]
                 if disk_id == hdd_id:
                     found = True
                     continue


### PR DESCRIPTION
the index should be 1 in order to capture the id (the labels look like "Disk 1" or "Festplatte 1" so index 1 will hit it properly.

# This repository is locked

Please open all new issues and pull requests in https://github.com/ansible/ansible

For more information please see http://docs.ansible.com/ansible/dev_guide/repomerge.html
