### PR TITLE
Permit table names that contain a colon

### DIFF
--- a/database/mysql/mysql_user.py
+++ b/database/mysql/mysql_user.py
@@ -463,7 +463,7 @@ def privileges_unpack(priv, mode):
     output = {}
     privs = []
     for item in priv.strip().split('/'):
-        pieces = item.strip().split(':')
+        pieces = item.strip().rsplit(':',1)
         dbpriv = pieces[0].rsplit(".", 1)
         # Do not escape if privilege is for database or table, i.e.
         # neither quote *. nor .*


### PR DESCRIPTION
During testing, we found that any table containing a colon would result in errors.
`priv = "*.*:USAGE/`xxxx-web-prod:wordpress`.*:ALL"`

The existing code splits "`xxxx-web-prod:wordpress`.*:ALL" into a list with three values which will cause errors when dbpriv is evaluated.
`['`xxxx-web-prod', 'wordpress`.*', 'ALL']`

Using rsplit(':', 1) on the string results in a list with two values as expected. 
`['`xxxx-web-prod:wordpress`.*', 'ALL']`

# This repository is locked

Please open all new issues and pull requests in https://github.com/ansible/ansible

For more information please see http://docs.ansible.com/ansible/dev_guide/repomerge.html
